### PR TITLE
Add start and end time to benchmark and hazard

### DIFF
--- a/src/coffee/run.py
+++ b/src/coffee/run.py
@@ -74,6 +74,7 @@ def benchmark(
     for sut in suts:
         echo(termcolor.colored(f'Examining system "{sut.display_name}"', "green"))
         sut_instance = SUTS.make_instance(sut.key)
+        benchark_start_time = datetime.now(timezone.utc)
         for benchmark_definition in benchmarks:
             echo(termcolor.colored(f'  Starting run for benchmark "{benchmark_definition.name()}"', "green"))
             hazard_scores = []
@@ -85,6 +86,7 @@ def benchmark(
                     # TODO load result from disk here
                     raise NotImplementedError
                 else:
+                    hazard_start_time = datetime.now(timezone.utc)
                     tests = hazard.tests()
                     counter = 0
                     for test in tests:
@@ -97,7 +99,8 @@ def benchmark(
                         )
                         counter += 1
 
-                    score = hazard.score(results)
+                    hazard_end_time = datetime.now(timezone.utc)
+                    score = hazard.score(results, hazard_start_time, hazard_end_time)
                     if debug:
                         echo(
                             termcolor.colored(
@@ -105,7 +108,10 @@ def benchmark(
                             )
                         )
                     hazard_scores.append(score)
-            benchmark_scores.append(BenchmarkScore(benchmark_definition, sut, hazard_scores))
+            benchmark_end_time = datetime.now(timezone.utc)
+            benchmark_scores.append(
+                BenchmarkScore(benchmark_definition, sut, hazard_scores, benchark_start_time, benchmark_end_time)
+            )
 
     echo()
     echo(termcolor.colored(f"Benchmarking complete, rendering reports...", "green"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 
@@ -5,3 +7,13 @@ import pytest
 def cwd_tmpdir(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     return tmp_path
+
+
+@pytest.fixture
+def start_time():
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def end_time():
+    return datetime.now(timezone.utc) + timedelta(minutes=2)

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -19,7 +19,7 @@ from coffee.static_site_generator import (
 )
 
 
-def _benchmark_score() -> BenchmarkScore:
+def _benchmark_score(start_time, end_time) -> BenchmarkScore:
     bd = GeneralChatBotBenchmarkDefinition()
     bh = BiasHazardDefinition()
     th = ToxicityHazardDefinition()
@@ -27,23 +27,25 @@ def _benchmark_score() -> BenchmarkScore:
         bd,
         NewhelmSut.GPT2,
         [
-            HazardScore(bh, bh.three_star_standard()),
-            HazardScore(th, th.three_star_standard()),
+            HazardScore(bh, bh.three_star_standard(), start_time, end_time),
+            HazardScore(th, th.three_star_standard(), start_time, end_time),
         ],
+        start_time,
+        end_time,
     )
     return bs
 
 
 @pytest.fixture()
-def benchmark_score() -> BenchmarkScore:
-    return _benchmark_score()
+def benchmark_score(start_time, end_time) -> BenchmarkScore:
+    return _benchmark_score(start_time, end_time)
 
 
 @pytest.fixture()
-def grouped_benchmark_scores() -> dict[str, list[BenchmarkScore]]:
+def grouped_benchmark_scores(start_time, end_time) -> dict[str, list[BenchmarkScore]]:
     benchmark_scores_dict = {}
     for benchmark_definition, grouped_benchmark_scores in groupby(
-        [_benchmark_score()], lambda x: x.benchmark_definition
+        [_benchmark_score(start_time, end_time)], lambda x: x.benchmark_definition
     ):
         grouped_benchmark_scores_list: list = list(grouped_benchmark_scores)
         benchmark_scores_dict[benchmark_definition] = grouped_benchmark_scores_list

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -7,9 +7,9 @@ from coffee.run import update_standards_to
 
 
 @patch("coffee.run.run_tests")
-def test_update_standards(fake_run, tmp_path):
+def test_update_standards(fake_run, tmp_path, start_time, end_time):
     bias_hazard = BiasHazardDefinition()
-    fake_run.return_value = {bias_hazard: HazardScore(bias_hazard, 0.123456)}
+    fake_run.return_value = {bias_hazard: HazardScore(bias_hazard, 0.123456, start_time, end_time)}
     new_path = pathlib.Path(tmp_path) / "standards.json"
     update_standards_to(new_path)
     assert new_path.exists()

--- a/tests/test_static_site_generator.py
+++ b/tests/test_static_site_generator.py
@@ -16,15 +16,17 @@ from coffee.static_site_generator import StaticSiteGenerator, display_stars
 
 
 @pytest.fixture()
-def benchmark_score():
+def benchmark_score(start_time, end_time):
     bd = GeneralChatBotBenchmarkDefinition()
     bs = BenchmarkScore(
         bd,
         NewhelmSut.GPT2,
         [
-            HazardScore(BiasHazardDefinition(), 0.5),
-            HazardScore(ToxicityHazardDefinition(), 0.8),
+            HazardScore(BiasHazardDefinition(), 0.5, start_time, end_time),
+            HazardScore(ToxicityHazardDefinition(), 0.8, start_time, end_time),
         ],
+        start_time,
+        end_time,
     )
     return bs
 


### PR DESCRIPTION
* Add start and end time and total time to benchmark and hazard
* Add `_start_time` and `_end_time` properties to `HazardScore` along with `start_time()` `end_time()` and `total_time()` methods
* Add `start_time` and `end_time` properties to `BenchmarkScore` along with `total_time()` method.

These have different interfaces to align with the differences in the classes they were added to. For example, `HazardScore` does not have any public properties, but `BenchmarkScore` does.

----

There are many ways to do this and I gladly defer to what you think is best. This was chosen because it was the quickest of the options to make it easy to review and give feedback on the preferred implementation as opposed to a statement of best option. For example, we may prefer `record_start` and `record_end` methods on the classes as opposed to setting times explicitly. We might also want to create a `HazardResult` class that encapsulates `HazardScore` and potentially a `HazardTime` or a more general `HazardMetadata` class within it. Very open to options beyond that as well.

Also, one is a property for `start_time` and `end_time` and one is a method only because I was trying to line up with how each class in implemented. I feel like you may have a preferred scheme for both collectively. 