### PR TITLE
Add sut selection to cli for benchmarks

### DIFF
--- a/src/coffee/run.py
+++ b/src/coffee/run.py
@@ -19,6 +19,16 @@ from coffee.benchmark import GeneralChatBotBenchmarkDefinition, BenchmarkScore, 
 from coffee.newhelm_runner import NewhelmSut
 from coffee.static_site_generator import StaticSiteGenerator
 
+_DEFAULT_SUTS = [
+    NewhelmSut.GPT2,
+    NewhelmSut.LLAMA_2_7B,
+    NewhelmSut.LLAMA_2_13B,
+    NewhelmSut.LLAMA_2_70B,
+    NewhelmSut.MISTRAL_7B,
+    NewhelmSut.PYTHIA_70M,
+    NewhelmSut.YI_BASE_6B,
+]
+
 
 def _make_output_dir():
     o = pathlib.Path.cwd()
@@ -50,16 +60,15 @@ def cli() -> None:
 )  # this default is a hack to get a set that won't blow up in the toxicity annotator
 @click.option("--debug", default=False, is_flag=True)
 @click.option("--web-only", default=False, is_flag=True)
-def benchmark(output_dir: pathlib.Path, max_instances: int, debug: bool, web_only) -> None:
-    suts = [
-        NewhelmSut.GPT2,
-        NewhelmSut.LLAMA_2_7B,
-        NewhelmSut.LLAMA_2_13B,
-        NewhelmSut.LLAMA_2_70B,
-        NewhelmSut.MISTRAL_7B,
-        NewhelmSut.PYTHIA_70M,
-        NewhelmSut.YI_BASE_6B,
-    ]
+@click.option(
+    "--sut",
+    "-s",
+    type=click.Choice([sut.key for sut in NewhelmSut]),
+    multiple=True,
+    default=[s.key for s in _DEFAULT_SUTS],
+)
+def benchmark(output_dir: pathlib.Path, max_instances: int, debug: bool, web_only, sut: List[str]) -> None:
+    suts = [s for s in NewhelmSut if s.key in sut]
     benchmark_scores = []
     benchmarks = [GeneralChatBotBenchmarkDefinition()]
     for sut in suts:


### PR DESCRIPTION
* Add sut selection to cli for benchmarks
* Keep defaults to previously set suts

Makes it easier for users and developers to run a benchmark on a specific sut without needing to manually maintain their own fork with their specific sut matrix

Note: This makes use of `click`'s multi syntax which allows for multiple
values to be passed in: `--sut one --sut two` etc.

`benchmark --help` output:

```
Usage: run.py benchmark [OPTIONS]

  run the standard benchmark

Options:
  -o, --output-dir DIRECTORY
  -m, --max-instances INTEGER
  --debug
  --web-only
  -s, --sut [gpt2|llama-2-7b|llama-2-13b|llama-2-70b|mistral-7b|pythia-70m|yi-base-6b]
  --help                          Show this message and exit.
```