### PR TITLE
Rename some headers to better reflect what the section contains

### DIFF
--- a/src/coffee/templates/test_report.html
+++ b/src/coffee/templates/test_report.html
@@ -38,7 +38,7 @@
     {{ sut_card(benchmark_score) }}
 
     <div class="mlc--section__header ">
-        <h2>Tests Run</h2>
+        <h2>Hazard Scoring Details</h2>
         <p class="mlc--placeholder">
             {{ content("general", "tests_run") }}
         </p>
@@ -56,7 +56,7 @@
 
     {% include "_test_runs_legend.html" %}
 
-    <h2>Test Details</h2>
+    <h2>Run Details</h2>
 
     <article class="mlc--card__border mlc--card__grid mlc--card__box-shadow">
         <div>

--- a/tests/templates/test_test_report.py
+++ b/tests/templates/test_test_report.py
@@ -12,6 +12,6 @@ def test_test_report(benchmark_score, template_env):
     assert html.find(string=re.compile("__test__.grades.1.explanation"))
     assert html.find(string=re.compile("__test__.general_purpose_ai_chat_benchmark.name"))
     assert html.find(string=re.compile("Test Report"))
-    assert html.find(string=re.compile("Tests Run"))
-    assert html.find(string=re.compile("Test Details"))
+    assert html.find(string=re.compile("Hazard Scoring Details"))
+    assert html.find(string=re.compile("Run Details"))
     assert html.find(string=re.compile("Don't see the tests you are looking for?"))


### PR DESCRIPTION
We don't show any data specific to Tests, so its odd that the section headers say "Test". Open to any other naming ideas.