### PR TITLE
Add ability to benchmark dynamic SUT

### DIFF
--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -13,9 +13,17 @@ from datetime import datetime, timezone
 from multiprocessing import Pool
 from typing import List, Mapping, Dict
 
+import casefy
 import click
 import termcolor
 from click import echo
+from modelbench.benchmarks import (
+    BenchmarkDefinition,
+    GeneralPurposeAiChatBenchmark,
+)
+from modelbench.hazards import HazardDefinition, HazardScore, STANDARDS
+from modelbench.modelgauge_runner import ModelGaugeSut, SutDescription
+from modelbench.static_site_generator import StaticSiteGenerator, StaticContent
 from modelgauge.config import load_secrets_from_config, write_default_config
 from modelgauge.instance_factory import FactoryEntry
 from modelgauge.load_plugins import load_plugins
@@ -24,14 +32,6 @@ from modelgauge.sut_registry import SUTS
 from modelgauge.test_registry import TESTS
 from modelgauge.tests.safe import SafeTestResult
 from retry import retry
-
-from modelbench.benchmarks import (
-    BenchmarkDefinition,
-    GeneralPurposeAiChatBenchmark,
-)
-from modelbench.hazards import HazardDefinition, HazardScore, STANDARDS
-from modelbench.modelgauge_runner import ModelGaugeSut, SutDescription
-from modelbench.static_site_generator import StaticSiteGenerator, StaticContent
 
 _DEFAULT_SUTS = ModelGaugeSut
 
@@ -54,9 +54,7 @@ def cli() -> None:
 @click.option(
     "--sut",
     "-s",
-    type=click.Choice([sut.key for sut in ModelGaugeSut]),
     multiple=True,
-    default=[s.key for s in _DEFAULT_SUTS],
 )
 @click.option("--view-embed", default=False, is_flag=True, help="Render the HTML to be embedded in another view")
 @click.option("--anonymize", type=int, help="Random number seed for consistent anonymization of SUTs")
@@ -70,10 +68,29 @@ def benchmark(
     anonymize=None,
     parallel=False,
 ) -> None:
-    suts = [s for s in ModelGaugeSut if s.key in sut]
+    suts = find_suts_for_sut_argument(sut)
     benchmarks = [GeneralPurposeAiChatBenchmark()]
     benchmark_scores = score_benchmarks(benchmarks, suts, max_instances, debug, parallel)
     generate_content(benchmark_scores, output_dir, anonymize, view_embed)
+
+
+def find_suts_for_sut_argument(sut_args:List[str]):
+    if sut_args:
+        suts = []
+        default_suts_by_key = {s.key: s for s in ModelGaugeSut}
+        registered_sut_keys = set(i[0] for i in SUTS.items())
+        for sut_arg in sut_args:
+            if sut_arg in default_suts_by_key:
+                suts.append(default_suts_by_key[sut_arg])
+            elif sut_arg in registered_sut_keys:
+                    suts.append(SutDescription(sut_arg, re.sub(r'[-_]+',' ', sut_arg)))
+            else:
+                all_sut_keys = registered_sut_keys.union(set(default_suts_by_key.keys()))
+                raise click.BadParameter(f"Unknown key '{sut_arg}'. Valid options are {sorted(all_sut_keys, key=lambda x:x.lower())}", param_hint="sut")
+
+    else:
+        suts = ModelGaugeSut
+    return suts
 
 
 def score_benchmarks(benchmarks, suts, max_instances, debug, parallel=True):
@@ -207,7 +224,7 @@ def update_standards_to(file):
 
 
 def run_tests(
-    hazards: List[HazardDefinition], sut: ModelGaugeSut, items: int
+        hazards: List[HazardDefinition], sut: ModelGaugeSut, items: int
 ) -> Mapping[HazardDefinition, HazardScore]:
     secrets = load_secrets_from_config()
     result = {}
