### PR TITLE
Always print progress bar

### DIFF
--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -181,7 +181,7 @@ def score_a_sut(benchmarks, max_instances, secrets, progress, debug, sut):
                     sut=sut_instance,
                     data_dir="./run",
                     max_test_items=items,
-                    disable_progress_bar=progress.print_updates,   # Proxy for machine-readable logging.
+                    disable_progress_bar=progress.print_updates,  # Proxy for machine-readable logging.
                 )
                 progress.increment()
 

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -60,7 +60,7 @@ local_plugin_dir_option = click.option(
 @local_plugin_dir_option
 def cli() -> None:
     write_default_config()
-    load_plugins()
+    load_plugins(disable_progress_bar=True)
     print()
     print(StaticContent()["general"]["provisional_disclaimer"])
     print()

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -186,7 +186,7 @@ def score_a_sut(benchmarks, max_instances, secrets, progress, sut):
                     sut=sut_instance,
                     data_dir="./run",
                     max_test_items=items,
-                    disable_progress_bar=False,
+                    disable_progress_bar=progress.print_updates,   # Proxy for machine-readable logging.
                 )
                 progress.increment()
 

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -186,7 +186,7 @@ def score_a_sut(benchmarks, max_instances, secrets, progress, sut):
                     sut=sut_instance,
                     data_dir="./run",
                     max_test_items=items,
-                    disable_progress_bar=progress.print_updates,  # Proxy for machine-readable logging.
+                    disable_progress_bar=False,
                 )
                 progress.increment()
 

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -3,7 +3,6 @@ import ctypes
 import functools
 import itertools
 import json
-import logging
 import os
 import pathlib
 import pkgutil
@@ -104,14 +103,10 @@ def benchmark(
     anonymize=None,
     parallel=False,
 ) -> None:
-    # Set up logging. If --machine-reports is set, only print errors to stdout.
-    logging_level = logging.DEBUG if debug else logging.ERROR if machine_reports else logging.INFO
-    logging.basicConfig(format="%(message)s", level=logging_level)
-
     start_time = datetime.now(timezone.utc)
     suts = find_suts_for_sut_argument(sut_uids)
     benchmark = BenchmarkDefinition.find_by_name(benchmark_name)
-    benchmark_scores = score_benchmarks([benchmark], suts, max_instances, machine_reports, parallel)
+    benchmark_scores = score_benchmarks([benchmark], suts, max_instances, machine_reports, debug, parallel)
     generate_content(benchmark_scores, output_dir, anonymize, view_embed, custom_branding)
     json_path = output_dir / f"benchmark_record-{benchmark.uid}.json"
     dump_json(json_path, start_time, benchmark, benchmark_scores)
@@ -139,7 +134,7 @@ def find_suts_for_sut_argument(sut_args: List[str]):
     return suts
 
 
-def score_benchmarks(benchmarks, suts, max_instances, machine_reports=False, parallel=True):
+def score_benchmarks(benchmarks, suts, max_instances, machine_reports=False, debug=False, parallel=True):
     secrets = load_secrets_from_config()
 
     # Count total number of tests * SUTs to run.
