### PR TITLE
Add embed comments for site embedding

### DIFF
--- a/src/coffee/templates/base.html
+++ b/src/coffee/templates/base.html
@@ -86,9 +86,11 @@
 </nav>
 
 <div class="min-vh-100">
+<!-- START EMBED -->
     {% block content %}
 
     {% endblock %}
+<!-- END EMBED -->
 </div>
 
 <div class="bg-darker navbar navbar-fixed-bottom">


### PR DESCRIPTION
* Add embed comments for site embedding. In the short term these are used to filter the header and footer content from the statically generated HTML when embedding