### PR TITLE
Add dataurl for stylesheet

### DIFF
--- a/src/coffee/templates/base.html
+++ b/src/coffee/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=DM+Sans:400,500,600,700,i,b">
-    <link rel="stylesheet" href="static/style.css">
+    <link rel="stylesheet" href="{{ url_for_static_path(path='style.css', can_inline=True) }}">
 </head>
 <body>
 

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -1,4 +1,5 @@
 import pathlib
+from functools import partial
 from itertools import groupby
 
 import pytest
@@ -15,6 +16,7 @@ from coffee.newhelm_runner import NewhelmSut
 from coffee.static_site_generator import (
     StaticSiteGenerator,
     display_stars,
+    url_for_static_path,
 )
 
 
@@ -60,4 +62,5 @@ def template_env() -> Environment:
     env.globals["benchmark_path"] = ssg.benchmark_path
     env.globals["test_report_path"] = ssg.test_report_path
     env.globals["content"] = ssg.content
+    env.globals["url_for_static_path"] = partial(url_for_static_path)
     return env

--- a/tests/test_static_site_generator.py
+++ b/tests/test_static_site_generator.py
@@ -12,7 +12,7 @@ from coffee.benchmark import (
     BenchmarkScore,
     ToxicityHazardDefinition,
 )
-from coffee.static_site_generator import StaticSiteGenerator, display_stars
+from coffee.static_site_generator import StaticSiteGenerator, display_stars, url_for_static_path
 
 
 @pytest.fixture()
@@ -101,4 +101,15 @@ def test_benchmark_path(static_site_generator, static_site_generator_view_embed)
     assert static_site_generator.benchmark_path("general_chat_bot_benchmark") == "general_chat_bot_benchmark.html"
     assert (
         static_site_generator_view_embed.benchmark_path("general_chat_bot_benchmark") == "../general_chat_bot_benchmark"
+    )
+
+
+def test_url_for_static_path(tmp_path):
+    temp_file = tmp_path / "styles.css"
+    temp_file.write_text("body { color: red; }")
+    assert url_for_static_path("images/ml_commons_logo.png") == "static/images/ml_commons_logo.png"
+    assert url_for_static_path("styles.css", view_embed=True) == "static/styles.css"
+    assert (
+        url_for_static_path("styles.css", static_files_dir=tmp_path, can_inline=True)
+        == "data:text/css;base64,Ym9keSB7IGNvbG9yOiByZWQ7IH0="
     )


### PR DESCRIPTION
* Add dataurl for stylesheet on local build
* Do not use dataurl for emdedded view

Use case: A someone that runs a benchmark, I want to be able to share an individual generated HTML file and have all the styling still applied.

Currently, if a single HTML file is shared with someone else via email or other mechanism, the href to the `style.css` file will not resolve. Because of this, they will not see the styling applied

This was lost in a merge/rebase and is #136 reapplied as that commit is not in the current history.