### PR TITLE
Show cache info at the end of the run

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,5 +40,5 @@ jobs:
       run: poetry run pytest
 
     - name: Run mypy
-      run: poetry run mypy --exclude modelbench .
+      run: poetry run mypy --follow-imports silent --exclude modelbench src/modelgauge
 

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -11,7 +11,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Mapping, Iterable, Sequence, List, Optional, Any
 
-import diskcache
+from tqdm import tqdm
+
+from modelbench.benchmarks import (
+    BenchmarkDefinition,
+    BenchmarkScore,
+)
+from modelbench.cache import MBCache, DiskCache
+from modelbench.suts import ModelGaugeSut
 from modelgauge.annotation import Annotation
 from modelgauge.annotator import CompletionAnnotator
 from modelgauge.annotator_registry import ANNOTATORS
@@ -30,13 +37,6 @@ from modelgauge.single_turn_prompt_response import (
     SUTCompletionAnnotations,
 )
 from modelgauge.sut import SUTResponse, SUTCompletion
-from tqdm import tqdm
-
-from modelbench.benchmarks import (
-    BenchmarkDefinition,
-    BenchmarkScore,
-)
-from modelbench.suts import ModelGaugeSut
 
 
 class RunTracker:
@@ -176,7 +176,8 @@ class TestRunBase:
         super().__init__()
         # copy the starting state
         self.pipeline_segments = []
-        self.test_data_path = runner.data_dir / "tests"
+        self.data_dir = runner.data_dir
+        self.test_data_path = self.data_dir / "tests"
         self.secrets = runner.secrets
         self.suts = runner.suts
         self.max_items = runner.max_items
@@ -185,6 +186,9 @@ class TestRunBase:
         self._test_lookup = {}
         self.run_tracker = runner.run_tracker
         self.completed_item_count = 0
+
+        self.caches = {}
+        self.cache_starting_size = {}
 
         # set up for result collection
         self.finished_items = defaultdict(lambda: defaultdict(lambda: list()))
@@ -228,6 +232,24 @@ class TestRunBase:
     def annotators_for_test(self, test: PromptResponseTest) -> Sequence[CompletionAnnotator]:
         return self.test_annotators[test.uid]
 
+    def cache_for(self, cache_name: str):
+        if self.data_dir:
+            result = DiskCache(self.data_dir / cache_name)
+        else:
+            result = NullCache()
+
+        self.caches[cache_name] = result
+        self.cache_starting_size[cache_name] = len(result)
+        return result
+
+    def cache_info(self):
+        result = []
+        for key in self.caches.keys():
+            result.append(f"  {key}: {self.caches[key]}")
+            result.append(f"  {key}: started with {self.cache_starting_size[key]}")
+            result.append(f"  {key}: finished with {len(self.caches[key])}")
+        return "\n".join(result)
+
 
 class TestRun(TestRunBase):
     tests: list[ModelgaugeTestWrapper]
