### PR TITLE
Use relative links for embed view

### DIFF
--- a/src/coffee/static_site_generator.py
+++ b/src/coffee/static_site_generator.py
@@ -181,10 +181,14 @@ class StaticSiteGenerator:
         return "#" if self.view_embed else "index.html"
 
     def benchmarks_path(self) -> str:
-        return f"benchmarks{'' if self.view_embed else '.html'}"
+        return "../benchmarks" if self.view_embed else "benchmarks.html"
 
     def benchmark_path(self, benchmark_path_name) -> str:
-        return f"{benchmark_path_name}{'' if self.view_embed else '.html'}"
+        return f"../{benchmark_path_name}" if self.view_embed else f"{benchmark_path_name}.html"
 
     def test_report_path(self, sut_path_name: str, benchmark_path_name: str) -> str:
-        return f"{sut_path_name}_{benchmark_path_name}_report{'' if self.view_embed else '.html'}"
+        return (
+            f"../{sut_path_name}_{benchmark_path_name}_report"
+            if self.view_embed
+            else f"{sut_path_name}_{benchmark_path_name}_report.html"
+        )

--- a/tests/test_static_site_generator.py
+++ b/tests/test_static_site_generator.py
@@ -94,9 +94,11 @@ def test_root_path(static_site_generator, static_site_generator_view_embed):
 
 def test_benchmarks_path(static_site_generator, static_site_generator_view_embed):
     assert static_site_generator.benchmarks_path() == "benchmarks.html"
-    assert static_site_generator_view_embed.benchmarks_path() == "benchmarks"
+    assert static_site_generator_view_embed.benchmarks_path() == "../benchmarks"
 
 
 def test_benchmark_path(static_site_generator, static_site_generator_view_embed):
     assert static_site_generator.benchmark_path("general_chat_bot_benchmark") == "general_chat_bot_benchmark.html"
-    assert static_site_generator_view_embed.benchmark_path("general_chat_bot_benchmark") == "general_chat_bot_benchmark"
+    assert (
+        static_site_generator_view_embed.benchmark_path("general_chat_bot_benchmark") == "../general_chat_bot_benchmark"
+    )


### PR DESCRIPTION
* Use relative links for embed view

When served from an arbitrary url, these need to `../` or they will stack ie `/benchmarks/my-test/benchmarks/my-test` etc.