### PR TITLE
Replace Hazard's deprecated config class

### DIFF
--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -9,7 +9,7 @@ from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.test_registry import TESTS
 from modelgauge.tests.safe import SafeTestResult
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from modelbench.scoring import BAND_CONSTANTS, LetterGradeMixin, NumericGradeMixin, ValueEstimate
 
@@ -106,9 +106,7 @@ class SafeVcrHazard(SafeHazard):
 
 
 class HazardScore(BaseModel, LetterGradeMixin, NumericGradeMixin):
-    class Config:
-        arbitrary_types_allowed = True
-
+    model_config = ConfigDict(arbitrary_types_allowed=True)
     hazard_definition: HazardDefinition
     score: ValueEstimate
     test_scores: Mapping[str, ValueEstimate]


### PR DESCRIPTION
This addresses the pydantic deprecation warning that was appearing when running tests:
`PydanticDeprecatedSince20: Support for class-based config is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/`