@@ -260,13 +282,9 @@ class IntermediateCachingPipe(Pipe):
     this just makes a cache available for internal use to cache intermediate results.
     """
 
-    def __init__(self, thread_count=1, cache_path=None):
+    def __init__(self, cache: MBCache, thread_count=1):
         super().__init__(thread_count)
-
-        if cache_path:
-            self.cache = diskcache.Cache(cache_path).__enter__()
-        else:
-            self.cache = NullCache()
+        self.cache = cache
 
     def handle_item(self, item) -> Optional[Any]:
         pass
@@ -312,8 +330,8 @@ class TestRunSutAssigner(Pipe):
 
 class TestRunSutWorker(IntermediateCachingPipe):
 
-    def __init__(self, test_run: TestRunBase, thread_count=1, cache_path=None):
-        super().__init__(thread_count, cache_path=cache_path)
+    def __init__(self, test_run: TestRunBase, cache: MBCache, thread_count=1):
+        super().__init__(cache, thread_count)
         self.test_run = test_run
 
     def handle_item(self, item):
@@ -340,8 +358,8 @@ class TestRunSutWorker(IntermediateCachingPipe):
 
 class TestRunAnnotationWorker(IntermediateCachingPipe):
 
-    def __init__(self, test_run: TestRunBase, thread_count=1, cache_path=None):
-        super().__init__(thread_count, cache_path=cache_path)
+    def __init__(self, test_run: TestRunBase, cache: MBCache, thread_count=1, cache_path=None):
+        super().__init__(cache, thread_count)
         self.test_run = test_run
 
     def handle_item(self, item: TestRunItem) -> TestRunItem:
@@ -425,11 +443,9 @@ class TestRunnerBase:
     def _build_pipeline(self, run):
         run.pipeline_segments.append(TestRunItemSource(run))
         run.pipeline_segments.append(TestRunSutAssigner(run))
+        run.pipeline_segments.append(TestRunSutWorker(run, run.cache_for("sut_cache"), thread_count=self.thread_count))
         run.pipeline_segments.append(
-            TestRunSutWorker(run, thread_count=self.thread_count, cache_path=self.data_dir / "sut_cache")
-        )
-        run.pipeline_segments.append(
-            TestRunAnnotationWorker(run, thread_count=self.thread_count, cache_path=self.data_dir / "annotator_cache")
+            TestRunAnnotationWorker(run, run.cache_for("annotator_cache"), thread_count=self.thread_count)
         )
         run.pipeline_segments.append(TestRunResultsCollector(run))
         pipeline = Pipeline(

--- a/src/modelbench/cache.py
+++ b/src/modelbench/cache.py
@@ -1,0 +1,93 @@
+import collections.abc
+from abc import ABC, abstractmethod
+
+import diskcache
+
+
+class MBCache(ABC, collections.abc.Mapping):
+    @abstractmethod
+    def __setitem__(self, __key, __value):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, __type, __value, __traceback):
+        pass
+
+
+class NullCache(MBCache):
+    """Doesn't save anything"""
+
+    def __setitem__(self, __key, __value):
+        pass
+
+    def __getitem__(self, key, /):
+        raise KeyError()
+
+    def __len__(self):
+        return 0
+
+    def __iter__(self):
+        pass
+
+
+class InMemoryCache(MBCache):
+    """Holds stuff in memory only"""
+
+    def __init__(self):
+        super().__init__()
+        self.contents = dict()
+
+    def __setitem__(self, __key, __value):
+        self.contents.__setitem__(__key, __value)
+
+    def __getitem__(self, key, /):
+        return self.contents.__getitem__(key)
+
+    def __len__(self):
+        return self.contents.__len__()
+
+    def __iter__(self):
+        return self.contents.__iter__()
+
+
+class DiskCache(MBCache):
+    """
+    Holds stuff in memory only. The docs recommend using
+    it as a context manager in a threaded context:
+
+    "Each thread that accesses a cache should also call close
+    on the cache. Cache objects can be used in a with statement
+    to safeguard calling close."
+
+    """
+
+    def __init__(self, cache_path):
+        super().__init__()
+        self.cache_path = cache_path
+        self.raw_cache = diskcache.Cache(cache_path)
+        self.contents = self.raw_cache
+
+    def __enter__(self):
+        self.contents = self.raw_cache.__enter__()
+        return self.contents
+
+    def __exit__(self, __type, __value, __traceback):
+        self.raw_cache.__exit__(__type, __value, __traceback)
+        self.contents = self.raw_cache
+
+    def __setitem__(self, __key, __value):
+        self.contents.__setitem__(__key, __value)
+
+    def __getitem__(self, key, /):
+        return self.contents.__getitem__(key)
+
+    def __len__(self):
+        return self.contents.__len__()
+
+    def __iter__(self):
+        return self.contents.__iter__()
+
+    def __str__(self):
+        return self.__class__.__name__ + f"({self.cache_path})"

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -13,10 +13,6 @@ from typing import List, Optional
 import click
 import termcolor
 from click import echo
-from modelgauge.config import load_secrets_from_config, write_default_config
-from modelgauge.load_plugins import load_plugins
-from modelgauge.sut_registry import SUTS
-from modelgauge.tests.safe_v1 import Locale
 
 from modelbench.benchmark_runner import BenchmarkRunner, TqdmRunTracker, JsonRunTracker
 from modelbench.benchmarks import BenchmarkDefinition, GeneralPurposeAiChatBenchmark, GeneralPurposeAiChatBenchmarkV1
