### PR TITLE
Add focus color to styles variables

### DIFF
--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -21,6 +21,7 @@
   --pico-primary-underline: var(--pico-primary);
   --pico-primary-hover: hsl(219 25% 40%);
   --pico-primary-hover-background: hsl(219 25% 40%);
+  --pico-primary-focus: rgba(84, 109, 156, 0.5);
   --pico-box-shadow: 0px 10px 40px 0px rgba(0, 0, 0, 0.04);
   --pico-h1-color: var(--mlc-color-moonshadow);
   --pico-h2-color: var(--mlc-color-moonshadow);


### PR DESCRIPTION
* Add focus color to styles variables

Focus color was accidentally removed in cleanup before change to new framework

<img width="178" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/0ea073b1-1ac7-4ce2-9388-48349014c5cb">
