### PR TITLE
Add placeholder for new test run design

### DIFF
--- a/src/coffee/templates/macros/test_runs.html
+++ b/src/coffee/templates/macros/test_runs.html
@@ -1,0 +1,43 @@
+{% macro test_runs(title, num_iterations, human_readable_safety_score) -%}
+<h3 class="mlc--test-run-title">{{ title }}</h3>
+    <ul class="mlc--test-run-metadata">
+        <li>Number of iterations: <span class="mlc--placeholder__dynamic">{{ num_iterations }}</span></li>
+        <li>Avg Safety Score: <span class="mlc--placeholder__dynamic">{{ human_readable_safety_score }}</span></li>
+    </ul>
+    <ul>
+        <li>
+            <div class="mlc--test-score-bar-container">
+                <h5 class="mlc--test-score-bar-title mlc--placeholder">Test Name</h5>
+
+                <div class="mlc--test-score-bar">
+                    <div style="width: 42%; left: 33%" class="mlc--test-response-percentage-bar-container">
+                        <div style="left: 43%" class="mlc--test-response-percentage-bar"></div>
+                    </div>
+                    <div style="right: 55%" class="mlc--test-response-percentage-dot"></div>
+
+                    <div style="width: 20%" class="mlc--test-score-bar-section mlc--test-score-bar-section__below"></div>
+                    <div style="width: 15%" class="mlc--test-score-bar-section mlc--test-score-bar-section__similar"></div>
+                    <div style="width: 30%" class="mlc--test-score-bar-section mlc--test-score-bar-section__exceeds"></div>
+                    <div style="width: 35%" class="mlc--test-score-bar-section mlc--test-score-bar-section__near-human"></div>
+                </div>
+            </div>
+        </li>
+        <li>
+            <div class="mlc--test-score-bar-container">
+                <h5 class="mlc--test-score-bar-title mlc--placeholder">Test Name</h5>
+
+                <div class="mlc--test-score-bar">
+                    <div style="width: 42%; left: 33%" class="mlc--test-response-percentage-bar-container">
+                        <div style="left: 43%" class="mlc--test-response-percentage-bar"></div>
+                    </div>
+                    <div style="right: 55%" class="mlc--test-response-percentage-dot"></div>
+
+                    <div style="width: 20%" class="mlc--test-score-bar-section mlc--test-score-bar-section__below"></div>
+                    <div style="width: 15%" class="mlc--test-score-bar-section mlc--test-score-bar-section__similar"></div>
+                    <div style="width: 30%" class="mlc--test-score-bar-section mlc--test-score-bar-section__exceeds"></div>
+                    <div style="width: 35%" class="mlc--test-score-bar-section mlc--test-score-bar-section__near-human"></div>
+                </div>
+            </div>
+        </li>
+    </ul>
+{%- endmacro %}

--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -9,6 +9,12 @@
   --mlc-color-cloud-blue: hsl(218 48% 95%);
   --mlc-color-deep-web-blue: hsl(224 22% 26%);
   --mlc-color-base-black: hsl(226 35% 14%);
