### PR TITLE
Add --sut flag to grid and responses commands

### DIFF
--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -274,7 +274,12 @@ def some_convenient_tests():
 @cli.command(help="produce a CSV grid of test scores for some convenient tests and SUTs")
 @click.option("--output", type=click.File("w"))
 @click.option("--max-instances", "-m", type=int, default=100)
-def grid(output, max_instances: int) -> None:
+@click.option(
+    "--sut",
+    "-s",
+    multiple=True,
+)
+def grid(output, max_instances: int, sut: List[str]) -> None:
     if not output:
         output = sys.stdout
 
@@ -283,7 +288,8 @@ def grid(output, max_instances: int) -> None:
 
     out = csv.writer(output)
     out.writerow(["SUT"] + list(tests.keys()))
-    for sut in _DEFAULT_SUTS:
+    suts = find_suts_for_sut_argument(sut)
+    for sut in suts:
         output_row = [sut.key]
         for test_id, test_record in test_records_for_sut(sut, tests, "./run", max_test_items=max_instances):
             result = test_record.result.to_instance(SafeTestResult)
@@ -306,7 +312,12 @@ def grid(output, max_instances: int) -> None:
 @cli.command(help="produce CSVs of the responses for the grid's tests and suts")
 @click.argument("output", type=click.Path(file_okay=False, path_type=pathlib.Path))
 @click.option("--max-instances", "-m", type=int, default=100)
-def responses(output: pathlib.Path, max_instances: int) -> None:
+@click.option(
+    "--sut",
+    "-s",
+    multiple=True,
+)
+def responses(output: pathlib.Path, max_instances: int, sut: List[str]) -> None:
     def clean_text(str):
         return re.sub(r"\s+", " ", str.replace("\n", " ")).strip()
 
@@ -316,7 +327,8 @@ def responses(output: pathlib.Path, max_instances: int) -> None:
     if not output.exists():
         output.mkdir(parents=True)
     test_records = defaultdict(lambda: dict())
-    for sut in _DEFAULT_SUTS:
+    suts = find_suts_for_sut_argument(sut)
+    for sut in suts:
         for test_id, test_record in test_records_for_sut(
             sut, some_convenient_tests(), "./run", max_test_items=max_instances
         ):


### PR DESCRIPTION
This allows running the `grid` and `responses` commands on user-specified SUTs.

Addresses #237