### PR TITLE
Benchmark runner instantiates annotators

### DIFF
--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -192,7 +192,6 @@ class TestRunBase:
         self.test_records = defaultdict(dict)
 
     def add_test(self, test: PromptResponseTest):
-        assert self._test_lookup.get(test, None) is None, f"Test {test.uid} already added"
         wrapped = ModelgaugeTestWrapper(test, self.test_data_path)
         self.tests.append(wrapped)
         self._test_lookup[test] = wrapped

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -353,7 +353,6 @@ class TestRunAnnotationWorker(IntermediateCachingPipe):
         return item
 
     def collect_annotations(self, item):
-        # TODO: Parallelize annotators
         test_annotators = self.test_run.test_annotators[item.test.uid]
         for annotator in test_annotators:
             annotator_request = annotator.translate_request(item.prompt_with_context(), item.completion())

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -14,7 +14,9 @@ from typing import Mapping, Iterable, Sequence, List, Optional, Any
 import diskcache
 from modelgauge.annotation import Annotation
 from modelgauge.annotator import CompletionAnnotator
+from modelgauge.annotator_registry import ANNOTATORS
 from modelgauge.base_test import PromptResponseTest, TestResult
+from modelgauge.config import raise_if_missing_from_config
 from modelgauge.dependency_helper import FromSourceDependencyHelper
 from modelgauge.pipeline import Source, Pipe, Sink, Pipeline, NullCache
 from modelgauge.records import TestRecord
@@ -179,6 +181,7 @@ class TestRunBase:
         self.suts = runner.suts
         self.max_items = runner.max_items
         self.tests = []
+        self.test_annotators = {}
         self._test_lookup = {}
         self.run_tracker = runner.run_tracker
         self.completed_item_count = 0
@@ -189,9 +192,23 @@ class TestRunBase:
         self.test_records = defaultdict(dict)
 
     def add_test(self, test: PromptResponseTest):
+        assert self._test_lookup.get(test, None) is None, f"Test {test.uid} already added"
         wrapped = ModelgaugeTestWrapper(test, self.test_data_path)
         self.tests.append(wrapped)
         self._test_lookup[test] = wrapped
+        self._add_test_annotators(test)
+
+    def _add_test_annotators(self, test: PromptResponseTest):
+        # Check for missing secrets without instantiating any objects
+        missing_secrets = []
+        for annotator_uid in test.get_annotators():
+            missing_secrets.extend(ANNOTATORS.get_missing_dependencies(annotator_uid, secrets=self.secrets))
+        raise_if_missing_from_config(missing_secrets)
+
+        annotators = []
+        for annotator_uid in test.get_annotators():
+            annotators.append(ANNOTATORS.make_instance(annotator_uid, secrets=self.secrets))
+        self.test_annotators[test.uid] = annotators
 
     def add_finished_item(self, item: "TestRunItem"):
         if item.completion() and item.annotations and not item.exception:
@@ -336,7 +353,9 @@ class TestRunAnnotationWorker(IntermediateCachingPipe):
         return item
 
     def collect_annotations(self, item):
-        for annotator_key, annotator in item.test.get_annotators().items():
+        # TODO: Parallelize annotators
+        test_annotators = self.test_run.test_annotators[item.test.uid]
+        for annotator in test_annotators:
             annotator_request = annotator.translate_request(item.prompt_with_context(), item.completion())
             cache_key = annotator_request.model_dump_json(exclude_none=True)
             self._debug(f"looking for {cache_key} in cache")
@@ -349,7 +368,7 @@ class TestRunAnnotationWorker(IntermediateCachingPipe):
                 self.cache[cache_key] = annotator_response
 
             annotation = annotator.translate_response(annotator_request, annotator_response)
-            item.annotations[annotator_key] = annotation
+            item.annotations[annotator.uid] = annotation
         item.test.measure_quality(item)
 
 

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -226,6 +226,9 @@ class TestRunBase:
     def failed_items_for(self, sut, test) -> Sequence[TestItem]:
         return self.failed_items[sut.key][test.uid]
 
+    def annotators_for_test(self, test: PromptResponseTest) -> Sequence[CompletionAnnotator]:
+        return self.test_annotators[test.uid]
+
 
 class TestRun(TestRunBase):
     tests: list[ModelgaugeTestWrapper]
@@ -353,8 +356,7 @@ class TestRunAnnotationWorker(IntermediateCachingPipe):
         return item
 
     def collect_annotations(self, item):
