### PR TITLE
Remove head and footer for embed view

### DIFF
--- a/src/coffee/static_site_generator.py
+++ b/src/coffee/static_site_generator.py
@@ -124,6 +124,7 @@ class StaticSiteGenerator:
             output=output_dir / "index.html",
             template_name="index.html",
             page_type="index",
+            view_embed=self.view_embed,
         )
 
     def _grouped_benchmark_scores(self, benchmark_scores: list[BenchmarkScore]) -> dict:
@@ -142,6 +143,7 @@ class StaticSiteGenerator:
             grouped_benchmark_scores=self._grouped_benchmark_scores(benchmark_scores),
             show_benchmark_header=True,
             page_type="benchmarks",
+            view_embed=self.view_embed,
         )
 
     def _generate_benchmark_pages(self, benchmark_scores: list[BenchmarkScore], output_dir: pathlib.Path) -> None:
@@ -153,6 +155,7 @@ class StaticSiteGenerator:
                     benchmark_definition=benchmark_definition,
                     grouped_benchmark_scores=self._grouped_benchmark_scores(benchmark_scores),
                     page_type="benchmark",
+                    view_embed=self.view_embed,
                 )
 
     def _generate_test_report_pages(self, benchmark_scores: list[BenchmarkScore], output_dir: pathlib.Path) -> None:
@@ -163,6 +166,7 @@ class StaticSiteGenerator:
                 template_name="test_report.html",
                 benchmark_score=benchmark_score,
                 page_type="test_report",
+                view_embed=self.view_embed,
             )
 
     def root_path(self) -> str:

--- a/src/coffee/templates/base.html
+++ b/src/coffee/templates/base.html
@@ -1,3 +1,4 @@
+{% if not view_embed %}
 <!doctype html>
 <html lang="en" data-theme="light" style="font-size: 16px;">
 <head>
@@ -8,8 +9,8 @@
     <link rel="stylesheet" href="static/style.css">
 </head>
 <body>
+{% endif %}
 
-<!-- START EMBED -->
 <div class="pico mlc-ais">
     <div class="container">
       {% block content %}
@@ -17,7 +18,8 @@
       {% endblock %}
     </div>
 </div>
-<!-- END EMBED -->
 
+{% if not view_embed %}
 </body>
 </html>
+{% endif %}


### PR DESCRIPTION
* Remove head and footer for embed view

As we have a full break between the local file view and the embed view, we should go ahead and completely remove the head and footer as they are no longer needed