### PR TITLE
Journal consistency checker

### DIFF
--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -1,5 +1,5 @@
 import json
-import os
+import shutil
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from itertools import product
@@ -8,7 +8,7 @@ from typing import Dict, List
 
 from modelbench.run_journal import journal_reader
 
-LINE_WIDTH = os.get_terminal_size().columns
+LINE_WIDTH = shutil.get_terminal_size(fallback=(120, 50)).columns
 
 
 class JournalSearch:

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -1,4 +1,5 @@
 import json
+import os
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
 from itertools import product
@@ -6,6 +7,8 @@ from tabulate import tabulate
 from typing import Dict, List
 
 from modelbench.run_journal import journal_reader
+
+LINE_WIDTH = os.get_terminal_size().columns
 
 
 class JournalSearch:
@@ -167,7 +170,7 @@ class JournalEntityLevelCheck:
             self.results[self._row_key(entities.values())][self._col_name(check_cls)] = result
             if not result:
                 # TODO: Add check name to warning message.
-                self.warnings.append(check.failure_message())
+                self.warnings.append(f"{self._col_name(check_cls)}: {check.failure_message()}")
 
 
 class ConsistencyChecker:
@@ -234,6 +237,7 @@ class ConsistencyChecker:
         """Print details about the failed checks."""
         check_groups = [self.test_sut_level_checker, self.test_sut_annotator_level_checker]
         for checker in check_groups:
+            print("-" * LINE_WIDTH)
             assert checker.check_is_complete()
             if len(checker.warnings) == 0:
                 print(f"All {checker.name} checks passed!")

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -255,7 +255,7 @@ class ConsistencyChecker:
 
         self.suts = starting_run_entry[0]["suts"]
         self.tests = starting_run_entry[0]["tests"]
