### PR TITLE
Add link functions and view embed flag

### DIFF
--- a/src/coffee/run.py
+++ b/src/coffee/run.py
@@ -50,7 +50,8 @@ def cli() -> None:
 )  # this default is a hack to get a set that won't blow up in the toxicity annotator
 @click.option("--debug", default=False, is_flag=True)
 @click.option("--web-only", default=False, is_flag=True)
-def benchmark(output_dir: pathlib.Path, max_instances: int, debug: bool, web_only) -> None:
+@click.option("--view-embed", default=False, is_flag=True, help="Render the HTML to be emdedded in another view")
+def benchmark(output_dir: pathlib.Path, max_instances: int, debug: bool, web_only, view_embed: bool) -> None:
     suts = [
         NewhelmSut.GPT2,
         NewhelmSut.LLAMA_2_7B,
@@ -99,7 +100,7 @@ def benchmark(output_dir: pathlib.Path, max_instances: int, debug: bool, web_onl
 
     echo()
     echo(termcolor.colored(f"Benchmarking complete, rendering reports...", "green"))
-    static_site_generator = StaticSiteGenerator()
+    static_site_generator = StaticSiteGenerator(view_embed=view_embed)
     static_site_generator.generate(benchmark_scores, output_dir)
     echo()
     echo(termcolor.colored(f"Reports complete, open {output_dir}/index.html", "green"))

--- a/src/coffee/static_site_generator.py
+++ b/src/coffee/static_site_generator.py
@@ -1,12 +1,29 @@
 import math
 import pathlib
 import shutil
+from functools import partial
 from itertools import groupby
 
 from jinja2 import Environment, PackageLoader, select_autoescape
 from markupsafe import Markup
 
 from coffee.benchmark import BenchmarkScore
+
+
+def root_path(view_embed: bool = False) -> str:
+    return "#" if view_embed else "index.html"
+
+
+def benchmarks_path(view_embed: bool = False) -> str:
+    return f"benchmarks{'' if view_embed else '.html'}"
+
+
+def benchmark_path(benchmark_path_name, view_embed: bool = False) -> str:
+    return f"{benchmark_path_name}{'' if view_embed else '.html'}"
+
+
+def test_report_path(sut_path_name: str, benchmark_path_name: str, view_embed: bool = False) -> str:
+    return f"{sut_path_name}_{benchmark_path_name}_report{'' if view_embed else '.html'}"
 
 
 def display_stars(score, size) -> Markup:
@@ -87,9 +104,18 @@ STARS_DESCRIPTION = {
 
 
 class StaticSiteGenerator:
-    def __init__(self) -> None:
+    def __init__(self, view_embed: bool = False) -> None:
+        """Initialize the StaticSiteGenerator class for local file or website partial
+
+        Args:
+            view_embed (bool): Whethere to generate local file or embedded view. Defaults to False.
+        """
         self.env = Environment(loader=PackageLoader("coffee"), autoescape=select_autoescape())
         self.env.filters["display_stars"] = display_stars
+        self.env.globals["root_path"] = partial(root_path, view_embed=view_embed)
+        self.env.globals["benchmarks_path"] = partial(benchmarks_path, view_embed=view_embed)
+        self.env.globals["benchmark_path"] = partial(benchmark_path, view_embed=view_embed)
+        self.env.globals["test_report_path"] = partial(test_report_path, view_embed=view_embed)
 
     def _template_dir(self):
         current_path = pathlib.Path(__file__)

--- a/src/coffee/templates/benchmark.html
+++ b/src/coffee/templates/benchmark.html
@@ -52,7 +52,7 @@
                             {{ stars_description[benchmark_score.stars() | round | int]["explanation"] }}
                         </td>
                         <td class="mlc--button-container__align-right">
-                          <a role="button" class="mlc--button__sm" href="{{ benchmark_score.sut.name }}_{{ benchmark_score.benchmark_definition.path_name() }}_report.html">Show Details &gt;</a>
+                          <a role="button" class="mlc--button__sm" href="{{ test_report_path(benchmark_score.sut.name, benchmark_score.benchmark_definition.path_name()) }}">Show Details &gt;</a>
                         </td>
                     </tr>
                 {% endfor %}

--- a/src/coffee/templates/macros/benchmark_card.html
+++ b/src/coffee/templates/macros/benchmark_card.html
@@ -3,7 +3,7 @@
     {% if show_benchmark_header %}
         <div class="mlc--card__button-header">
             <h2>{{ benchmark_definition.name() }} Benchmark</h2>
-            <a role="button" href="{{ benchmark_definition.path_name() }}.html">Show Details &gt;</a>
+            <a role="button" href="{{ benchmark_path(benchmark_definition.path_name()) }}">Show Details &gt;</a>
         </div>
     {% endif %}
     <p>

--- a/src/coffee/templates/macros/breadcrumb.html
+++ b/src/coffee/templates/macros/breadcrumb.html
@@ -1,11 +1,11 @@
 {% macro breadcrumb(benchmark_score, benchmark_definition) %}
     <nav aria-label="breadcrumb">
         <ul>
-            <li><a href="index.html">ML Commons</a></li>
-            <li><a href="benchmarks.html">Benchmarks</a></li>
+            <li><a href="{{ root_path() }}">ML Commons</a></li>
+            <li><a href="{{ benchmarks_path() }}">Benchmarks</a></li>
             {% if benchmark_score %}
                 <li>
-                    <a href="{{ benchmark_score.benchmark_definition.path_name() }}.html">{{ benchmark_score.benchmark_definition.name() }}</a>
+                    <a href="{{ benchmark_path(benchmark_score.benchmark_definition.path_name()) }}">{{ benchmark_score.benchmark_definition.name() }}</a>
                 </li>
                 <li>{{ benchmark_score.sut.name }} Report</li>
             {% elif benchmark_definition %}

--- a/src/coffee/templates/macros/tooltip_info.html
+++ b/src/coffee/templates/macros/tooltip_info.html
@@ -1,5 +1,5 @@
 {% macro tooltip_info(content) %}
     <span class="mlc--tooltip-info" data-tooltip="{{ content }}">
-      <span class="mlc--tooltip-info-content">i</span>
+        <span class="mlc--tooltip-info-content">i</span>
     </span>
 {%- endmacro %}

--- a/tests/test_static_site_generator.py
+++ b/tests/test_static_site_generator.py
@@ -12,7 +12,7 @@ from coffee.benchmark import (
     BenchmarkScore,
     ToxicityHazardDefinition,
 )
-from coffee.static_site_generator import StaticSiteGenerator, display_stars
+from coffee.static_site_generator import StaticSiteGenerator, display_stars, root_path, benchmarks_path, benchmark_path
 
 
 @pytest.fixture()
@@ -70,3 +70,18 @@ def test_displays_correct_stars(score, size, expected):
     assert full_stars == expected[0]
     assert half_stars == expected[1]
     assert empty_stars == expected[2]
+
+
+def test_root_path():
+    assert root_path() == "index.html"
+    assert root_path(view_embed=True) == "#"
+
+
+def test_benchmarks_path():
+    assert benchmarks_path() == "benchmarks.html"
+    assert benchmarks_path(view_embed=True) == "benchmarks"
+
+
+def test_benchmark_path():
+    assert benchmark_path("general_chat_bot_benchmark") == "general_chat_bot_benchmark.html"
+    assert benchmark_path("general_chat_bot_benchmark", view_embed=False) == "general_chat_bot_benchmark"


### PR DESCRIPTION
* Add link functions and view embed flag

This allows for running `--view-embed` to generate a "emdedded view" html. The main thing this is currently doing is simply not appending `.html` to links. There will be more changes needed and the generic term of `view-embed` vs doing `remove-extention` was in anticipation of those other changes

This option defaults to false so users of the tool that are running their own reports will not need to be aware of it as the default will simply create the local html test report output.

new help text:

```
Usage: run.py benchmark [OPTIONS]

  run the standard benchmark

Options:
  -o, --output-dir DIRECTORY
  -m, --max-instances INTEGER
  --debug
  --web-only
  --view-embed                 Render the HTML to be emdedded in another view
  --help                       Show this message and exit.
```