### PR TITLE
Add dev build command for local development

### DIFF
--- a/src/coffee/dev.py
+++ b/src/coffee/dev.py
@@ -1,0 +1,55 @@
+import click
+import pathlib
+import pickle
+
+from coffee.static_site_generator import StaticSiteGenerator
+
+from coffee.newhelm_runner import NewhelmSut
+from coffee.benchmark import (
+    GeneralChatBotBenchmarkDefinition,
+    BiasHazardDefinition,
+    HazardScore,
+    BenchmarkScore,
+    ToxicityHazardDefinition,
+)
+
+
+def benchmark_scores():
+    bd = GeneralChatBotBenchmarkDefinition()
+    bs = [
+        BenchmarkScore(
+            bd,
+            NewhelmSut.GPT2,
+            [
+                HazardScore(BiasHazardDefinition(), 0.5),
+                HazardScore(ToxicityHazardDefinition(), 0.8),
+            ],
+        ),
+        BenchmarkScore(
+            bd,
+            NewhelmSut.LLAMA_2_7B,
+            [
+                HazardScore(BiasHazardDefinition(), 0.5),
+                HazardScore(ToxicityHazardDefinition(), 0.8),
+            ],
+        ),
+    ]
+    return bs
+
+
+@click.group()
+def cli() -> None:
+    pass
+
+
+@cli.command(help="Generate a simple site for development")
+@click.option(
+    "--output-dir", "-o", default="./web", type=click.Path(file_okay=False, dir_okay=True, path_type=pathlib.Path)
+)
+def build(output_dir: pathlib.Path) -> None:
+    generator = StaticSiteGenerator()
+    generator.generate(benchmark_scores(), output_dir)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
* Add dev build command for local development

This is to allow for a more rapid iteration loop than running a full sut benchmark.

This is preliminary data for benchmark scores, but should become more full featured in the future.

Intended to supersede `--web-only` option in run benchmark cli

---

I am very, very open to any suggestions on the implementation of this. This pass is just to give a minimum viable dev build for iterating on HTML and CSS. I can imagine wanting to put this somewhere else in the code base or even running it differently. So please do share any ideas you might have.