### PR TITLE
Remove `.container` from embed view

### DIFF
--- a/src/coffee/templates/base.html
+++ b/src/coffee/templates/base.html
@@ -12,7 +12,7 @@
 {% endif %}
 
 <div class="pico mlc-ais">
-    <div class="container">
+    <div class="{{ 'mlc--container__embed' if view_embed else 'container' }}">
       {% block content %}
 
       {% endblock %}

--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -322,7 +322,8 @@
   --pico-font-size: 3.5rem;
 }
 
-.pico .container {
+.pico .container,
+.pico .mlc--container__embed {
   padding-top: 3rem;
   padding-bottom: 3rem;
 }

--- a/tests/templates/conftest.py
+++ b/tests/templates/conftest.py
@@ -46,8 +46,7 @@ def grouped_benchmark_scores(start_time, end_time) -> dict[str, list[BenchmarkSc
     return group_by_key(scores, key=lambda x: x.benchmark_definition)
 
 
-@pytest.fixture()
-def template_env() -> Environment:
+def _template_env(view_embed: bool = False) -> Environment:
     def update_dict_values(d: dict, parent_keys=[]) -> dict:
         for k, v in d.items():
             new_keys = parent_keys + [k]
@@ -59,7 +58,7 @@ def template_env() -> Environment:
 
     template_dir = pathlib.Path(__file__).parent.parent.parent / "src" / "coffee" / "templates"
     env = Environment(loader=FileSystemLoader(template_dir))
-    ssg = StaticSiteGenerator()
+    ssg = StaticSiteGenerator(view_embed=view_embed)
     env.filters["display_stars"] = display_stars
     env.globals["root_path"] = ssg.root_path
     env.globals["benchmarks_path"] = ssg.benchmarks_path
@@ -68,3 +67,13 @@ def template_env() -> Environment:
     ssg._content = update_dict_values(ssg._content)
     env.globals["content"] = ssg.content
     return env
+
+
+@pytest.fixture()
+def template_env() -> Environment:
+    return _template_env()
+
+
+@pytest.fixture()
+def template_env_view_embed() -> Environment:
+    return _template_env(view_embed=True)

--- a/tests/templates/test_benchmark.py
+++ b/tests/templates/test_benchmark.py
@@ -15,3 +15,15 @@ def test_benchmark(benchmark_score, template_env, grouped_benchmark_scores):
     assert html.find(string=re.compile("Hazards Tested"))
     assert html.find(string=re.compile("How to Interpret Safety Ratings?"))
     assert html.find(string=re.compile("AI Systems Evaluated"))
+
+
+def test_benchmark_container_embed_class(benchmark_score, template_env_view_embed, grouped_benchmark_scores):
+    template = template_env_view_embed.get_template("benchmark.html")
+    result = template.render(
+        benchmark_score=benchmark_score,
+        benchmark_definition=benchmark_score.benchmark_definition,
+        grouped_benchmark_scores=grouped_benchmark_scores,
+        view_embed=True,
+    )
+    html = BeautifulSoup(result, "html.parser")
+    assert html.find("div", {"class": "mlc--container__embed"})


### PR DESCRIPTION
* Remove `.container` from embed view
* Replace with `.mlc--container__embed` to still apply `3rem` padding
* Fixes slightly compressed content on emded view. Especially on smaller viewports

Not styling `.container` via `.pico` or other data attribute as the `.container` class is widely used so ultimately it is better to just get entitely out of the way