### PR TITLE
Fix (not yet observed) issue with using itertools.groupby.

### DIFF
--- a/src/coffee/static_site_generator.py
+++ b/src/coffee/static_site_generator.py
@@ -2,7 +2,6 @@ import math
 import pathlib
 import shutil
 from functools import singledispatchmethod
-from itertools import groupby
 
 import casefy
 import tomli
@@ -11,6 +10,7 @@ from markupsafe import Markup
 
 from coffee.benchmark import BenchmarkDefinition, BenchmarkScore, HazardDefinition
 from coffee.newhelm_runner import NewhelmSut
+from coffee.utilities import group_by_key
 
 
 def display_stars(score, size) -> Markup:
@@ -131,13 +131,7 @@ class StaticSiteGenerator:
         )
 
     def _grouped_benchmark_scores(self, benchmark_scores: list[BenchmarkScore]) -> dict:
-        benchmark_scores_dict = {}
-        for benchmark_definition, grouped_benchmark_scores in groupby(
-            benchmark_scores, lambda x: x.benchmark_definition
-        ):
-            grouped_benchmark_scores_list: list = list(grouped_benchmark_scores)
-            benchmark_scores_dict[benchmark_definition] = grouped_benchmark_scores_list
-        return benchmark_scores_dict
+        return group_by_key(benchmark_scores, lambda x: x.benchmark_definition)
 
     def _generate_benchmarks_page(self, benchmark_scores: list[BenchmarkScore], output_dir: pathlib.Path) -> None:
         self._write_file(

--- a/src/coffee/utilities.py
+++ b/src/coffee/utilities.py
@@ -1,0 +1,10 @@
+from collections import defaultdict
+from typing import Callable, Mapping, Sequence
+
+
+def group_by_key(items: Sequence, key=Callable) -> Mapping:
+    """Group `items` by the value returned by `key(item)`."""
+    groups = defaultdict(list)
+    for item in items:
+        groups[key(item)].append(item)
+    return groups

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -1,5 +1,4 @@
 import pathlib
-from itertools import groupby
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
@@ -16,6 +15,7 @@ from coffee.static_site_generator import (
     StaticSiteGenerator,
     display_stars,
 )
+from coffee.utilities import group_by_key
 
 
 def _benchmark_score(start_time, end_time, fake_secrets) -> BenchmarkScore:
@@ -42,13 +42,8 @@ def benchmark_score(start_time, end_time, fake_secrets) -> BenchmarkScore:
 
 @pytest.fixture()
 def grouped_benchmark_scores(start_time, end_time, fake_secrets) -> dict[str, list[BenchmarkScore]]:
-    benchmark_scores_dict = {}
-    for benchmark_definition, grouped_benchmark_scores in groupby(
-        [_benchmark_score(start_time, end_time, fake_secrets)], lambda x: x.benchmark_definition
-    ):
-        grouped_benchmark_scores_list: list = list(grouped_benchmark_scores)
-        benchmark_scores_dict[benchmark_definition] = grouped_benchmark_scores_list
-    return benchmark_scores_dict
+    scores = [_benchmark_score(start_time, end_time, fake_secrets)]
+    return group_by_key(scores, key=lambda x: x.benchmark_definition)
 
 
 @pytest.fixture()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from itertools import groupby
+
+from coffee.utilities import group_by_key
+
+
+@dataclass
+class SomeClass:
+    my_group: int
+    value: int
+
+
+def test_iterables_groupby():
+    # This test demonstrates that itertools.groupby requires groups to be sorted.
+    group_1_item_1 = SomeClass(my_group=1, value=1)
+    group_1_item_2 = SomeClass(my_group=1, value=2)
+    group_2_item_1 = SomeClass(my_group=2, value=1)
+    group_2_item_2 = SomeClass(my_group=2, value=2)
+
+    items = [
+        # Not sorted by group
+        group_1_item_1,
+        group_2_item_1,
+        group_1_item_2,
+        group_2_item_2,
+    ]
+    groups = []
+    for key, values in groupby(items, key=lambda c: c.my_group):
+        groups.append((key, list(values)))
+    # Shows that no grouping was performed.
+    assert groups == [
+        (1, [group_1_item_1]),
+        (2, [group_2_item_1]),
+        (1, [group_1_item_2]),
+        (2, [group_2_item_2]),
+    ]
+
+
+def test_group_by_key():
+    group_1_item_1 = SomeClass(my_group=1, value=1)
+    group_1_item_2 = SomeClass(my_group=1, value=2)
+    group_2_item_1 = SomeClass(my_group=2, value=1)
+    group_2_item_2 = SomeClass(my_group=2, value=2)
+
+    items = [
+        # Not sorted by group
+        group_1_item_1,
+        group_2_item_1,
+        group_1_item_2,
+        group_2_item_2,
+    ]
+    groups = []
+    for key, values in group_by_key(items, key=lambda c: c.my_group).items():
+        groups.append((key, list(values)))
+    assert groups == [
+        (1, [group_1_item_1, group_1_item_2]),
+        (2, [group_2_item_1, group_2_item_2]),
+    ]


### PR DESCRIPTION
This is subtly called out in the [docs](https://docs.python.org/3/library/itertools.html#itertools.groupby): "Generally, the iterable needs to already be sorted on the same key function".