### PR TITLE
Register mistral nemo

### DIFF
--- a/plugins/huggingface/modelgauge/suts/huggingface_inference.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_inference.py
@@ -90,9 +90,18 @@ class HuggingFaceInferenceSUT(PromptResponseSUT[HuggingFaceInferenceChatRequest,
         return SUTResponse(completions=completions)
 
 
+HF_SECRET = InjectSecret(HuggingFaceInferenceToken)
+
 SUTS.register(
     HuggingFaceInferenceSUT,
     "gemma-9b-it-hf",
     "gemma-2-9b-it-qfa",
-    InjectSecret(HuggingFaceInferenceToken),
+    HF_SECRET,
+)
+
+SUTS.register(
+    HuggingFaceInferenceSUT,
+    "mistral-nemo-instruct-2407-hf",
+    "mistral-nemo-instruct-2407-mgt",
+    HF_SECRET,
 )


### PR DESCRIPTION
Registers a mistral-nemo huggingface SUT that points to workstream 3's dedicated huggingface endpoint. 

Note: WS3 keeps this endpoint paused when not in use. `HuggingFaceInferenceSUT` automatically resumes an endpoint if it's scaled to 0. But paused endpoints need to be manually started. If this becomes an issue, we can change the SUT to automatically resume paused endpoints as well.