### PR TITLE
Call the HuggingFace token a token consistently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ run/
 __pycache__/
 web/
 secrets/
+.vscode/
+config/secrets.toml

--- a/plugins/huggingface/modelgauge/suts/huggingface_inference.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_inference.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from huggingface_hub import ( # type: ignore
+from huggingface_hub import (  # type: ignore
     ChatCompletionOutput,
     get_inference_endpoint,
     InferenceClient,

--- a/plugins/huggingface/modelgauge/suts/huggingface_inference.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_inference.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from huggingface_hub import (
+from huggingface_hub import ( # type: ignore
     ChatCompletionOutput,
     get_inference_endpoint,
     InferenceClient,

--- a/plugins/huggingface/modelgauge/suts/huggingface_inference.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_inference.py
@@ -1,19 +1,21 @@
-from huggingface_hub import (  # type: ignore
-    ChatCompletionOutput,
-    InferenceClient,
-    InferenceEndpointStatus,
-    get_inference_endpoint,
-)
-from huggingface_hub.utils import HfHubHTTPError  # type: ignore
-from pydantic import BaseModel
 from typing import List, Optional
 
+from huggingface_hub import (
+    ChatCompletionOutput,
+    get_inference_endpoint,
+    InferenceClient,
+    InferenceEndpointStatus,
+)
+from huggingface_hub.utils import HfHubHTTPError  # type: ignore
+
+from modelgauge.auth.huggingface_inference_token import HuggingFaceInferenceToken
 from modelgauge.prompt import TextPrompt
-from modelgauge.secret_values import InjectSecret, RequiredSecret, SecretDescription
+from modelgauge.secret_values import InjectSecret
 from modelgauge.sut import PromptResponseSUT, SUTCompletion, SUTResponse
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.sut_decorator import modelgauge_sut
 from modelgauge.sut_registry import SUTS
+from pydantic import BaseModel
 
 
 class ChatMessage(BaseModel):
@@ -26,16 +28,6 @@ class HuggingFaceInferenceChatRequest(BaseModel):
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = None
-
-
-class HuggingFaceInferenceToken(RequiredSecret):
-    @classmethod
-    def description(cls) -> SecretDescription:
-        return SecretDescription(
-            scope="hugging_face",
-            key="token",
-            instructions="You can create tokens at https://huggingface.co/settings/tokens.",
-        )
 
 
 @modelgauge_sut(capabilities=[AcceptsTextPrompt])

--- a/plugins/huggingface/tests/test_huggingface_inference.py
+++ b/plugins/huggingface/tests/test_huggingface_inference.py
@@ -1,17 +1,18 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from huggingface_hub import InferenceEndpointStatus  # type: ignore
 from huggingface_hub.utils import HfHubHTTPError  # type: ignore
-from pydantic import BaseModel
-from unittest.mock import Mock, patch
 
+from modelgauge.auth.huggingface_inference_token import HuggingFaceInferenceToken
 from modelgauge.prompt import SUTOptions, TextPrompt
 from modelgauge.sut import SUTCompletion, SUTResponse
 from modelgauge.suts.huggingface_inference import (
     ChatMessage,
     HuggingFaceInferenceChatRequest,
     HuggingFaceInferenceSUT,
-    HuggingFaceInferenceToken,
 )
+from pydantic import BaseModel
 
 
 @pytest.fixture

--- a/src/modelgauge/auth/huggingface_inference_token.py
+++ b/src/modelgauge/auth/huggingface_inference_token.py
@@ -1,0 +1,11 @@
+from modelgauge.secret_values import RequiredSecret, SecretDescription
+
+
+class HuggingFaceInferenceToken(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="hugging_face",
+            key="token",
+            instructions="You can create tokens at https://huggingface.co/settings/tokens.",
+        )

--- a/src/modelgauge/auth/together_key.py
+++ b/src/modelgauge/auth/together_key.py
@@ -1,0 +1,11 @@
+from modelgauge.secret_values import RequiredSecret, SecretDescription
+
+
+class TogetherApiKey(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="together",
+            key="api_key",
+            instructions="See https://api.together.xyz/settings/api-keys",
+        )

--- a/src/modelgauge/auth/vllm_key.py
+++ b/src/modelgauge/auth/vllm_key.py
@@ -1,0 +1,11 @@
+from modelgauge.secret_values import RequiredSecret, SecretDescription
+
+
+class VllmApiKey(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="vllm",
+            key="api_key",
+            instructions="Contact MLCommons admin for access.",
+        )

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -4,35 +4,15 @@ import requests  # type:ignore
 from pydantic import BaseModel, Field
 from requests.adapters import HTTPAdapter, Retry  # type:ignore
 
+from modelgauge.auth.together_key import TogetherApiKey
 from modelgauge.general import APIException
 from modelgauge.prompt import ChatPrompt, ChatRole, SUTOptions, TextPrompt
 from modelgauge.prompt_formatting import format_chat
-from modelgauge.secret_values import InjectSecret, RequiredSecret, SecretDescription
-from modelgauge.sut import (
-    PromptResponseSUT,
-    SUTCompletion,
-    SUTResponse,
-    TokenProbability,
-    TopTokens,
-)
-from modelgauge.sut_capabilities import (
-    AcceptsChatPrompt,
-    AcceptsTextPrompt,
-    ProducesPerTokenLogProbabilities,
-)
+from modelgauge.secret_values import InjectSecret
+from modelgauge.sut import PromptResponseSUT, SUTCompletion, SUTResponse, TokenProbability, TopTokens
+from modelgauge.sut_capabilities import AcceptsChatPrompt, AcceptsTextPrompt, ProducesPerTokenLogProbabilities
 from modelgauge.sut_decorator import modelgauge_sut
 from modelgauge.sut_registry import SUTS
-
-
-class TogetherApiKey(RequiredSecret):
-    @classmethod
-    def description(cls) -> SecretDescription:
-        return SecretDescription(
-            scope="together",
-            key="api_key",
-            instructions="See https://api.together.xyz/settings/api-keys",
-        )
-
 
 _SYSTEM_ROLE = "system"
 _USER_ROLE = "user"

--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -147,7 +147,7 @@ class SafeTestVersion1(PromptResponseTest):
         LG2_LORA_CONFIG.base_url = self.vllm_endpoint_url
 
     def _configure_huggingface_annotators(self, huggingface_inference_token: HuggingFaceInferenceToken):
-        WILDGUARD_ANNOTATOR_CONFIG.api_key = huggingface_inference_token.value
+        WILDGUARD_ANNOTATOR_CONFIG.token = huggingface_inference_token.value
         assert WILDGUARD_ANNOTATOR_CONFIG.is_valid(), "HuggingFace configuration is missing a token or endpoint URL."
 
     def _configure_together_annotators(self, together_api_key: TogetherApiKey):

--- a/tests/modelgauge_tests/test_safe.py
+++ b/tests/modelgauge_tests/test_safe.py
@@ -1,12 +1,10 @@
 import pytest
 
+from modelgauge.auth.huggingface_inference_token import HuggingFaceInferenceToken
+from modelgauge.auth.together_key import TogetherApiKey
+from modelgauge.auth.vllm_key import VllmApiKey
 from modelgauge.prompt import TextPrompt
-from modelgauge.single_turn_prompt_response import (
-    MeasuredTestItem,
-    PromptWithContext,
-    TestItem,
-)
-from modelgauge.suts.together_client import TogetherApiKey
+from modelgauge.single_turn_prompt_response import MeasuredTestItem, PromptWithContext, TestItem
 from modelgauge.tests.safe import (
     FOLDER_NAME,
     PersonaResult,
@@ -15,18 +13,14 @@ from modelgauge.tests.safe import (
     SafeTestItemContext,
     SafeTestResult,
 )
-from modelgauge.tests.safe_v1 import (
-    HuggingFaceKey,
-    Locale,
-    SafeTestVersion1,
-    SafePersonasVersion1,
-    VllmApiKey,
-)
+from modelgauge.tests.safe_v1 import Locale, SafePersonasVersion1, SafeTestVersion1
+
 from modelgauge_tests.fake_dependency_helper import FakeDependencyHelper, make_csv
+
 
 FAKE_TOGETHER_KEY = TogetherApiKey("some-value")
 FAKE_VLLM_KEY = VllmApiKey("some-value")
-FAKE_HF_KEY = HuggingFaceKey("some-value")
+FAKE_HF_TOKEN = HuggingFaceInferenceToken("some-value")
 
 
 def _init_safe_test(hazard, persona_types):
@@ -46,7 +40,7 @@ def _init_safe_test_v1_private(hazard, persona_types):
         persona_types,
         FAKE_TOGETHER_KEY,
         FAKE_VLLM_KEY,
-        FAKE_HF_KEY,
+        FAKE_HF_TOKEN,
         use_private_annotators=True,
     )
 


### PR DESCRIPTION
The HuggingFace token was referred to as api_key in some places. This PR makes the naming consistent.

Together with that change, the token/key secret classes are moved out of the client code that uses them and into their own modules, so they can be imported into client code and tests and other modules.