@@ -154,7 +149,7 @@ def score_benchmarks(benchmarks, suts, max_instances, machine_reports=False, par
             shared_count = manager.Value(ctypes.c_double, 0.0)
             lock = manager.Lock()
             progress = ProgressTracker(total, machine_reports, shared_count, lock)
-            f = functools.partial(score_a_sut, benchmarks, max_instances, secrets, progress)
+            f = functools.partial(score_a_sut, benchmarks, max_instances, secrets, progress, debug)
             with Pool(len(suts)) as p:
                 results = p.map(f, suts)
                 p.close()
@@ -164,20 +159,20 @@ def score_benchmarks(benchmarks, suts, max_instances, machine_reports=False, par
         progress = ProgressTracker(total, machine_reports)
         benchmark_scores = []
         for sut in suts:
-            sut_scores = score_a_sut(benchmarks, max_instances, secrets, progress, sut)
+            sut_scores = score_a_sut(benchmarks, max_instances, secrets, progress, debug, sut)
             benchmark_scores.extend(sut_scores)
         return benchmark_scores
 
 
-def score_a_sut(benchmarks, max_instances, secrets, progress, sut):
+def score_a_sut(benchmarks, max_instances, secrets, progress, debug, sut):
     sut_scores = []
-    logging.info(termcolor.colored(f'Examining system "{sut.key}"', "green"))
+    echo(termcolor.colored(f'Examining system "{sut.key}"', "green"))
     sut_instance = sut.instance(secrets)
     for benchmark_definition in benchmarks:
-        logging.info(termcolor.colored(f'  Starting run for benchmark "{benchmark_definition.name()}"', "green"))
+        echo(termcolor.colored(f'  Starting run for benchmark "{benchmark_definition.name()}"', "green"))
         hazard_scores = []
         for hazard in benchmark_definition.hazards():
-            logging.info(termcolor.colored(f'    Examining hazard "{hazard.name()}"', "green"))
+            echo(termcolor.colored(f'    Examining hazard "{hazard.name()}"', "green"))
             results = {}
             for test in hazard.tests(secrets=secrets):
                 items = max_instances
@@ -191,9 +186,12 @@ def score_a_sut(benchmarks, max_instances, secrets, progress, sut):
                 progress.increment()
 
             score = hazard.score(results)
-            logging.debug(
-                termcolor.colored(f"    For hazard {hazard.name()}, {sut.key} scores {score.score.estimate}", "green")
-            )
+            if debug:
+                echo(
+                    termcolor.colored(
+                        f"    For hazard {hazard.name()}, {sut.key} scores {score.score.estimate}", "green"
+                    )
+                )
             hazard_scores.append(score)
         benchmark_end_time = datetime.now(timezone.utc)
         sut_scores.append(benchmark_definition.score(sut, hazard_scores, benchmark_end_time))
@@ -221,9 +219,9 @@ def generate_content(benchmark_scores, output_dir, anonymize, view_embed, custom
 
             bs.sut = FakeSut(key, name)
             static_site_generator._content[key] = {"name": name, "tagline": "A well-known model."}
-    logging.info(termcolor.colored(f"\nBenchmarking complete, rendering reports...", "green"))
+    echo(termcolor.colored(f"\nBenchmarking complete, rendering reports...", "green"))
     static_site_generator.generate(benchmark_scores, output_dir)
-    logging.info(termcolor.colored(f"\nReports complete, open {output_dir}/index.html", "green"))
+    echo(termcolor.colored(f"\nReports complete, open {output_dir}/index.html", "green"))
 
 
 @cli.command(help="Show and optionally update the benchmark three-star standard")

--- a/src/modelbench/static_site_generator.py
+++ b/src/modelbench/static_site_generator.py
@@ -1,4 +1,3 @@
-import logging
 import pathlib
 import shutil
 from collections import defaultdict
@@ -221,7 +220,7 @@ class StaticSiteGenerator:
 
     def _generate_test_report_pages(self, benchmark_scores: list[BenchmarkScore], output_dir: pathlib.Path) -> None:
         for benchmark_score in benchmark_scores:
-            logging.info(benchmark_score.sut.key)
+            print(benchmark_score.sut.key)
             self._write_file(
                 output=output_dir
                 / f"{benchmark_score.sut.key}_{benchmark_score.benchmark_definition.path_name()}_report.html",

--- a/src/modelbench/utilities.py
+++ b/src/modelbench/utilities.py
@@ -19,10 +19,16 @@ class ProgressTracker:
         self.total = total
         self.print_updates = print_updates
         self.lock = lock
+        if self.print_updates:
+            # Print initial progress json.
+            self.print_progress_json()
 
     @property
     def progress(self):
         return self.complete_count.value / self.total
+
+    def print_progress_json(self):
+        print({"progress": self.progress})
 
     def increment(self):
         if self.lock:
@@ -34,4 +40,4 @@ class ProgressTracker:
     def _increment(self):
         self.complete_count.value += 1.0
         if self.print_updates:
-            print({"progress": self.progress})
+            self.print_progress_json()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -71,7 +71,7 @@ def test_progress_tracker(capsys):
     assert progress.progress == 0.5
 
     captured = capsys.readouterr()
-    assert captured.out == "{'progress': 0.25}\n{'progress': 0.5}\n"
+    assert captured.out == "{'progress': 0.25}\n{'progress': 0.25}\n{'progress': 0.5}\n"
 
 
 def worker(progress, num_updates):
@@ -100,7 +100,7 @@ def test_progress_tracker_concurrency(capfd):
 
         # Machine-readable progress updates are in correct order.
         captured = capfd.readouterr()
-        assert captured.out == "{'progress': 0.25}\n{'progress': 0.5}\n{'progress': 0.75}\n{'progress': 1.0}\n"
+        assert captured.out == "{'progress': 0.0}\n{'progress': 0.25}\n{'progress': 0.5}\n{'progress': 0.75}\n{'progress': 1.0}\n"
 
 
 def test_progress_tracker_invalid_total():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -100,7 +100,10 @@ def test_progress_tracker_concurrency(capfd):
 
         # Machine-readable progress updates are in correct order.
         captured = capfd.readouterr()
-        assert captured.out == '{"progress": 0.0}\n{"progress": 0.25}\n{"progress": 0.5}\n{"progress": 0.75}\n{"progress": 1.0}\n'
+        assert (
+            captured.out
+            == '{"progress": 0.0}\n{"progress": 0.25}\n{"progress": 0.5}\n{"progress": 0.75}\n{"progress": 1.0}\n'
+        )
 
 
 def test_progress_tracker_invalid_total():


### PR DESCRIPTION
Output with `--machine-reports --parallel true` flags from before:
![Screenshot 2024-08-27 at 12 23 27 PM](https://github.com/user-attachments/assets/55870fd4-37ef-4b34-9975-9407cfb6adba)

After this change:
![Screenshot 2024-08-27 at 12 24 20 PM](https://github.com/user-attachments/assets/38ca9891-6934-425e-8746-ceddf2662ace)

Let me know if this is what we want.