-        test_annotators = self.test_run.test_annotators[item.test.uid]
-        for annotator in test_annotators:
+        for annotator in self.test_run.annotators_for_test(item.test):
             annotator_request = annotator.translate_request(item.prompt_with_context(), item.completion())
             cache_key = annotator_request.model_dump_json(exclude_none=True)
             self._debug(f"looking for {cache_key} in cache")

--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -135,7 +135,7 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
                         continue
 
                     # Check that prompt is for correct hazard/persona/locale.
-                    file_hazard = row["hazard"]
+                    file_hazard = row["hazard"].split("_")[0]
                     persona = SafePersonasVersion1(row["persona"])
                     locale = Locale(row["locale"])
                     if not file_hazard == self.hazard:

--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -3,8 +3,7 @@ from typing import Dict
 from unittest.mock import MagicMock
 
 import pytest
-from modelgauge.annotator import Annotator
-from modelgauge.annotator_registry import ANNOTATORS
+
 from modelgauge.annotators.demo_annotator import DemoYBadAnnotation, DemoYBadAnnotator
 from modelgauge.annotators.llama_guard_annotator import LlamaGuardAnnotation
 from modelgauge.dependency_helper import DependencyHelper
@@ -14,6 +13,7 @@ from modelgauge.prompt import TextPrompt
 from modelgauge.record_init import InitializationRecord
 from modelgauge.secret_values import RawSecrets, get_all_secrets
 from modelgauge.suts.together_client import TogetherChatRequest, TogetherChatResponse
+from modelgauge_tests.fake_annotator import FakeAnnotator
 
 from modelbench.benchmark_runner import *
 from modelbench.hazards import HazardDefinition, HazardScore
@@ -36,14 +36,23 @@ def fake_all_secrets(value="some-value") -> RawSecrets:
     return raw_secrets
 
 
+class FakeExplodingAnnotator(FakeAnnotator):
+    def annotate(self, annotation_request):
+        raise ValueError("annotator done broke")
+
+
+ANNOTATORS.register(FakeExplodingAnnotator, "fake_exploding_annotator")
+ANNOTATORS.register(FakeAnnotator, "fake_annotator_1")
+ANNOTATORS.register(FakeAnnotator, "fake_annotator_2")
+
+
 class AFakeTest(PromptResponseTest):
 
-    def __init__(self, uid: str, items, secrets, annotator=None):
+    def __init__(self, uid: str, items, annotators=["demo_annotator"]):
         super().__init__(uid)
         self.items = items
-        self.secrets = secrets
         self.initialization_record = InitializationRecord(module="testing", class_name="a_test", args=[], kwargs={})
-        self.annotator = annotator or ANNOTATORS.make_instance("demo_annotator", secrets=self.secrets)
+        self.annotator_uids = annotators
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
         pass
@@ -51,11 +60,11 @@ class AFakeTest(PromptResponseTest):
     def make_test_items(self, dependency_helper: DependencyHelper) -> List[TestItem]:
         return self.items
 
-    def get_annotators(self) -> Mapping[str, Annotator]:
-        return {"demo_annotator": self.annotator}
+    def get_annotators(self) -> List[str]:
+        return self.annotator_uids
 
     def measure_quality(self, item: TestItemAnnotations) -> Dict[str, float]:
-        ann = item.interactions[0].response.completions[0].get_annotation("demo_annotator", DemoYBadAnnotation)
+        ann = item.interactions[0].response.completions[0].get_annotation(self.annotator_uids[0], DemoYBadAnnotation)
         return {"badness": float(ann.badness)}
 
     def aggregate_measurements(self, items: List[MeasuredTestItem]):
@@ -65,6 +74,28 @@ class AFakeTest(PromptResponseTest):
             total_badness += item.measurements["badness"]
             badness_count += 1
         return {"total_badness": total_badness, "badness_count": badness_count}
+
+
+class AHazard(HazardDefinition):
+    def __init__(self, test_list):
+        super().__init__()
+        self.test_list = test_list
+
+    def tests(self, secrets: RawSecrets) -> List[PromptResponseTest]:
+        return self.test_list
+
+    def score(self, sut_scores: Mapping[str, TestRecord]) -> HazardScore:
+        count = 0
+        total = 0
+        for key, value in sut_scores.items():
+            d = value.result.data
+            count += d["badness_count"]
+            total += d["total_badness"]
+
+        score = ValueEstimate.make(total / count, count)
+
+        test_scores = {}
+        return HazardScore(hazard_definition=self, score=score, test_scores=test_scores, exceptions=0)
 
 
 class TestRunners:
@@ -80,8 +111,8 @@ class TestRunners:
         return TestItem(prompts=[PromptWithContext(prompt=TextPrompt(text=text), source_id=source_id)])
 
     @pytest.fixture()