+
+  --mlc-color-red: hsl(5, 81%, 61%);
+  --mlc-color-orange: hsl(26, 95%, 58%);
+  --mlc-color-yellow: hsl(45, 97%, 55%);
+  --mlc-color-green: hsl(136, 42%, 49%);
+  --mlc-color-blue: hsl(215, 67%, 51%);
 }
 
 /**
@@ -553,4 +559,103 @@
 
 .pico tbody tr:not(:last-child) {
   border-bottom: 1px solid var(--pico-table-border-color) !important;
+}
+
+.pico .mlc--test-runs > li {
+  margin-bottom: 3rem;
+}
+
+.pico .mlc--test-run-title {
+  color: var(--mlc-color-deep-web-blue);
+  margin-bottom: 1.25rem;
+}
+
+.pico .mlc--test-run-metadata {
+  margin-bottom: 2rem;
+}
+
+.pico .mlc--test-run-metadata li {
+  color: var(--mlc-color-moonshadow);
+  line-height: 1;
+  font-size: 0.85rem;
+}
+
+.pico .mlc--test-score-bar-container {
+  display: flex;
+  flex-wrap: nowrap;
+  column-gap: 5px;
+  align-items: end;
+  justify-content: space-between;
+  margin-bottom: 1.75rem;
+}
+
+.pico .mlc--test-response-percentage-bar-container {
+  position: absolute;
+  bottom: 20px;
+  height: 8px;
+  border-right: 2px solid var(--mlc-color-blue);
+  border-left: 2px solid var(--mlc-color-blue);
+}
+
+.pico .mlc--test-response-percentage-bar {
+  width: 100%;
+  background: var(--mlc-color-blue);
+  height: 2px;
+  margin-top: 3px;
+}
+
+.pico .mlc--test-response-percentage-dot {
+  position: absolute;
+  bottom: 15px;
+  width: 18px;
+  height: 18px;
+  background: var(--mlc-color-blue);
+  border-radius: 50%;
+}
+
+.pico .mlc--test-score-bar {
+  display: flex;
+  width: 65%;
+  column-gap: 5px;
+  position: relative;
+}
+
+.pico .mlc--test-score-bar-title {
+  color: var(--mlc-color-deep-web-blue);
+  width: 35%;
+  padding-bottom: 10px;
+  background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><rect x="0" y="0" width="100%" height="100%" fill="%23EEF2F9" stroke="none" rx="2.5" /></svg>');
+  background-repeat: no-repeat;
+  background-position: bottom;
+  background-size: 100% 5px;
+}
+
+.pico .mlc--test-score-bar-section {
+  height: 5px;
+}
+
+.pico .mlc--test-score-bar-section:first-child {
+  border-top-left-radius: 2.5px;
+  border-bottom-left-radius: 2.5px;
+}
+
+.pico .mlc--test-score-bar-section:last-child {
+  border-top-right-radius: 2.5px;
+  border-bottom-right-radius: 2.5px;
+}
+
+.pico .mlc--test-score-bar-section__below {
+  background: var(--mlc-color-red);
+}
+
+.pico .mlc--test-score-bar-section__similar {
+  background: var(--mlc-color-orange);
+}
+
+.pico .mlc--test-score-bar-section__exceeds {
+  background: var(--mlc-color-yellow);
+}
+
+.pico .mlc--test-score-bar-section__near-human {
+  background: var(--mlc-color-green);
 }

--- a/src/coffee/templates/test_report.html
+++ b/src/coffee/templates/test_report.html
@@ -3,6 +3,7 @@
 {% from "macros/interpret_safety_ratings.html" import interpret_safety_ratings %}
 {% from "macros/sut_card.html" import sut_card %}
 {% from "macros/tooltip_info.html" import tooltip_info %}
+{% from "macros/test_runs.html" import test_runs %}
 {% from "macros/use_hazards_limitations.html" import use_hazards_limitations %}
 
 {% extends "base.html" %}
@@ -45,46 +46,16 @@
         </p>
     </div>
 
-    <figure class="mlc--table__box-shadow overflow-auto mlc--placeholder">
-        <table>
-            <thead>
-                <tr>
-                    <th>Test</th>
-                    <th>No. of iterations</th>
-                    <th>% good</th>
-                    <th>Reference (% good)</th>
-                    <th>Human expert (% good)</th>
-                    <th>Error rating</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>Test Name</td>
-                    <td>34553</td>
-                    <td>80%</td>
-                    <td>80%</td>
-                    <td>100%</td>
-                    <td>0.45</td>
-                </tr>
-                <tr>
-                    <td>Test Name</td>
-                    <td>23434</td>
-                    <td>60%</td>
-                    <td>60%</td>
-                    <td>100%</td>
-                    <td>0.45</td>
-                </tr>
-                <tr>
-                    <td>Test Name</td>
-                    <td>23423</td>
-                    <td>30%</td>
-                    <td>30%</td>
-                    <td>100%</td>
-                    <td>0.45</td>
-                </tr>
-            </tbody>
-        </table>
-    </figure>
+    <article class="mlc--card__border">
+        <ul class="mlc--test-runs">
+            <li>
+                {{ test_runs("Physical Harms", 1, "Excellent (80% safe responses)") }}
+            </li>
+            <li>
+                {{ test_runs("Bias and Offense", 1, "Excellent (80% safe responses)") }}
+            </li>
+        </ul>
+    </article>
 
     <h2>Test Details</h2>
 


### PR DESCRIPTION
* Add placeholder for new test run design

Note: Does not currently implement tooltip and does not account for dynamically scaling bars

<img width="768" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/82cad80b-1946-46cd-ae14-fe0961c02444">
