### PR TITLE
Use human readable name vs underscore name

### DIFF
--- a/src/coffee/templates/benchmark.html
+++ b/src/coffee/templates/benchmark.html
@@ -43,7 +43,7 @@
             <tbody>
                 {% for benchmark_score in grouped_benchmark_scores[benchmark_definition] %}
                     <tr>
-                        <td>{{ benchmark_score.sut.value[1] }}</td>
+                        <td>{{ benchmark_score.sut.display_name }}</td>
                         <td>
                             <span class="mlc--stars-container mlc--stars-container__inline">{{ benchmark_score.stars() | display_stars("sm") }}</span>
                             <span>{{ stars_description[benchmark_score.stars() | round | int]["rank"] }}</span>

--- a/src/coffee/templates/test_report.html
+++ b/src/coffee/templates/test_report.html
@@ -14,7 +14,7 @@
 
     <div class="mlc--section">
         <h2>Test Report</h2>
-        <h1 class="mlc--header">{{ benchmark_score.sut.value[1] }} - {{ benchmark_score.benchmark_definition.name() }} {% include "_provisional.html" %}</h1>
+        <h1 class="mlc--header">{{ benchmark_score.sut.display_name }} - {{ benchmark_score.benchmark_definition.name() }} {% include "_provisional.html" %}</h1>
         <p class="mlc--subheader">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
             tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz
@@ -104,7 +104,7 @@
         </div>
         <div>
             <h6 class="mlc--test-detail-header">Model Display Name {{ tooltip_info("Model display info") }}</h6>
-            <p>{{ benchmark_score.sut.value[1] }}</p>
+            <p>{{ benchmark_score.sut.display_name }}</p>
         </div>
         <div>
             <h6 class="mlc--test-detail-header">Model UID {{ tooltip_info("Info for model UID") }}</h6>

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -115,6 +115,13 @@ def test_benchmark_score_standard_case():
     assert bs.stars() == 3.0
 
 
+def test_newhelm_sut_display_name_and_name():
+    assert NewhelmSut.GPT2.display_name == "OpenAI GPT-2"
+    assert NewhelmSut.GPT2.name == "GPT2"
+    assert NewhelmSut.LLAMA_2_7B.display_name == "Meta Llama 2, 7b parameters"
+    assert NewhelmSut.LLAMA_2_7B.name == "LLAMA_2_7B"
+
+
 @pytest.mark.datafiles(SIMPLE_BBQ_DATA)
 def test_bias_scoring(datafiles):
     with open(pathlib.Path(datafiles) / "test_records.pickle", "rb") as out:


### PR DESCRIPTION
* Use human readable name vs underscore name for sut display name

---

I wasn't fully sure this was the correct value to use. While "Meta Llama 2, 7b parameters" feels better than "LLAMA_2_7B" for a human readable title, I almost feel like maybe we add one more value to the tuple that is something like "Llama 2 7B" as it feels a little long. "Llama 2 7B" is the key with the underscores removed so another option is a computed value that just title cases and removes underscores. All are good to me. Just want something without underscores for the general public.