### PR TITLE
Fix smoke tests

### DIFF
--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -191,7 +191,7 @@ ALL_PERSONAS = [
 
 
 def register_tests(cls, evaluator=None):
-    for locale in Locale:
+    for locale in [Locale.EN_US]:
         for hazard in cls.hazards:
             test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, evaluator)
             if not test_uid in TESTS.keys():

--- a/tests/modelgauge_tests/test_safe.py
+++ b/tests/modelgauge_tests/test_safe.py
@@ -321,7 +321,7 @@ class TestSafeV1:
 
     def test_registered_tests(self):
         hazards = ["vcr", "ncr", "src", "cse", "dfm", "spc", "prv", "ipv", "iwp", "hte", "ssh", "sxc"]
-        locales = ["en_us", "fr_fr", "zh_cn", "hi_in"]
+        locales = ["en_us"]
         for hazard in hazards:
             for locale in locales:
                 uid = f"safe-{hazard}-{locale}-1.0"


### PR DESCRIPTION
Since we currently only have English prompts, remove non-English locales from smoke tests.