-    def a_test(self, item_from_test, fake_secrets):
-        return AFakeTest("a_test", [item_from_test], fake_secrets)
+    def a_test(self, item_from_test):
+        return AFakeTest("a_test", [item_from_test])
 
     @pytest.fixture()
     def a_sut(self):
@@ -100,33 +131,15 @@ class TestRunners:
 
     @pytest.fixture()
     def exploding_wrapped_test(self, item_from_test, tmp_path):
-        a = MagicMock(spec=DemoYBadAnnotator)
-        a.annotate.side_effect = ValueError("annotator done broke")
-        raw_test = AFakeTest("a_test", [item_from_test], None, annotator=a)
+        raw_test = AFakeTest("a_test", [item_from_test], annotators=["fake_exploding_annotator"])
         return ModelgaugeTestWrapper(raw_test, tmp_path)
 
     @pytest.fixture()
     def benchmark(self, a_test):
-        class AHazard(HazardDefinition):
-            def tests(self, secrets: RawSecrets) -> List[PromptResponseTest]:
-                return [a_test]
-
-            def score(self, sut_scores: Mapping[str, TestRecord]) -> HazardScore:
-                count = 0
-                total = 0
-                for key, value in sut_scores.items():
-                    d = value.result.data
-                    count += d["badness_count"]
-                    total += d["total_badness"]
-
-                score = ValueEstimate.make(total / count, count)
-
-                test_scores = {}
-                return HazardScore(hazard_definition=self, score=score, test_scores=test_scores, exceptions=0)
 
         class ABenchmark(BenchmarkDefinition):
             def _make_hazards(self) -> Sequence[HazardDefinition]:
-                return [AHazard()]
+                return [AHazard([a_test])]
 
         return ABenchmark()
 
@@ -145,6 +158,30 @@ class TestRunners:
     @pytest.fixture()
     def hazard(self):
         pass
+
+    def test_test_run_loads_annotators(self, tmp_path, item_from_test, benchmark):
+        test_1 = AFakeTest("test_1", [item_from_test], annotators=["fake_annotator_1"])
+        test_2 = AFakeTest("test_2", [item_from_test], annotators=["fake_annotator_1", "fake_annotator_2"])
+
+        class BenchmarkMultipleTests(BenchmarkDefinition):
+            def _make_hazards(self) -> Sequence[HazardDefinition]:
+                return [AHazard([test_1, test_2])]
+
+        runner = BenchmarkRunner(tmp_path / "run")
+        runner.add_benchmark(BenchmarkMultipleTests())
+        run = BenchmarkRun(runner)
+
+        assert len(run.test_annotators) == 2
+
+        test_1_annotators = run.test_annotators["test_1"]
+        assert len(test_1_annotators) == 1
+        assert isinstance(test_1_annotators[0], FakeAnnotator)
+        assert test_1_annotators[0].uid == "fake_annotator_1"
+
+        test_2_annotators = run.test_annotators["test_2"]
+        assert len(test_2_annotators) == 2
+        assert all(isinstance(annotator, FakeAnnotator) for annotator in test_2_annotators)
+        assert {annotator.uid for annotator in test_2_annotators} == {"fake_annotator_1", "fake_annotator_2"}
 
     def test_test_run_items_properly_isolated(self, a_wrapped_test):
 
@@ -204,12 +241,15 @@ class TestRunners:
         assert result.sut_response is None
         assert isinstance(result.exception, ValueError)
 
-    def test_benchmark_annotation_worker(self, a_wrapped_test, tmp_path, item_from_test, sut_response, a_sut):
-        baw = TestRunAnnotationWorker(self.a_run(tmp_path, suts=[a_sut]))
+    def test_benchmark_annotation_worker(
+        self, a_wrapped_test, tmp_path, item_from_test, sut_response, a_sut, benchmark
+    ):
+        baw = TestRunAnnotationWorker(self.a_run(tmp_path, suts=[a_sut], benchmarks=[benchmark]))
         pipeline_item = TestRunItem(a_wrapped_test, item_from_test, a_sut, sut_response)
 
         result = baw.handle_item(pipeline_item)
 
+        assert list(result.annotations.keys()) == ["demo_annotator"]
         assert result.annotations["demo_annotator"].badness == 1.0
 
     def test_benchmark_annotation_worker_ignores_failed(self, a_wrapped_test, tmp_path, item_from_test, a_sut):


### PR DESCRIPTION
PR #487 did not apply its test annotator instantiation change to modelbench's runner. This fixes that.

I also snuck in a bug fix for the "sxc" prompt issue that was causing some tests to fail.