@@ -298,7 +315,7 @@ def responses(output: pathlib.Path, max_instances: int) -> None:
     test_records = defaultdict(lambda: dict())
     for sut in _DEFAULT_SUTS:
         for test_id, test_record in test_records_for_sut(
-            sut, some_convenient_tests(), "./run", max_test_items=max_instances
+                sut, some_convenient_tests(), "./run", max_test_items=max_instances
         ):
             test_records[test_id][sut.key] = test_record
     for test_id in test_records.keys():

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -74,7 +74,7 @@ def benchmark(
     generate_content(benchmark_scores, output_dir, anonymize, view_embed)
 
 
-def find_suts_for_sut_argument(sut_args:List[str]):
+def find_suts_for_sut_argument(sut_args: List[str]):
     if sut_args:
         suts = []
         default_suts_by_key = {s.key: s for s in ModelGaugeSut}
@@ -83,10 +83,13 @@ def find_suts_for_sut_argument(sut_args:List[str]):
             if sut_arg in default_suts_by_key:
                 suts.append(default_suts_by_key[sut_arg])
             elif sut_arg in registered_sut_keys:
-                    suts.append(SutDescription(sut_arg, re.sub(r'[-_]+',' ', sut_arg)))
+                suts.append(SutDescription(sut_arg, re.sub(r"[-_]+", " ", sut_arg)))
             else:
                 all_sut_keys = registered_sut_keys.union(set(default_suts_by_key.keys()))
-                raise click.BadParameter(f"Unknown key '{sut_arg}'. Valid options are {sorted(all_sut_keys, key=lambda x:x.lower())}", param_hint="sut")
+                raise click.BadParameter(
+                    f"Unknown key '{sut_arg}'. Valid options are {sorted(all_sut_keys, key=lambda x:x.lower())}",
+                    param_hint="sut",
+                )
 
     else:
         suts = ModelGaugeSut
@@ -224,7 +227,7 @@ def update_standards_to(file):
 
 
 def run_tests(
-        hazards: List[HazardDefinition], sut: ModelGaugeSut, items: int
+    hazards: List[HazardDefinition], sut: ModelGaugeSut, items: int
 ) -> Mapping[HazardDefinition, HazardScore]:
     secrets = load_secrets_from_config()
     result = {}
@@ -315,7 +318,7 @@ def responses(output: pathlib.Path, max_instances: int) -> None:
     test_records = defaultdict(lambda: dict())
     for sut in _DEFAULT_SUTS:
         for test_id, test_record in test_records_for_sut(
-                sut, some_convenient_tests(), "./run", max_test_items=max_instances
+            sut, some_convenient_tests(), "./run", max_test_items=max_instances
         ):
             test_records[test_id][sut.key] = test_record
     for test_id in test_records.keys():

--- a/src/modelbench/static_site_generator.py
+++ b/src/modelbench/static_site_generator.py
@@ -121,7 +121,12 @@ class StaticSiteGenerator:
 
     @content.register
     def content_sut(self, item: SutDescription, key: str):
-        return self._content[item.key][key]
+        if item.key in self._content:
+            return self._content[item.key][key]
+        elif key=="name":
+                return item.display_name
+        else:
+            raise ValueError(f"Unknown SUT key for {item} and {key}")
 
     @content.register
     def content_test(self, item: BaseTest, key: str):

--- a/src/modelbench/static_site_generator.py
+++ b/src/modelbench/static_site_generator.py
@@ -123,8 +123,8 @@ class StaticSiteGenerator:
     def content_sut(self, item: SutDescription, key: str):
         if item.key in self._content:
             return self._content[item.key][key]
-        elif key=="name":
-                return item.display_name
+        elif key == "name":
+            return item.display_name
         else:
             raise ValueError(f"Unknown SUT key for {item} and {key}")
 

--- a/src/modelbench/templates/content/suts.toml
+++ b/src/modelbench/templates/content/suts.toml
@@ -1,59 +1,44 @@
 [alpaca-7b]
 name="Alpaca, 7B parameters"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [chronos-hermes-13b]
 name="Chronos Hermes (13B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [deepseek-67b]
 name="DeepSeek LLM Chat (67B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [gemma-7b]
 name="Gemma Instruct (7B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [llama-2-7b-chat]
 name = "Meta Llama 2, 7b parameters"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [llama-2-13b-chat]
 name = "Meta Llama 2, 13b parameters"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [llama-2-70b-chat]
 name = "Meta Llama 2, 70b parameters"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [mistral-7b]
 name = "Mistral 7B Instruct v0.2"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [mixtral-8x-7b]
 name = "Mixtral-8x7B Instruct v0.1 (46.7B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [qwen-72b]
 name = "Qwen 1.5 (72B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [openchat-3_5]
 name = "OpenChat 3.5 (7B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [stripedhyena-nous-7b]
 name = "Together StripedHyena Nous 7B"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [wizardlm-13b]
 name = "WizardLM v1.2 (13B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [vicuna-13b]
 name = "LM Sys Vicuna v1.5 (13B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."
 
 [yi-34b]
 name = "01-ai Yi Chat (34B)"
-tagline = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore quis nostrud exercitation ullamcaz."

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,9 +3,13 @@ import pathlib
 import unittest.mock
 from unittest.mock import patch
 
+import click
+import pytest
+
+from modelbench.modelgauge_runner import ModelGaugeSut
 from modelbench.scoring import ValueEstimate
 from modelbench.hazards import HazardScore, SafeCbrHazard
-from modelbench.run import update_standards_to
+from modelbench.run import update_standards_to, find_suts_for_sut_argument
 
 
 @patch("modelbench.run.run_tests")
@@ -24,3 +28,18 @@ def test_update_standards(fake_run, tmp_path, fake_secrets):
             j = json.load(f)
             assert j["standards"]["reference_standards"][bias_hazard.key()] == 0.123456
             assert j["standards"]["reference_suts"][0]["id"] == "vicuna-13b"
+
+def test_find_suts():
+    # nothing gets everything
+    assert find_suts_for_sut_argument([]) == ModelGaugeSut
+
+    # key from modelbench gets a known SUT
+    assert find_suts_for_sut_argument(['alpaca-7b']) == [ModelGaugeSut.ALPACA_7B]
+
+    # key from modelgauge gets a dynamic one
+    dynamic_qwen = find_suts_for_sut_argument(["Qwen1.5-72B-Chat"])[0]
+    assert dynamic_qwen.key == "Qwen1.5-72B-Chat"
+    assert dynamic_qwen.display_name == "Qwen1.5 72B Chat"
+
+    with pytest.raises(click.BadParameter):
+        find_suts_for_sut_argument(["something nonexistent"])

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -29,12 +29,13 @@ def test_update_standards(fake_run, tmp_path, fake_secrets):
             assert j["standards"]["reference_standards"][bias_hazard.key()] == 0.123456
             assert j["standards"]["reference_suts"][0]["id"] == "vicuna-13b"
 
+
 def test_find_suts():
     # nothing gets everything
     assert find_suts_for_sut_argument([]) == ModelGaugeSut
 
     # key from modelbench gets a known SUT
-    assert find_suts_for_sut_argument(['alpaca-7b']) == [ModelGaugeSut.ALPACA_7B]
+    assert find_suts_for_sut_argument(["alpaca-7b"]) == [ModelGaugeSut.ALPACA_7B]
 
     # key from modelgauge gets a dynamic one
     dynamic_qwen = find_suts_for_sut_argument(["Qwen1.5-72B-Chat"])[0]

--- a/tests/test_static_site_generator.py
+++ b/tests/test_static_site_generator.py
@@ -209,10 +209,12 @@ class TestObjectContentKeysExist:
         assert ssg.content(test, "display_name") == "not_a_real_uid"
         assert ssg.content(test, "not_a_real_key") == ""
 
+
 def test_sut_content_defaults():
     ssg = StaticSiteGenerator()
     a_dynamic_sut = SutDescription("fake", "Fake SUT")
     assert ssg.content(a_dynamic_sut, "name") == "Fake SUT"
+
 
 class TestHazardScorePositions:
     @pytest.fixture

--- a/tests/test_static_site_generator.py
+++ b/tests/test_static_site_generator.py
@@ -9,7 +9,7 @@ from modelgauge.tests.bbq import BBQ
 
 import pytest
 
-from modelbench.modelgauge_runner import ModelGaugeSut
+from modelbench.modelgauge_runner import ModelGaugeSut, SutDescription
 from modelbench.benchmarks import (
     BenchmarkDefinition,
     GeneralPurposeAiChatBenchmark,
@@ -209,6 +209,10 @@ class TestObjectContentKeysExist:
         assert ssg.content(test, "display_name") == "not_a_real_uid"
         assert ssg.content(test, "not_a_real_key") == ""
 
+def test_sut_content_defaults():
+    ssg = StaticSiteGenerator()
+    a_dynamic_sut = SutDescription("fake", "Fake SUT")
+    assert ssg.content(a_dynamic_sut, "name") == "Fake SUT"
 
 class TestHazardScorePositions:
     @pytest.fixture


### PR DESCRIPTION
Now users should be able to run a benchmark for any registered ModelGauge SUT via the `-s` option. Also add some very basic defaulting for SUT static content so that reports will render.