### PR TITLE
CSS Variable reset for dark mode

### DIFF
--- a/src/coffee/templates/base.html
+++ b/src/coffee/templates/base.html
@@ -1,6 +1,6 @@
 {% if not view_embed %}
 <!doctype html>
-<html lang="en" data-theme="light" style="font-size: 16px;">
+<html lang="en" style="font-size: 16px;">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -10,6 +10,143 @@
   --mlc-color-base-black: hsl(226 35% 14%);
 }
 
+/**
+ * Reset for prefer dark mode
+ */
+@media only screen and (prefers-color-scheme: dark) {
+  :root:not([data-theme=dark]) {
+    --pico-background-color: #fff;
+    --pico-color: #373c44;
+    --pico-text-selection-color: rgba(2, 154, 232, 0.25);
+    --pico-muted-color: #646b79;
+    --pico-muted-border-color: #e7eaf0;
+    --pico-primary: #0172ad;
+    --pico-primary-background: #0172ad;
+    --pico-primary-border: var(--pico-primary-background);
+    --pico-primary-underline: rgba(1, 114, 173, 0.5);
+    --pico-primary-hover: #015887;
+    --pico-primary-hover-background: #02659a;
+    --pico-primary-hover-border: var(--pico-primary-hover-background);
+    --pico-primary-hover-underline: var(--pico-primary-hover);
+    --pico-primary-focus: rgba(2, 154, 232, 0.5);
+    --pico-primary-inverse: #fff;
+    --pico-secondary: #5d6b89;
+    --pico-secondary-background: #525f7a;
+    --pico-secondary-border: var(--pico-secondary-background);
+    --pico-secondary-underline: rgba(93, 107, 137, 0.5);
+    --pico-secondary-hover: #48536b;
+    --pico-secondary-hover-background: #48536b;
+    --pico-secondary-hover-border: var(--pico-secondary-hover-background);
+    --pico-secondary-hover-underline: var(--pico-secondary-hover);
+    --pico-secondary-focus: rgba(93, 107, 137, 0.25);
+    --pico-secondary-inverse: #fff;
+    --pico-contrast: #181c25;
+    --pico-contrast-background: #181c25;
+    --pico-contrast-border: var(--pico-contrast-background);
+    --pico-contrast-underline: rgba(24, 28, 37, 0.5);
+    --pico-contrast-hover: #000;
+    --pico-contrast-hover-background: #000;
+    --pico-contrast-hover-border: var(--pico-contrast-hover-background);
+    --pico-contrast-hover-underline: var(--pico-secondary-hover);
+    --pico-contrast-focus: rgba(93, 107, 137, 0.25);
+    --pico-contrast-inverse: #fff;
+    --pico-box-shadow: 0.0145rem 0.029rem 0.174rem rgba(129, 145, 181, 0.01698), 0.0335rem 0.067rem 0.402rem rgba(129, 145, 181, 0.024), 0.0625rem 0.125rem 0.75rem rgba(129, 145, 181, 0.03), 0.1125rem 0.225rem 1.35rem rgba(129, 145, 181, 0.036), 0.2085rem 0.417rem 2.502rem rgba(129, 145, 181, 0.04302), 0.5rem 1rem 6rem rgba(129, 145, 181, 0.06), 0 0 0 0.0625rem rgba(129, 145, 181, 0.015);
+    --pico-h1-color: #2d3138;
+    --pico-h2-color: #373c44;
+    --pico-h3-color: #424751;
+    --pico-h4-color: #4d535e;
+    --pico-h5-color: #5c6370;
+    --pico-h6-color: #646b79;
+    --pico-mark-background-color: #fde7c0;
+    --pico-mark-color: #0f1114;
+    --pico-ins-color: #1d6a54;
+    --pico-del-color: #883935;
+    --pico-blockquote-border-color: var(--pico-muted-border-color);
+    --pico-blockquote-footer-color: var(--pico-muted-color);
+    --pico-button-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+    --pico-button-hover-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+    --pico-table-border-color: var(--pico-muted-border-color);
+    --pico-table-row-stripped-background-color: rgba(111, 120, 135, 0.0375);
+    --pico-code-background-color: #f3f5f7;
+    --pico-code-color: #646b79;
+    --pico-code-kbd-background-color: var(--pico-color);
+    --pico-code-kbd-color: var(--pico-background-color);
+    --pico-form-element-background-color: #fbfcfc;
+    --pico-form-element-selected-background-color: #dfe3eb;
+    --pico-form-element-border-color: #cfd5e2;
+    --pico-form-element-color: #23262c;
+    --pico-form-element-placeholder-color: var(--pico-muted-color);
+    --pico-form-element-active-background-color: #fff;
+    --pico-form-element-active-border-color: var(--pico-primary-border);
+    --pico-form-element-focus-color: var(--pico-primary-border);
+    --pico-form-element-disabled-opacity: 0.5;
+    --pico-form-element-invalid-border-color: #b86a6b;
+    --pico-form-element-invalid-active-border-color: #c84f48;
+    --pico-form-element-invalid-focus-color: var(--pico-form-element-invalid-active-border-color);
+    --pico-form-element-valid-border-color: #4c9b8a;
+    --pico-form-element-valid-active-border-color: #279977;
+    --pico-form-element-valid-focus-color: var(--pico-form-element-valid-active-border-color);
+    --pico-switch-background-color: #bfc7d9;
+    --pico-switch-checked-background-color: var(--pico-primary-background);
+    --pico-switch-color: #fff;
+    --pico-switch-thumb-box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+    --pico-range-border-color: #dfe3eb;
+    --pico-range-active-border-color: #bfc7d9;
+    --pico-range-thumb-border-color: var(--pico-background-color);
+    --pico-range-thumb-color: var(--pico-secondary-background);
+    --pico-range-thumb-active-color: var(--pico-primary-background);
+    --pico-accordion-border-color: var(--pico-muted-border-color);
+    --pico-accordion-active-summary-color: var(--pico-primary-hover);
+    --pico-accordion-close-summary-color: var(--pico-color);
+    --pico-accordion-open-summary-color: var(--pico-muted-color);
+    --pico-card-background-color: var(--pico-background-color);
+    --pico-card-border-color: var(--pico-muted-border-color);
+    --pico-card-box-shadow: var(--pico-box-shadow);
+    --pico-card-sectioning-background-color: #fbfcfc;
+    --pico-dropdown-background-color: #fff;
+    --pico-dropdown-border-color: #eff1f4;
+    --pico-dropdown-box-shadow: var(--pico-box-shadow);
+    --pico-dropdown-color: var(--pico-color);
+    --pico-dropdown-hover-background-color: #eff1f4;
+    --pico-loading-spinner-opacity: 0.5;
+    --pico-modal-overlay-background-color: rgba(232, 234, 237, 0.75);
+    --pico-progress-background-color: #dfe3eb;
+    --pico-progress-color: var(--pico-primary-background);
+    --pico-tooltip-background-color: var(--pico-contrast-background);
+    --pico-tooltip-color: var(--pico-contrast-inverse);
+    --pico-icon-valid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(76, 155, 138)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+    --pico-icon-invalid: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='rgb(200, 79, 72)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'%3E%3C/circle%3E%3Cline x1='12' y1='8' x2='12' y2='12'%3E%3C/line%3E%3Cline x1='12' y1='16' x2='12.01' y2='16'%3E%3C/line%3E%3C/svg%3E");
+    color-scheme: light;
+  }
+  [data-theme=light] input:is([type=submit],
+  [type=button],
+  [type=reset],
+  [type=checkbox],
+  [type=radio],
+  [type=file]),
+  :root:not([data-theme=dark]) input:is([type=submit],
+  [type=button],
+  [type=reset],
+  [type=checkbox],
+  [type=radio],
+  [type=file]) {
+    --pico-form-element-focus-color: var(--pico-primary-focus);
+  }
+  /**
+   * Only set for dark mode default in picocss
+   */
+  :root:not([data-theme]) details summary[role=button].contrast:not(.outline)::after {
+    filter: brightness(1);
+  }
+  :root:not([data-theme]) [aria-busy=true]:not(input, select, textarea).contrast:is(button,
+  [type=submit],
+  [type=button],
+  [type=reset],
+  [role=button]):not(.outline)::before {
+    filter: brightness(1);
+  }
+}
+
 [data-theme=light],
 :root:not([data-theme=dark]) {
   --pico-color: #343C52;


### PR DESCRIPTION
* CSS Variable reset for dark mode
* Apply light mode colors to dark mode media query to prevent any default dark mode styles from applying

This removes the `data-theme="light"` from the `<html>` element as the embedded view cannot set that in a maintainable way. This applies the defaults directly from the css framework

See: https://github.com/picocss/pico/tree/main/scss/themes/default
See: https://picocss.com/docs/css-variables