### PR TITLE
Remove tooltip from run details

### DIFF
--- a/src/coffee/templates/macros/tooltip_info.html
+++ b/src/coffee/templates/macros/tooltip_info.html
@@ -1,5 +1,0 @@
-{% macro tooltip_info(content) -%}
-    <span class="mlc--tooltip-info" data-tooltip="{{ content }}">
-        <span class="mlc--tooltip-info-content">i</span>
-    </span>
-{%- endmacro %}

--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -569,24 +569,6 @@
   --pico-border-radius: 0.25rem;
 }
 
-.pico [data-tooltip].mlc--tooltip-info {
-  border: 1.5px solid var(--pico-primary);
-  cursor: pointer;
-  width: 14px;
-  height: 14px;
-  display: inline-grid;
-  border-radius: 50%;
-  position: relative;
-  top: -1px;
-}
-
-.pico .mlc--tooltip-info-content {
-  place-self: center;
-  font-style: italic;
-  font-size: 12px;
-  line-height: 1;
-}
-
 .pico .mlc--provisional {
   display: flex;
   gap: 2rem;

--- a/src/coffee/templates/test_report.html
+++ b/src/coffee/templates/test_report.html
@@ -1,7 +1,6 @@
 {% from "macros/breadcrumb.html" import breadcrumb %}
 {% from "macros/interpret_safety_ratings.html" import interpret_safety_ratings %}
 {% from "macros/sut_card.html" import sut_card %}
-{% from "macros/tooltip_info.html" import tooltip_info %}
 {% from "macros/test_runs.html" import test_runs %}
 {% from "macros/use_hazards_limitations.html" import use_hazards_limitations %}
 
@@ -52,23 +51,23 @@
 
     <article class="mlc--card__border mlc--card__grid mlc--card__box-shadow">
         <div>
-            <h6 class="mlc--test-detail-header">Benchmark UID {{ tooltip_info("Help test for UID") }}</h6>
+            <h6 class="mlc--test-detail-header">Benchmark UID</h6>
             <p>{{ content(benchmark_score.benchmark_definition, "uid") }}</p>
         </div>
         <div>
-            <h6 class="mlc--test-detail-header">Benchmark Version {{ tooltip_info("Benchmark version help text") }}</h6>
+            <h6 class="mlc--test-detail-header">Benchmark Version</h6>
             <p class="mlc--placeholder">{{ content(benchmark_score.benchmark_definition, "version") }}</p>
         </div>
         <div>
-            <h6 class="mlc--test-detail-header">Last Run {{ tooltip_info("Last run info") }}</h6>
+            <h6 class="mlc--test-detail-header">Last Run</h6>
             <p>{{ benchmark_score.end_time.strftime('%Y-%m-%d %H:%M:%S %Z') }}</p>
         </div>
         <div>
-            <h6 class="mlc--test-detail-header">Model Display Name {{ tooltip_info("Model display info") }}</h6>
+            <h6 class="mlc--test-detail-header">Model Display Name</h6>
             <p>{{ content(benchmark_score.sut, "name") }}</p>
         </div>
         <div>
-            <h6 class="mlc--test-detail-header">Model UID {{ tooltip_info("Info for model UID") }}</h6>
+            <h6 class="mlc--test-detail-header">Model UID</h6>
             <p>{{ benchmark_score.sut.key }}</p>
         </div>
     </article>


### PR DESCRIPTION
* Remove tooltip from run details

There is no content for the item tooltipes and items content would most likely be redundant as items are self explanatory

<img width="278" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/539329c3-8863-4b21-876c-f24cfbfcf5d6">
