### PR TITLE
Remove anchor on benchmarks in breadcrumbs

### DIFF
--- a/src/coffee/static_site_generator.py
+++ b/src/coffee/static_site_generator.py
@@ -133,6 +133,7 @@ class StaticSiteGenerator:
         self._write_file(
             output=output_dir / "index.html",
             template_name="index.html",
+            page_type="index",
         )
 
     def _grouped_benchmark_scores(self, benchmark_scores: list[BenchmarkScore]) -> dict:
@@ -150,6 +151,7 @@ class StaticSiteGenerator:
             template_name="benchmarks.html",
             grouped_benchmark_scores=self._grouped_benchmark_scores(benchmark_scores),
             show_benchmark_header=True,
+            page_type="benchmarks",
         )
 
     def _generate_benchmark_pages(self, benchmark_scores: list[BenchmarkScore], output_dir: pathlib.Path) -> None:
@@ -161,6 +163,7 @@ class StaticSiteGenerator:
                     benchmark_definition=benchmark_definition,
                     grouped_benchmark_scores=self._grouped_benchmark_scores(benchmark_scores),
                     stars_description=STARS_DESCRIPTION,
+                    page_type="benchmark",
                 )
 
     def _generate_test_report_pages(self, benchmark_scores: list[BenchmarkScore], output_dir: pathlib.Path) -> None:
@@ -171,6 +174,7 @@ class StaticSiteGenerator:
                 template_name="test_report.html",
                 benchmark_score=benchmark_score,
                 stars_description=STARS_DESCRIPTION,
+                page_type="test_report",
             )
 
     def root_path(self) -> str:

--- a/src/coffee/templates/benchmarks.html
+++ b/src/coffee/templates/benchmarks.html
@@ -6,7 +6,7 @@
 {% block title %}Benchmarks{% endblock %}
 
 {% block content %}
-    {{ breadcrumb(benchmark_score, benchmark_definition) }}
+    {{ breadcrumb(benchmark_score, benchmark_definition, page_type="benchmarks") }}
 
     <div class="mlc--section">
       <h1 class="mlc--header">AI Safety Benchmarks {% include "_provisional.html" %}</h1>

--- a/src/coffee/templates/macros/breadcrumb.html
+++ b/src/coffee/templates/macros/breadcrumb.html
@@ -1,8 +1,12 @@
-{% macro breadcrumb(benchmark_score, benchmark_definition) %}
+{% macro breadcrumb(benchmark_score, benchmark_definition, page_type) %}
     <nav aria-label="breadcrumb">
         <ul>
             <li><a href="{{ root_path() }}">ML Commons</a></li>
-            <li><a href="{{ benchmarks_path() }}">Benchmarks</a></li>
+            {% if page_type == "benchmarks" %}
+              <li>Benchmarks</li>
+            {% else %}
+              <li><a href="{{ benchmarks_path() }}">Benchmarks</a></li>
+            {% endif %}
             {% if benchmark_score %}
                 <li>
                     <a href="{{ benchmark_path(benchmark_score.benchmark_definition.path_name()) }}">{{ benchmark_score.benchmark_definition.name() }}</a>

--- a/tests/templates/macros/test_breadcrumb.py
+++ b/tests/templates/macros/test_breadcrumb.py
@@ -1,3 +1,6 @@
+import re
+
+
 def test_display_breadcrumb(benchmark_score, template_env):
     template = template_env.get_template("macros/breadcrumb.html")
     result = template.module.breadcrumb(benchmark_score, benchmark_score.benchmark_definition)
@@ -8,3 +11,13 @@ def test_display_breadcrumb(benchmark_score, template_env):
     assert "Benchmarks" in result
     assert 'href="general_chat_bot_benchmark.html"' not in result
     assert "General Chat Bot" in result
+
+
+def test_breadcrumb_no_link_benchmarks_page_type(benchmark_score, template_env):
+    template = template_env.get_template("macros/breadcrumb.html")
+    result = template.module.breadcrumb(benchmark_score, benchmark_score.benchmark_definition, "benchmarks")
+    assert "Benchmarks" in result
+    assert re.search("<li.*>Benchmarks</li>", result) is not None
+    result = template.module.breadcrumb(benchmark_score, benchmark_score.benchmark_definition)
+    assert re.search("<li.*>Benchmarks</li>", result) is None
+    assert re.search(r"<li.*><a.*>Benchmarks</a></li>", result) is not None


### PR DESCRIPTION
* Remove anchor on benchmarks in breadcrumbs when on the benchmarks page
* Add `page_type` to each template run for page type specific logic