### PR TITLE
Change "benchmarks" stub to "ai-safety"

### DIFF
--- a/src/coffee/static_site_generator.py
+++ b/src/coffee/static_site_generator.py
@@ -176,8 +176,8 @@ class StaticSiteGenerator:
 
     def benchmarks_path(self, page_type: str) -> str:
         if page_type == "benchmarks" and self.view_embed:
-            return "../benchmarks"
-        return "../../benchmarks" if self.view_embed else "benchmarks.html"
+            return "../ai-safety"
+        return "../../ai-safety" if self.view_embed else "benchmarks.html"
 
     def benchmark_path(self, benchmark_path_name, page_type: str) -> str:
         if page_type == "benchmarks" and self.view_embed:

--- a/tests/test_static_site_generator.py
+++ b/tests/test_static_site_generator.py
@@ -109,8 +109,8 @@ def test_root_path(static_site_generator, static_site_generator_view_embed):
 
 def test_benchmarks_path(static_site_generator, static_site_generator_view_embed):
     assert static_site_generator.benchmarks_path(page_type="benchmarks") == "benchmarks.html"
-    assert static_site_generator_view_embed.benchmarks_path(page_type="benchmarks") == "../benchmarks"
-    assert static_site_generator_view_embed.benchmarks_path(page_type="benchmark") == "../../benchmarks"
+    assert static_site_generator_view_embed.benchmarks_path(page_type="benchmarks") == "../ai-safety"
+    assert static_site_generator_view_embed.benchmarks_path(page_type="benchmark") == "../../ai-safety"
 
 
 def test_benchmark_path(static_site_generator, static_site_generator_view_embed):


### PR DESCRIPTION
* Change "benchmarks" stub to "ai-safety"

Live site will be a "ai-safety" stub, not "benchmarks". Change to "ai-safety" in embed view.