### PR TITLE
Remove double highlight and minor cleanup

### DIFF
--- a/src/coffee/templates/macros/interpret_safety_ratings.html
+++ b/src/coffee/templates/macros/interpret_safety_ratings.html
@@ -1,12 +1,12 @@
 {% macro interpret_safety_ratings() %}
-    <div class="mlc--section__header ">
+    <div class="mlc--section__header">
         <h2>How to Interpret Safety Ratings?</h2>
         <p class="mlc--placeholder">
             {{ content("general", "interpret_safety_ratings") }}
         </p>
     </div>
 
-    <article class="mlc--card__muted-background mlc--card__grid ">
+    <article class="mlc--card__muted-background mlc--card__grid">
         {% for i in range(5, 0, -1) %}
             <div>
                 <h3>{{ content("stars", i | string)["rank"] }}</h3>

--- a/src/coffee/templates/macros/use_hazards_limitations.html
+++ b/src/coffee/templates/macros/use_hazards_limitations.html
@@ -11,7 +11,7 @@
             <p>
                 {{ content(benchmark_definition, "hazards_description") }}
             </p>
-            <ul class="mlc--placeholder">
+            <ul>
                 {% for hazard in benchmark_definition.hazards() %}
                     <li class="mlc--placeholder">
                         <strong>{{ content(hazard, "name") }}:</strong> {{ content(hazard, "description") }}


### PR DESCRIPTION
* Remove double highlight and minor cleanup

As `<li class="mlc-placeholder">` is already set, setting `<ul class="mlc-placeholder">` creates an extra bright yellow due to the layering of `rgba(255, 255, 0, 0.4)`.

<img width="647" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/c59f8884-2e18-4d01-a2ba-74e3e429a199">
