### PR TITLE
Change to new louder provisional disclaimer

### DIFF
--- a/src/coffee/templates/_provisional.html
+++ b/src/coffee/templates/_provisional.html
@@ -1,1 +1,1 @@
-<span class="mlc--provisional">Provisional</span>
+<article class="mlc--provisional">{{ content("general", "provisional_disclaimer") }}</article>

--- a/src/coffee/templates/benchmark.html
+++ b/src/coffee/templates/benchmark.html
@@ -11,11 +11,13 @@
     {{ breadcrumb(None, benchmark_definition) }}
 
     <div class="mlc--section">
-        <h1 class="mlc--header">{{ content(benchmark_definition, "name") }} {% include "_provisional.html" %}</h1>
+        <h1 class="mlc--header">{{ content(benchmark_definition, "name") }}</h1>
         <p class="mlc--subheader mlc--placeholder">
             {{ content(benchmark_definition, "tagline") }}
         </p>
     </div>
+
+    {% include "_provisional.html" %}
 
     {{ use_hazards_limitations(benchmark_definition) }}
 

--- a/src/coffee/templates/benchmarks.html
+++ b/src/coffee/templates/benchmarks.html
@@ -10,11 +10,13 @@
     {{ breadcrumb(benchmark_score, benchmark_definition, page_type="benchmarks") }}
 
     <div class="mlc--section">
-        <h1 class="mlc--header">AI Safety Benchmarks {% include "_provisional.html" %}</h1>
+        <h1 class="mlc--header">AI Safety Benchmarks</h1>
         <p class="mlc--subheader">
             {{ content("general", "description") }}
         </p>
     </div>
+
+    {% include "_provisional.html" %}
 
     {% for benchmark_definition in grouped_benchmark_scores %}
         {{ benchmark_card(True, benchmark_definition) }}

--- a/src/coffee/templates/content/general.toml
+++ b/src/coffee/templates/content/general.toml
@@ -12,3 +12,5 @@ overall_safety_rating = "How is overall rating calculated explanation goes here 
 tests_run = "Description goes here lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboliquip ex ea commodo consequat."
 
 interpret_safety_ratings = "Description goes here lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+
+provisional_disclaimer = "ML Commons Safety Benchmarks v0.5 is a proof of concept only. Results are not intended to indicate actual levels of  AI system safety."

--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -166,8 +166,9 @@
 
 .pico article {
   --pico-border-radius: 1rem;
-  --pico-block-spacing-vertical: 3rem;
+  --pico-block-spacing-vertical: 2.6rem;
   --pico-block-spacing-horizontal: 3rem;
+  margin-bottom: 3rem;
 }
 
 .pico article.mlc--card__border {
@@ -313,16 +314,10 @@
 }
 
 .pico .mlc--provisional {
-  color: var(--mlc-color-efficient-ember);
-  font-size: 1rem;
-  border: 2px solid var(--mlc-color-efficient-ember);
-  background-color: hsl(33 85% 95%);
-  text-transform: uppercase;
-  padding: 0.75rem 1.5rem;
-  border-radius: 0.25rem;
-  display: inline-block;
+  background-color: var(--mlc-color-efficient-ember);
+  color: #fff;
   font-weight: 700;
-  letter-spacing: 1px;
+  font-size: 1.25rem;
 }
 
 .pico .mlc--placeholder {

--- a/src/coffee/templates/test_report.html
+++ b/src/coffee/templates/test_report.html
@@ -14,11 +14,13 @@
 
     <div class="mlc--section">
         <h2>Test Report</h2>
-        <h1 class="mlc--header">{{ content(benchmark_score.sut, "name") }} - {{ content(benchmark_score.benchmark_definition, "name") }} {% include "_provisional.html" %}</h1>
+        <h1 class="mlc--header">{{ content(benchmark_score.sut, "name") }} - {{ content(benchmark_score.benchmark_definition, "name") }}</h1>
         <p class="mlc--subheader mlc--placeholder">
             {{ content(benchmark_score.sut, "tagline") }}
         </p>
     </div>
+
+    {% include "_provisional.html" %}
 
     {{ use_hazards_limitations(benchmark_score.benchmark_definition) }}
 


### PR DESCRIPTION
* Change to new louder provisional disclaimer
* Adjust card padding to match design more closely

<img width="790" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/e9c01fca-a967-4e76-99d7-243918023233">

Edit: The gray over "Bias" is just that I had that text highlighted when I took the screenshot. It is not a regression.