### PR TITLE
Move card alignment to top and break word

### DIFF
--- a/src/coffee/templates/static/style.css
+++ b/src/coffee/templates/static/style.css
@@ -1121,14 +1121,15 @@
 
 .pico .mlc--interpret-ratings__item h3 {
   margin-bottom: 1.25rem;
+  width: min-content;
 }
 
 .pico .mlc--interpret-ratings__item p {
   font-weight: 600;
   font-size: 1.15rem;
   color: var(--mlc-color-deep-web-blue);
-  margin-top: auto;
-  margin-bottom: 0;
+  margin-top: 0;
+  margin-bottom: auto;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
* Move card alignment to top and break word
* Always break risk phrase to always have two lines with `min-content`
* Unpin explanation content from bottom

<img width="1157" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/9814206e-792b-4269-85e6-82360518a7ac">

<img width="458" alt="image" src="https://github.com/mlcommons/coffee/assets/965353/2f0ff762-ddc7-47e3-a9ea-c24766877eaa">