-        # TODO: Find a more reliable way of getting all expected annotators for the tests.
+        # TODO: Find a more reliable way of getting all expected annotators for the tests. THIS WILL FAIL IF THEY ARE ALL CACHED.
         annotator_entries = self.search_engine.query("fetched annotator response", test=self.tests[0], sut=self.suts[0])
         self.annotators = list(set([entry["annotator"] for entry in annotator_entries]))
 

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -1,0 +1,164 @@
+import json
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import Dict, List
+
+from modelbench.run_journal import journal_reader
+
+
+class JournalSearch:
+    def __init__(self, journal_path, record_path):
+        self.journal_path = journal_path
+        self.record_path = record_path
+        self.message_entries: Dict[str, List] = defaultdict(list)  # or maybe sqllite dict?
+        # Load journal into message_entries dict.
+        self._read_journal()
+
+    def _read_journal(self):
+        # Might want to filter out irrelevant messages here. idk.
+        with journal_reader(self.journal_path) as f:
+            for line in f:
+                entry = json.loads(line)
+                self.message_entries[entry["message"]].append(entry)
+
+    def query(self, message: str, **kwargs):
+        messages = self.message_entries[message]
+        return [m for m in messages if all(m[k] == v for k, v in kwargs.items())]
+
+
+class JournalCheck(ABC):
+    """All checks must inherit from this class + their respective entity level class."""
+
+    @abstractmethod
+    def required_messages(self) -> List[str]:
+        """The set of messages that this check relies on.
+        Might be used to filter out irrelevant journal entries. not sure if that would actually help."""
+        pass
+
+    @abstractmethod
+    def check(self) -> bool:
+        pass
+
+    @abstractmethod
+    def failure_message(self) -> str:
+        """The message to display if the check fails."""
+        pass
+
+
+class EachPromptHasOneResponse(JournalCheck):
+    def __init__(self, sut, test, search_engine: JournalSearch):
+        # Load all data needed for the check.
+        self.num_cached_responses = len(search_engine.query("using cached sut response", sut=sut, test=test))
+        self.num_fetched_responses = len(search_engine.query("fetched sut response", sut=sut, test=test))
+        # Get num. test prompts
+        test_entry = search_engine.query("using test items", test=test)
+        assert len(test_entry) == 1
+        self.num_test_prompts = test_entry[0]["using"]
+
+    def required_messages(self) -> List[str]:
+        return ["using cached sut response", "fetched sut response", "using test items"]
+
+    def check(self) -> bool:
+        return self.num_cached_responses + self.num_fetched_responses == self.num_test_prompts
+
+    def failure_message(self) -> str:
+        """The message to display if the check fails."""
+        assert not self.check()
+        return f"The total number of SUT responses (cached=({self.num_cached_responses} + fetched = {self.num_fetched_responses}) does not correspond to the total num prompts in test ({self.num_test_prompts})"
+
+
+class EachResponseTranslatedOnce(JournalCheck):
+    def __init__(self, sut, test, search_engine: JournalSearch):
+        # Load all data needed for the check.
+        self.num_translated_responses = len(search_engine.query("translated sut response", sut=sut, test=test))
+        self.num_test_prompts = search_engine.query("using test items", test=test)[0]["using"]
+
+    def required_messages(self) -> List[str]:
+        return ["translated sut response", "using test items"]
+
+    def check(self) -> bool:
+        return self.num_translated_responses == self.num_test_prompts
+
+    def failure_message(self) -> str:
+        """The message to display if the check fails."""
+        assert not self.check()
+        return f"The number of SUT response translated ({self.num_translated_responses}) does not equal the total num prompts in test ({self.num_test_prompts})"
+
+
+class JournalEntityLevelCheck(ABC):
+    """Concrete subclasses run all checks that occupy the same conceptual entity-level in the journal"""
+
+    def __init__(self):
+        """All subclasses must call super().__init__()."""
+        self.results = defaultdict(dict)
+        self.warnings = []
+
+    @abstractmethod
+    def collect_entities(self, search_engine: JournalSearch):
+        """Collect all entities relevant to this level of checking from the journal.
+        These entities will be used to run checks.
+        """
+        pass
+
+    @abstractmethod
+    def run_checks(self, search_engine: JournalSearch):
+        """Store results in self.results and self.warnings."""
+        pass
+
+    def display_all_results(self):
+        """Print simple table where each row is a single entity (or entity tuple e.g. test x SUT) and each column is a check."""
+        # TODO
+        # Not sure if this should be implemented here, by the concrete subclass, or in ConsistencyChecker...
+        pass
+
+    def display_warnings(self):
+        """Print details about the failed checks."""
+        for warning in self.warnings:
+            print(warning)  # or something
+
+
+class SUTxTestLevelChecker(JournalEntityLevelCheck):
+    """Runs all checks relevant to a (SUT, test) tuple."""
+
+    def __init__(self):
+        super().__init__()
+        self.suts = []
+        self.tests = []
+        # All checks must accept `sut` and `test` init. params.
+        self.check_classes = [EachPromptHasOneResponse, EachResponseTranslatedOnce]
+
+    def collect_entities(self, search_engine: JournalSearch):
+        # Get all SUTs and tests that were ran in the journal. We will run checks for each (SUT, test) pair.
+        starting_run_entry = search_engine.query("starting run")
+        assert len(starting_run_entry) == 1
+        self.suts = starting_run_entry[0]["suts"]
+        self.tests = starting_run_entry[0]["tests"]
+
+    def run_checks(self, search_engine: JournalSearch):
+        for sut in self.suts:
+            for test in self.tests:
+                things = f"{sut}-{test}"
+                for cls in self.check_classes:
+                    check = cls(sut, test, search_engine)
+                    self.results[things][cls] = check.check()  # True or False
+                    if not self.results[things][cls]:
+                        self.warnings.append(check.failure_message())
+
+
+class ConsistencyChecker:
+
+    def __init__(self, journal_path, record_path):
+        # Get all subclasses of JournalEntityLevelCheck
+        self.check_levels = [SUTxTestLevelChecker()]
+
+        # Object holding journal entries
+        self.search_engine = JournalSearch(journal_path, record_path)
+
+    def run_checks(self, verbose=False):
+        for level in self.check_levels:
+            level.run_checks(self.search_engine)
+            # TODO: Maybe move the display-formatting logic into this class.
+            level.display_all_results()
+            if verbose:
+                level.display_warnings()
+        # TODO: Also run checks for the json record file.

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -31,11 +31,11 @@ class JournalSearch:
 class JournalCheck(ABC):
     """All checks must inherit from this class + their respective entity level class."""
 