@@ -24,6 +20,10 @@ from modelbench.hazards import STANDARDS
 from modelbench.record import dump_json
 from modelbench.static_site_generator import StaticContent, StaticSiteGenerator
 from modelbench.suts import ModelGaugeSut, SutDescription, SUTS_FOR_V_0_5
+from modelgauge.config import load_secrets_from_config, write_default_config
+from modelgauge.load_plugins import load_plugins
+from modelgauge.sut_registry import SUTS
+from modelgauge.tests.safe_v1 import Locale
 
 _DEFAULT_SUTS = SUTS_FOR_V_0_5
 
@@ -175,6 +175,8 @@ def run_benchmarks_for_suts(benchmarks, suts, max_instances, debug=False, json_l
     runner.thread_count = thread_count
     runner.run_tracker = JsonRunTracker() if json_logs else TqdmRunTracker(0.5)
     run = runner.run()
+    print("Cache info:")
+    print(run.cache_info())
     return run
 
 

--- a/src/modelgauge/pipeline.py
+++ b/src/modelgauge/pipeline.py
@@ -62,6 +62,8 @@ from typing import Any, Callable, Iterable, Optional
 
 import diskcache  # type: ignore
 
+from modelbench.cache import DiskCache, NullCache
+
 
 class PipelineSegment(ABC):
     """A segment of a Pipeline used for parallel processing."""
@@ -228,19 +230,6 @@ class Pipe(PipelineSegment):
         self._debug(f"join done")
 
 
-class NullCache(dict):
-    """Compatible with diskcache.Cache, but does nothing."""
-
-    def __setitem__(self, __key, __value):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, __type, __value, __traceback):
-        pass
-
-
 class CachingPipe(Pipe):
     """A Pipe that optionally caches results the given directory. Implement key and handle_uncached_item."""
 
@@ -248,7 +237,7 @@ class CachingPipe(Pipe):
         super().__init__(thread_count)
 
         if cache_path:
-            self.cache = diskcache.Cache(cache_path).__enter__()
+            self.cache = DiskCache(cache_path)
         else:
             self.cache = NullCache()
 

--- a/tests/modelbench_tests/test_cache.py
+++ b/tests/modelbench_tests/test_cache.py
@@ -1,0 +1,58 @@
+from modelbench.cache import MBCache, NullCache, InMemoryCache, DiskCache
+
+
+class TestNullCache:
+    def test_basics(self):
+        c: MBCache = NullCache()
+        c["a"] = 1
+        assert "a" not in c
+
+    def test_context(self):
+        c = NullCache()
+        with c as cache:
+            cache["a"] = 1
+            assert "a" not in cache
+        assert "a" not in c
+
+
+class TestInMemoryCache:
+    def test_basics(self):
+        c: MBCache = InMemoryCache()
+        c["a"] = 1
+        assert "a" in c
+        assert c["a"] == 1
+
+    def test_context(self):
+        c = InMemoryCache()
+        with c as cache:
+            cache["a"] = 1
+            assert "a" in cache
+            assert cache["a"] == 1
+        assert c["a"] == 1
+
+
+class TestDiskCache:
+    def test_basics(self, tmp_path):
+        c1: MBCache = DiskCache(tmp_path)
+        c1["a"] = 1
+        assert "a" in c1
+        assert c1["a"] == 1
+
+        c2: MBCache = DiskCache(tmp_path)
+        assert "a" in c2
+        assert c2["a"] == 1
+
+        c2["a"] = 2
+        assert c1["a"] == 2
+
+    def test_context(self, tmp_path):
+        c = DiskCache(tmp_path)
+        with c as cache:
+            cache["a"] = 1
+            assert "a" in cache
+            assert cache["a"] == 1
+        assert c["a"] == 1
+
+    def test_as_string(self, tmp_path):
+        c = DiskCache(tmp_path)
+        assert str(c) == f"DiskCache({tmp_path})"


### PR DESCRIPTION
Adds some basic cache information at the end. I'm thinking we'll add more over time; this was just enough to try to debug a problem in the runner.

```
Cache info:
  sut_cache: DiskCache(run/sut_cache)
  sut_cache: started with 0
  sut_cache: finished with 60
  annotator_cache: DiskCache(run/annotator_cache)
  annotator_cache: started with 0
  annotator_cache: finished with 60
```