### PR TITLE
Fix annotator cache bug in benchmark runner

### DIFF
--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -394,6 +394,7 @@ class TestRunAnnotationWorker(IntermediateCachingPipe):
         # Add annotator UID to key to avoid collisions.
         return f"annotator: {annotator_uid}\n {key}"
 
+
 class TestRunResultsCollector(Sink):
     def __init__(self, test_run: TestRunBase):
         super().__init__()


### PR DESCRIPTION
Note: we should come back to this and create separate caches for each annotator (and SUT?).