### PR TITLE
Machine-readable progress updates

### DIFF
--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -165,7 +165,7 @@ def score_benchmarks(benchmarks, suts, max_instances, machine_reports=False, par
 
 def score_a_sut(benchmarks, max_instances, secrets, progress, sut):
     sut_scores = []
-    logging.info(f'Examining system "{sut.display_name}"')
+    logging.info(termcolor.colored(f'Examining system "{sut.display_name}"', "green"))
     sut_instance = sut.instance(secrets)
     for benchmark_definition in benchmarks:
         logging.info(termcolor.colored(f'  Starting run for benchmark "{benchmark_definition.name()}"', "green"))

--- a/src/modelbench/static_site_generator.py
+++ b/src/modelbench/static_site_generator.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import shutil
 from collections import defaultdict
@@ -222,7 +223,7 @@ class StaticSiteGenerator:
 
     def _generate_test_report_pages(self, benchmark_scores: list[BenchmarkScore], output_dir: pathlib.Path) -> None:
         for benchmark_score in benchmark_scores:
-            print(benchmark_score.sut.key)
+            logging.info(benchmark_score.sut.key)
             self._write_file(
                 output=output_dir
                 / f"{benchmark_score.sut.key}_{benchmark_score.benchmark_definition.path_name()}_report.html",

--- a/src/modelbench/utilities.py
+++ b/src/modelbench/utilities.py
@@ -22,6 +22,10 @@ class ProgressTracker:
         self.print_updates = print_updates
         self.lock = lock
 
+    @property
+    def progress(self):
+        return self.complete_count.value / self.total
+
     def increment(self):
         if self.lock:
             with self.lock:
@@ -32,4 +36,4 @@ class ProgressTracker:
     def _increment(self):
         self.complete_count.value += 1.0
         if self.print_updates:
-            print({"progress": self.complete_count.value / self.total})
+            print({"progress": self.progress})

--- a/src/modelbench/utilities.py
+++ b/src/modelbench/utilities.py
@@ -14,10 +14,7 @@ def group_by_key(items: Sequence, key=Callable) -> Mapping:
 
 class ProgressTracker:
     def __init__(self, total, print_updates=False, shared_count=None, lock=None):
-        if shared_count is None:
-            self.complete_count = Value(ctypes.c_double, 0.0)
-        else:
-            self.complete_count = shared_count
+        self.complete_count = shared_count or Value(ctypes.c_double, 0.0)
         self.total = total
         self.print_updates = print_updates
         self.lock = lock

--- a/src/modelbench/utilities.py
+++ b/src/modelbench/utilities.py
@@ -8,3 +8,15 @@ def group_by_key(items: Sequence, key=Callable) -> Mapping:
     for item in items:
         groups[key(item)].append(item)
     return groups
+
+
+class ProgressTracker:
+    def __init__(self, total, print_updates=False):
+        self.complete_count = 0.0
+        self.total = total
+        self.print_updates = print_updates
+
+    def increment(self):
+        self.complete_count += 1.0
+        if self.print_updates:
+            print({"progress": self.complete_count / self.total})

--- a/src/modelbench/utilities.py
+++ b/src/modelbench/utilities.py
@@ -14,6 +14,7 @@ def group_by_key(items: Sequence, key=Callable) -> Mapping:
 
 class ProgressTracker:
     def __init__(self, total, print_updates=False, shared_count=None, lock=None):
+        assert total > 0, f"Total must be a positive number, got {total}."
         self.complete_count = shared_count or Value(ctypes.c_double, 0.0)
         self.total = total
         self.print_updates = print_updates

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,4 +1,5 @@
 import ctypes
+import pytest
 from dataclasses import dataclass
 from itertools import groupby
 from multiprocessing import Manager, Process
@@ -100,3 +101,10 @@ def test_progress_tracker_concurrency(capfd):
         # Machine-readable progress updates are in correct order.
         captured = capfd.readouterr()
         assert captured.out == "{'progress': 0.25}\n{'progress': 0.5}\n{'progress': 0.75}\n{'progress': 1.0}\n"
+
+
+def test_progress_tracker_invalid_total():
+    with pytest.raises(AssertionError) as err_info:
+        progress = ProgressTracker(total=0)
+
+        assert str(err_info.value) == "Total must be a positive number, got 0."

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,7 +1,9 @@
+import ctypes
 from dataclasses import dataclass
 from itertools import groupby
+from multiprocessing import Manager, Process
 
-from modelbench.utilities import group_by_key
+from modelbench.utilities import ProgressTracker, group_by_key
 
 
 @dataclass
@@ -56,3 +58,45 @@ def test_group_by_key():
         (1, [group_1_item_1, group_1_item_2]),
         (2, [group_2_item_1, group_2_item_2]),
     ]
+
+
+def test_progress_tracker(capsys):
+    progress = ProgressTracker(total=4, print_updates=True)
+
+    progress.increment()
+    progress.increment()
+
+    assert progress.complete_count.value == 2
+    assert progress.progress == 0.5
+
+    captured = capsys.readouterr()
+    assert captured.out == "{'progress': 0.25}\n{'progress': 0.5}\n"
+
+
+def worker(progress, num_updates):
+    for _ in range(num_updates):
+        progress.increment()
+
+
+def test_progress_tracker_concurrency(capfd):
+    with Manager() as manager:
+        shared_count = manager.Value(ctypes.c_double, 0.0)
+        lock = manager.Lock()
+        progress = ProgressTracker(total=4, print_updates=True, shared_count=shared_count, lock=lock)
+        processes = [
+            Process(target=worker, args=(progress, 1)),
+            Process(target=worker, args=(progress, 1)),
+            Process(target=worker, args=(progress, 2)),
+        ]
+
+        for p in processes:
+            p.start()
+        for p in processes:
+            p.join()
+
+        assert progress.complete_count.value == 4
+        assert progress.progress == 1.0
+
+        # Machine-readable progress updates are in correct order.
+        captured = capfd.readouterr()
+        assert captured.out == "{'progress': 0.25}\n{'progress': 0.5}\n{'progress': 0.75}\n{'progress': 1.0}\n"


### PR DESCRIPTION
This adds a progress tracker to benchmark runs, which can be used to print out machine-readable progress updates (e.g. for modellab) by setting the `--machine-reports` flag. If this flag is set, none of the regular print statements will be logged either, so as to not confuse the machine. To accomplish that, I had to replace the `click.echo` statements with logging statements.

Right now the progress tracker just prints a dictionary containing % complete. But we can easily add more information to it in the future if needed.

Progress can only be measured at the test-level at the moment. If we decide that this generally the direction we want to go in for progress reporting, then I can go ahead and update modelgauge so that progress can be calculated at the test-item level.

In addition to higher-level feedback, I’d love to hear input on some annoyingly small stuff:
- Is there a better place for `ProgressTracker` other than utilities? It feels weird putting it in it’s own file since it’s such a small class.
- Is the param name `machine-reports` an adequate descriptor

:)