### PR TITLE
Add DM Sans font

### DIFF
--- a/src/coffee/templates/base.html
+++ b/src/coffee/templates/base.html
@@ -4,11 +4,13 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %}</title>
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=DM+Sans:400,500,600,700,i,b">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.2/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="static/style.css">
-</headsty>
+</head>
 <body>
 
 <nav class="navbar navbar-expand-lg">

--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -1,3 +1,7 @@
+html, body {
+    font-family: "DM Sans", sans-serif;
+}
+
 a {
     text-decoration: none;
     color: #596C97;


### PR DESCRIPTION
This uses DM Sans font from as listed in the MLC Brand Guidelines
<img width="767" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/1dd49e6c-3c1c-40f0-9828-62403b990756">
