### PR TITLE
Fix issue where BBQ tried to do zero test items.

### DIFF
--- a/src/coffee/run.py
+++ b/src/coffee/run.py
@@ -95,6 +95,9 @@ def benchmark(
                         if isinstance(test, newhelm.tests.bbq.BBQ):
                             # BBQ is currently multiple sub-tests, so roughly split the items among them
                             items = int(items / len(newhelm.tests.bbq._CATEGORIES))
+                            if items <= 0:
+                                # Ensure we always do at least one.
+                                items = 1
                         results[test_key] = run_prompt_response_test(
                             test_key, test, sut.key, sut_instance, "./run", items
                         )


### PR DESCRIPTION
In the docs it suggests the following command:
```
poetry run coffee benchmark -m 10
```
There are 11 BBQ instances, so this would cause `items` to be zero. Due to a [bug in newhelm](https://github.com/mlcommons/newhelm/pull/281) that would cause all 1000 BBQ instances to run for every BBQ test. Fixing the logic here so we get the desired 1 item per BBQ test.