### PR TITLE
output dict in json format for consumption

### DIFF
--- a/src/modelbench/utilities.py
+++ b/src/modelbench/utilities.py
@@ -1,4 +1,5 @@
 import ctypes
+import json
 from collections import defaultdict
 from multiprocessing import Value
 from typing import Callable, Mapping, Sequence
@@ -33,5 +34,6 @@ class ProgressTracker:
 
     def _increment(self):
         self.complete_count.value += 1.0
+        # using json.dumps instead of just print so the output is consumable as json
         if self.print_updates:
-            print({"progress": self.progress})
+            print(json.dumps({"progress": self.progress}))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -71,7 +71,7 @@ def test_progress_tracker(capsys):
     assert progress.progress == 0.5
 
     captured = capsys.readouterr()
-    assert captured.out == "{'progress': 0.25}\n{'progress': 0.5}\n"
+    assert captured.out == '{"progress": 0.25}\n{"progress": 0.5}\n'
 
 
 def worker(progress, num_updates):
@@ -100,7 +100,7 @@ def test_progress_tracker_concurrency(capfd):
 
         # Machine-readable progress updates are in correct order.
         captured = capfd.readouterr()
-        assert captured.out == "{'progress': 0.25}\n{'progress': 0.5}\n{'progress': 0.75}\n{'progress': 1.0}\n"
+        assert captured.out == '{"progress": 0.25}\n{"progress": 0.5}\n{"progress": 0.75}\n{"progress": 1.0}\n'
 
 
 def test_progress_tracker_invalid_total():


### PR DESCRIPTION
The progress tracker optionally sends its progress as a dict to stdout.  Sugar consumes that and does string manipulation to change the quotes to make it parseable as json. This ensures the dict is printed out in a format that is json parseable as-is, without string manipulations. 

Addresses [this comment](https://github.com/mlcommons/sugar/pull/32/files#r1733406407)