-    @abstractmethod
-    def required_messages(self) -> List[str]:
-        """The set of messages that this check relies on.
-        Might be used to filter out irrelevant journal entries. not sure if that would actually help."""
-        pass
+    # @abstractmethod
+    # def required_messages(self) -> List[str]:
+    #     """The set of messages that this check relies on.
+    #     Might be used to filter out irrelevant journal entries. not sure if that would actually help."""
+    #     pass
 
     @abstractmethod
     def check(self) -> bool:
@@ -57,9 +57,6 @@ class EachPromptHasOneResponse(JournalCheck):
         assert len(test_entry) == 1
         self.num_test_prompts = test_entry[0]["using"]
 
-    def required_messages(self) -> List[str]:
-        return ["using cached sut response", "fetched sut response", "using test items"]
-
     def check(self) -> bool:
         return self.num_cached_responses + self.num_fetched_responses == self.num_test_prompts
 
@@ -74,9 +71,6 @@ class EachResponseTranslatedOnce(JournalCheck):
         # Load all data needed for the check.
         self.num_translated_responses = len(search_engine.query("translated sut response", sut=sut, test=test))
         self.num_test_prompts = search_engine.query("using test items", test=test)[0]["using"]
-
-    def required_messages(self) -> List[str]:
-        return ["translated sut response", "using test items"]
 
     def check(self) -> bool:
         return self.num_translated_responses == self.num_test_prompts

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -61,6 +61,8 @@ class JournalCheck(ABC):
         pass
 
 
+# TODO: Check that all prompts in a test are unique.
+
 # TODO:
 # class NumPromptsQueuedMatchesExpected(JournalCheck):
 #     def __init__(self, search_engine: JournalSearch, sut, test):
@@ -72,12 +74,14 @@ class OneToOneCheck(JournalCheck):
     """Checks for a one-to-one mapping between two lists of prompt uids."""
 
     def __init__(self, expected_prompts: List[str], found_prompts: List[str]):
-        expected_counts = Counter(expected_prompts)
         found_counts = Counter(found_prompts)
-        # TODO: Could probably make this more efficient.
+        # TODO: Could probably make these 3 checks more efficient.
         self.duplicates = [uid for uid, count in found_counts.items() if count > 1]
-        self.missing_prompts = list((expected_counts - found_counts).keys())
-        self.unknown_prompts = list((found_counts - expected_counts).keys())
+        # Check for differences in the two sets.
+        expected_prompts = set(expected_prompts)
+        found_prompts = set(found_prompts)
+        self.missing_prompts = list(expected_prompts - found_prompts)
+        self.unknown_prompts = list(found_prompts - expected_prompts)
 
     def check(self) -> bool:
         return not any([len(self.duplicates), len(self.missing_prompts), len(self.unknown_prompts)])
@@ -88,9 +92,9 @@ class OneToOneCheck(JournalCheck):
         if len(self.duplicates) > 0:
             messages.append(f"The following duplicate prompts were found: {self.duplicates}")
         if len(self.missing_prompts) > 0:
-            messages.append(f"The prompts were missing: {self.missing_prompts}")
+            messages.append(f"The prompts were expected but missing: {self.missing_prompts}")
         if len(self.unknown_prompts) > 0:
