### PR TITLE
Put code info in run record

### DIFF
--- a/src/modelbench/record.py
+++ b/src/modelbench/record.py
@@ -81,6 +81,7 @@ def dump_json(
 ):
     with open(json_path, "w") as f:
         output = {
+            "_metadata": benchmark_metadata(),
             "benchmark": (benchmark),
             "run_uid": f"run-{benchmark.uid}-{start_time.strftime('%Y%m%d-%H%M%S')}",
             "scores": (benchmark_scores),

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -184,6 +184,7 @@ def test_dump_json(benchmark_score, tmp_path):
     )
     with open(json_path) as f:
         j = json.load(f)
+    assert "_metadata" in j
     assert j["benchmark"]["uid"] == benchmark_score.benchmark_definition.uid
     assert j["run_uid"] == "run-" + benchmark_score.benchmark_definition.uid + "-20231114-221320"
     assert "grades" in j["content"]


### PR DESCRIPTION
This makes the benchmark record look like this: [benchmark_record-general_purpose_ai_chat_benchmark-1.0.json](https://github.com/user-attachments/files/17031659/benchmark_record-general_purpose_ai_chat_benchmark-1.0.json)

It looks like this:
```
    "_metadata": {
        "format_version": 1,
        "run": {
            "user": "william",
            "timestamp": "2024-09-17 12:55:36 UTC",
            "platform": "Linux-6.9.3-76060903-generic-x86_64-with-glibc2.35",
            "system": "Linux 6.9.3-76060903-generic #202405300957~1721174657~22.04~abb7c06 SMP PREEMPT_DYNAMIC Wed J",
            "node": "loewen",
            "python": "3.10.12"
        },
        "code": {
            "source": {
                "git_version": "git version 2.34.1",
                "origin": "git@github.com:mlcommons/modelbench.git",
                "code_version": "v0.5.1-43-gc9749253",
                "changed_files": [
                    "M src/modelbench/record.py",
                    "M tests/test_record.py"
                ]
            },
            "libraries": {
                "aiohappyeyeballs": "2.4.0",
                "aiohttp": "3.10.5",
[...]
```