-            messages.append(f"The following prompts were found but are not in the test: {self.unknown_prompts}")
+            messages.append(f"The following prompts were found but were not expected: {self.unknown_prompts}")
         return "\n\t".join(messages)
 
 

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -12,9 +12,8 @@ LINE_WIDTH = shutil.get_terminal_size(fallback=(120, 50)).columns
 
 
 class JournalSearch:
-    def __init__(self, journal_path, record_path):
+    def __init__(self, journal_path):
         self.journal_path = journal_path
-        self.record_path = record_path
         self.message_entries: Dict[str, List] = defaultdict(list)  # or maybe sqllite dict?
         # Load journal into message_entries dict.
         self._read_journal()
@@ -224,9 +223,9 @@ class JournalEntityLevelCheck:
 
 class ConsistencyChecker:
 
-    def __init__(self, journal_path, record_path):
+    def __init__(self, journal_path):
         # Object holding journal entries
-        self.search_engine = JournalSearch(journal_path, record_path)
+        self.search_engine = JournalSearch(journal_path)
 
         # Entities to run checks for.
         self.suts = None

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -139,10 +139,10 @@ def benchmark(
 
 @cli.command(help="check the consistency of a benchmark run using it's record and journal files.")
 @click.option("--journal-path", "-j", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
-@click.option("--record-path", "-r", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
+# @click.option("--record-path", "-r", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
 @click.option("--verbose", "-v", default=False, is_flag=True, help="Print details about the failed checks.")
-def consistency_check(journal_path, record_path, verbose):
-    checker = ConsistencyChecker(journal_path, record_path)
+def consistency_check(journal_path, verbose):
+    checker = ConsistencyChecker(journal_path)
     checker.run(verbose)
 
 

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -140,9 +140,10 @@ def benchmark(
 @cli.command(help="check the consistency of a benchmark run using it's record and journal files.")
 @click.option("--journal-path", "-j", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
 @click.option("--record-path", "-r", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
-def consistency_check(journal_path, record_path):
+@click.option("--verbose", "-v", default=False, is_flag=True, help="Print details about the failed checks.")
+def consistency_check(journal_path, record_path, verbose):
     checker = ConsistencyChecker(journal_path, record_path)
-    checker.run_checks()
+    checker.run_checks(verbose)
 
 
 def find_suts_for_sut_argument(sut_args: List[str]):

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -18,6 +18,7 @@ from click import echo
 import modelgauge
 from modelbench.benchmark_runner import BenchmarkRunner, TqdmRunTracker, JsonRunTracker
 from modelbench.benchmarks import BenchmarkDefinition, GeneralPurposeAiChatBenchmark, GeneralPurposeAiChatBenchmarkV1
+from modelbench.consistency_checker import ConsistencyChecker
 from modelbench.hazards import STANDARDS
 from modelbench.record import dump_json
 from modelbench.static_site_generator import StaticContent, StaticSiteGenerator
@@ -137,10 +138,11 @@ def benchmark(
 
 
 @cli.command(help="check the consistency of a benchmark run using it's record and journal files.")
-@click.option("--record-filename", "-r", type=click.Path(file_okay=True, dir_okay=False, path_type=pathlib.Path))
-@click.option("--journal-filename", "-j", type=click.Path(file_okay=True, dir_okay=False, path_type=pathlib.Path))
-def consistency_check(record_filename, journal_filename):
-    pass
+@click.option("--journal-path", "-j", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
+@click.option("--record-path", "-r", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
+def consistency_check(journal_path, record_path):
+    checker = ConsistencyChecker(journal_path, record_path)
+    checker.run_checks()
 
 
 def find_suts_for_sut_argument(sut_args: List[str]):

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -143,7 +143,7 @@ def benchmark(
 @click.option("--verbose", "-v", default=False, is_flag=True, help="Print details about the failed checks.")
 def consistency_check(journal_path, record_path, verbose):
     checker = ConsistencyChecker(journal_path, record_path)
-    checker.run_checks(verbose)
+    checker.run(verbose)
 
 
 def find_suts_for_sut_argument(sut_args: List[str]):

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -133,6 +133,14 @@ def benchmark(
         json_path = output_dir / f"benchmark_record-{b.uid}.json"
         scores = [score for score in benchmark_scores if score.benchmark_definition == b]
         dump_json(json_path, start_time, b, scores)
+        # TODO: Consistency check
+
+
+@cli.command(help="check the consistency of a benchmark run using it's record and journal files.")
+@click.option("--record-filename", "-r", type=click.Path(file_okay=True, dir_okay=False, path_type=pathlib.Path))
+@click.option("--journal-filename", "-j", type=click.Path(file_okay=True, dir_okay=False, path_type=pathlib.Path))
+def consistency_check(record_filename, journal_filename):
+    pass
 
 
 def find_suts_for_sut_argument(sut_args: List[str]):

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -42,15 +42,85 @@ def basic_benchmark_run():
     )
 
 
-def test_normal_run(tmp_path, basic_benchmark_run):
+def init_checker_for_journal(tmp_path, journal):
     journal_path = tmp_path / "journal.jsonl"
     with open(journal_path, "w") as f:
-        for item in basic_benchmark_run:
+        for item in journal:
             f.write(json.dumps(item) + "\n")
 
     checker = ConsistencyChecker(journal_path=journal_path)
+    return checker
+
+
+def test_normal_run(tmp_path, basic_benchmark_run):
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     for subchecker in [checker.test_sut_level_checker, checker.test_sut_annotator_level_checker]:
-        assert subchecker.warnings == []
         assert subchecker.check_is_complete()
+        for row in subchecker.results.values():
+            assert all(row)
+        assert subchecker.warnings == []
+
+
+@pytest.mark.parametrize(
+    "duplicate_message,failed_check",
+    [
+        ("fetched sut response", "EachPromptRespondedToOnce"),
+        ("using cached sut response", "EachPromptRespondedToOnce"),
+        ("translated sut response", "EachResponseTranslatedOnce"),
+        ("measured item quality", "EachItemMeasuredOnce"),
+    ],
+)
+def test_run_with_duplicate_sut_stuff(tmp_path, basic_benchmark_run, duplicate_message, failed_check):
+    basic_benchmark_run.append({"message": duplicate_message, "test": "test1", "sut": "sut1", "prompt_id": "prompt1"})
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
+    checker.run()
+
+    subchecker = checker.test_sut_level_checker
+    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    assert subchecker.check_is_complete()
+    assert subchecker.results[failed_row][failed_check] is False
+    # TODO: Check warnings
+
+
+@pytest.mark.parametrize(
+    "extra_earlier_message,failed_check",
+    [
+        ("queuing item", "EachPromptRespondedToOnce"),
+        ("fetched sut response", "EachResponseTranslatedOnce"),
+        ("translated sut response", "EachItemMeasuredOnce"),
+    ],
+)
+def test_run_with_missing_sut_stuff(tmp_path, basic_benchmark_run, extra_earlier_message, failed_check):
+    basic_benchmark_run.append(
+        {"message": extra_earlier_message, "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT"}
+    )
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
+    checker.run()
+
+    subchecker = checker.test_sut_level_checker
+    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    assert subchecker.check_is_complete()
+    assert subchecker.results[failed_row][failed_check] is False
+    # TODO: Check warnings
+
+
+@pytest.mark.parametrize(
+    "extra_message,failed_check",
+    [
+        ("fetched sut response", "EachPromptRespondedToOnce"),
+        ("translated sut response", "EachResponseTranslatedOnce"),
+        ("measured item quality", "EachItemMeasuredOnce"),
+    ],
+)
+def test_run_with_extra_sut_stuff(tmp_path, basic_benchmark_run, extra_message, failed_check):
+    basic_benchmark_run.append({"message": extra_message, "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT"})
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
+    checker.run()
+
+    subchecker = checker.test_sut_level_checker
+    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    assert subchecker.check_is_complete()
+    assert subchecker.results[failed_row][failed_check] is False
+    # TODO: Check warnings

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -1,0 +1,56 @@
+import json
+import pytest
+from typing import Dict, List
+
+from modelbench.consistency_checker import ConsistencyChecker
+
+
+def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotators: List[str]):
+    """Successful "fresh" benchmark run with all SUT/annotator responses fetched (not cached)."""
+    journal = []
+    journal.append({"message": "starting run", "suts": suts, "tests": list(test_prompts.keys())})
+    for sut in suts:
+        for test, prompts in test_prompts.items():
+            journal.append({"message": "using test items", "test": test, "using": len(prompts)})
+            for prompt in prompts:
+                # Normal pipeline.
+                sut_messages = [
+                    "queuing item",
+                    "fetched sut response",
+                    "translated sut response",
+                    "measured item quality",
+                ]
+                for message in sut_messages:
+                    journal.append({"message": message, "test": test, "prompt_id": prompt, "sut": sut})
+                for annotator in annotators:
+                    journal.append(
+                        {
+                            "message": "fetched annotator response",
+                            "test": test,
+                            "sut": sut,
+                            "prompt_id": prompt,
+                            "annotator": annotator,
+                        }
+                    )
+    return journal
+
+
+@pytest.fixture
+def basic_benchmark_run():
+    return make_basic_run(
+        suts=["sut1", "sut2"], test_prompts={"test1": ["prompt1", "prompt2"]}, annotators=["annotator1", "annotator2"]
+    )
+
+
+def test_normal_run(tmp_path, basic_benchmark_run):
+    journal_path = tmp_path / "journal.jsonl"
+    with open(journal_path, "w") as f:
+        for item in basic_benchmark_run:
+            f.write(json.dumps(item) + "\n")
+
+    checker = ConsistencyChecker(journal_path=journal_path)
+    checker.run()
+
+    for subchecker in [checker.test_sut_level_checker, checker.test_sut_annotator_level_checker]:
+        assert subchecker.warnings == []
+        assert subchecker.check_is_complete()


### PR DESCRIPTION
I don't particularly like this. I think the class hierarchy is too complicated. My general goal was to make it easy to 1) add new checks and 2) understand what each check does. 

I didn't put any effort towards efficiently querying the journal, so there's room for optimization there.
I only added a handful of checks to demonstrate what this looks like. Once we decide on the approach we want to take here, I will add some more easy checks + some basic unit testing with sample run journals.

Here is what the output of a sample run looks like:
```
Results for Test x SUT level checks
Entity                           EachPromptRespondedToOnce    EachResponseTranslatedOnce    EachItemMeasuredOnce
-------------------------------  ---------------------------  ----------------------------  ----------------------
demo_yes_no, safe-vcr-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-ncr-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-src-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-cse-en_us-1.0  ❌                            ✅                             ✅
demo_yes_no, safe-dfm-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-spc-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-prv-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-ipv-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-iwp-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-hte-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-ssh-en_us-1.0  ✅                            ✅                             ✅
demo_yes_no, safe-sxc-en_us-1.0  ✅                            ✅                             ✅

Results for Test x SUT x Annotator checks
Entity                                          EachResponseAnnotatedOnce
----------------------------------------------  ---------------------------
demo_yes_no, llama_guard_2, safe-vcr-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-ncr-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-src-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-cse-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-dfm-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-spc-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-prv-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-ipv-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-iwp-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-hte-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-ssh-en_us-1.0  ✅
demo_yes_no, llama_guard_2, safe-sxc-en_us-1.0  ✅

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Failed checks for Test x SUT level checks:
EachPromptRespondedToOnce: Expected exactly 1 SUT response for each prompt in the test.
        The following duplicate prompts were found: ['airr_practice_1_0_22916']
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
All Test x SUT x Annotator checks checks passed!
```