### PR TITLE
Fix smoke tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,6 +20,55 @@ jobs:
 
     - uses: actions/checkout@v4
 
+    - name: Vertex AI authentication
+      uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.VERTEX_AI_CREDENTIALS_JSON }}'
+
+    - name: Write secrets
+      env:
+        SECRETS_CONFIG: |
+          [anthropic]
+          api_key = "${{ secrets.ANTHROPIC_API_KEY }}"
+
+          [together]
+          api_key = "${{ secrets.TOGETHER_API_KEY }}"
+
+          [openai]
+          api_key = "${{ secrets.OPENAI_API_KEY }}"
+
+          [hugging_face]
+          token = "${{ secrets.HUGGING_FACE_TOKEN }}"
+
+          [google_ai]
+          api_key = "${{ secrets.GOOGLE_AI_API_KEY }}"
+
+          [mistralai]
+          api_key = "${{ secrets.MISTRAL_AI_API_KEY }}"
+
+          [vertexai]
+          project_id = "${{ secrets.GOOGLE_PROJECT_ID }}"
+          region = "us-central1"
+
+          [azure_phi_3_5_mini_endpoint]
+          api_key = "${{ secrets.AZURE_PHI_3_5_MINI_API_KEY }}"
+
+          [azure_phi_3_5_moe_endpoint]
+          api_key = "${{ secrets.AZURE_PHI_3_5_MOE_API_KEY }}"
+
+          [modellab_files]
+          token = "${{ secrets.MODELLAB_FILE_DOWNLOAD_TOKEN }}"
+
+          [nvidia-nim-api]
+          api_key = "${{ secrets.NVIDIA_API_KEY }}"
+
+          [demo]
+          api_key="12345"
+
+      run: |
+        mkdir -p config
+        echo "$SECRETS_CONFIG" > config/secrets.toml
+
     - name: Install poetry
       run: pipx install poetry
 
@@ -41,4 +90,3 @@ jobs:
 
     - name: Run mypy
       run: poetry run mypy --follow-imports silent --exclude modelbench src/modelgauge
-

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -4,14 +4,15 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    environment: Scheduled Testing
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -130,10 +130,10 @@ jobs:
         poetry install --no-root
         poetry run modelgauge list-tests
 
-    # - name: Discord notification
-    #   if: failure()
-    #   env:
-    #     DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-    #   uses: Ilshidur/action-discord@0.3.2
-    #   with:
-    #     args: 'The smoke test for {{ EVENT_PAYLOAD.repository.full_name }} has failed. See <{{ EVENT_PAYLOAD.repository.html_url }}/actions>'
+    - name: Discord notification
+      if: failure()
+      env:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      uses: Ilshidur/action-discord@0.3.2
+      with:
+        args: 'The smoke test for {{ EVENT_PAYLOAD.repository.full_name }} has failed. See <{{ EVENT_PAYLOAD.repository.html_url }}/actions>'

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -119,10 +119,10 @@ jobs:
         poetry install --no-root
         poetry run modelgauge list-tests
 
-    - name: Discord notification
-      if: failure()
-      env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-      uses: Ilshidur/action-discord@0.3.2
-      with:
-        args: 'The smoke test for {{ EVENT_PAYLOAD.repository.full_name }} has failed. See <{{ EVENT_PAYLOAD.repository.html_url }}/actions>'
+    # - name: Discord notification
+    #   if: failure()
+    #   env:
+    #     DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+    #   uses: Ilshidur/action-discord@0.3.2
+    #   with:
+    #     args: 'The smoke test for {{ EVENT_PAYLOAD.repository.full_name }} has failed. See <{{ EVENT_PAYLOAD.repository.html_url }}/actions>'

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -86,6 +86,9 @@ jobs:
           [azure_phi_3_5_moe_endpoint]
           api_key = ${{ secrets.AZURE_PHI_3_5_MOE_API_KEY }}
 
+          [modellab_files]
+          token = ${{ secrets.MODELLAB_FILE_DOWNLOAD_TOKEN }}
+
           [demo]
           api_key="12345"
 

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -69,12 +69,26 @@ jobs:
 
           [hugging_face]
           token = "${{ secrets.HUGGING_FACE_TOKEN }}"
-          
+
           [google_ai]
           api_key = "${{ secrets.GOOGLE_AI_API_KEY }}"
 
+          [mistralai]
+          api_key = "${{ secrets.MISTRAL_AI_API_KEY }}"
+
+          [vertexai]
+          project_id = ${{ secrets.GOOGLE_PROJECT_ID }}"
+          region = "us-central1"
+
+          [azure_phi_3_5_mini_endpoint]
+          api_key = ${{ secrets.AZURE_PHI_3_5_MINI_API_KEY }}
+
+          [azure_phi_3_5_moe_endpoint]
+          api_key = ${{ secrets.AZURE_PHI_3_5_MOE_API_KEY }}
+
           [demo]
           api_key="12345"
+
       run: |
         mkdir -p config
         echo "$SECRETS_CONFIG" > config/secrets.toml

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -55,6 +55,13 @@ jobs:
     - name: Install with plugins
       run: poetry install --no-interaction --sync --extras all_plugins
 
+
+    - name: Write Vertex AI secrets
+      run: |
+        mkdir -p ~/.local/.config/gcloud
+        echo ${{ secrets.VERTEX_AI_CREDENTIALS_JSON }} > ~/.config/gcloud/application_default_credentials.json
+        echo "GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json" >> $GITHUB_ENV
+
     - name: Write secrets
       env:
         SECRETS_CONFIG: |

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -89,6 +89,9 @@ jobs:
           [modellab_files]
           token = "${{ secrets.MODELLAB_FILE_DOWNLOAD_TOKEN }}"
 
+          [nvidia-nim-api]
+          api_key = "${{ secrets.NVIDIA_API_KEY }}"
+
           [demo]
           api_key="12345"
 

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Write Vertex AI secrets
       run: |
         mkdir -p ~/.local/.config/gcloud
-        echo ${{ secrets.VERTEX_AI_CREDENTIALS_JSON }} > ~/.config/gcloud/application_default_credentials.json
+        echo "${{ secrets.VERTEX_AI_CREDENTIALS_JSON }}" > ~/.config/gcloud/application_default_credentials.json
         echo "GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json" >> $GITHUB_ENV
 
     - name: Write secrets

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -56,11 +56,10 @@ jobs:
       run: poetry install --no-interaction --sync --extras all_plugins
 
 
-    - name: Write Vertex AI secrets
-      run: |
-        mkdir -p ~/.local/.config/gcloud
-        echo "${{ secrets.VERTEX_AI_CREDENTIALS_JSON }}" > ~/.config/gcloud/application_default_credentials.json
-        echo "GOOGLE_APPLICATION_CREDENTIALS=~/.config/gcloud/application_default_credentials.json" >> $GITHUB_ENV
+    - name: Vertex AI authentication
+      uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.VERTEX_AI_CREDENTIALS_JSON }}'
 
     - name: Write secrets
       env:

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -55,7 +55,6 @@ jobs:
     - name: Install with plugins
       run: poetry install --no-interaction --sync --extras all_plugins
 
-
     - name: Vertex AI authentication
       uses: 'google-github-actions/auth@v2'
       with:

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -77,17 +77,17 @@ jobs:
           api_key = "${{ secrets.MISTRAL_AI_API_KEY }}"
 
           [vertexai]
-          project_id = ${{ secrets.GOOGLE_PROJECT_ID }}"
+          project_id = "${{ secrets.GOOGLE_PROJECT_ID }}"
           region = "us-central1"
 
           [azure_phi_3_5_mini_endpoint]
-          api_key = ${{ secrets.AZURE_PHI_3_5_MINI_API_KEY }}
+          api_key = "${{ secrets.AZURE_PHI_3_5_MINI_API_KEY }}"
 
           [azure_phi_3_5_moe_endpoint]
-          api_key = ${{ secrets.AZURE_PHI_3_5_MOE_API_KEY }}
+          api_key = "${{ secrets.AZURE_PHI_3_5_MOE_API_KEY }}"
 
           [modellab_files]
-          token = ${{ secrets.MODELLAB_FILE_DOWNLOAD_TOKEN }}
+          token = "${{ secrets.MODELLAB_FILE_DOWNLOAD_TOKEN }}"
 
           [demo]
           api_key="12345"

--- a/plugins/validation_tests/test_object_creation.py
+++ b/plugins/validation_tests/test_object_creation.py
@@ -71,7 +71,14 @@ def test_all_suts_construct_and_record_init(sut_name):
     assert isinstance(sut.initialization_record, InitializationRecord)
 
 
-SUTS_THAT_WE_DONT_CARE_ABOUT_FAILING = {"StripedHyena-Nous-7B", "olmo-7b-0724-instruct-hf"}
+# mistral-nemo-instruct-2407-hf removed from test because of a bug in HF's date parsing code
+# https://github.com/huggingface/huggingface_hub/issues/2671
+# Remove mistral-nemo-instruct-2407-hf from this set once it's fixed.
+SUTS_THAT_WE_DONT_CARE_ABOUT_FAILING = {
+    "StripedHyena-Nous-7B",
+    "olmo-7b-0724-instruct-hf",
+    "mistral-nemo-instruct-2407-hf",
+}
 
 
 # This test can take a while, and we don't want a test run to fail

--- a/plugins/validation_tests/test_object_creation.py
+++ b/plugins/validation_tests/test_object_creation.py
@@ -20,7 +20,8 @@ from modelgauge_tests.utilities import expensive_tests
 
 # Ensure all the plugins are available during testing.
 load_plugins()
-_FAKE_SECRETS = fake_all_secrets()
+# Some tests need to download a file from modellab, which requires a real auth token
+_FAKE_SECRETS = fake_all_secrets(use_real_secrets_for=("modellab_files",))
 
 
 @pytest.mark.parametrize("test_name", [key for key, _ in TESTS.items()])

--- a/src/modelgauge/secret_values.py
+++ b/src/modelgauge/secret_values.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Generic, List, Mapping, Optional, Sequence, Type, TypeVar
+
 from modelgauge.general import get_concrete_subclasses
 from pydantic import BaseModel
-from typing import Generic, List, Mapping, Optional, Sequence, Type, TypeVar
 
 
 class SecretDescription(BaseModel):

--- a/tests/modelgauge_tests/fake_secrets.py
+++ b/tests/modelgauge_tests/fake_secrets.py
@@ -14,7 +14,10 @@ class FakeRequiredSecret(RequiredSecret):
 def fake_all_secrets(value="some-value", use_real_secrets_for: list[str] | None = None) -> RawSecrets:
     secrets = get_all_secrets()
     raw_secrets: Dict[str, Dict[str, str]] = {}
-    real_secrets = load_secrets_from_config()
+    if use_real_secrets_for:
+        real_secrets = load_secrets_from_config()
+    else:
+        real_secrets = {}
 
     for secret in secrets:
         if secret.scope not in raw_secrets:

--- a/tests/modelgauge_tests/fake_secrets.py
+++ b/tests/modelgauge_tests/fake_secrets.py
@@ -1,10 +1,8 @@
-from modelgauge.secret_values import (
-    RawSecrets,
-    RequiredSecret,
-    SecretDescription,
-    get_all_secrets,
-)
 from typing import Dict
+
+from modelgauge.config import load_secrets_from_config
+
+from modelgauge.secret_values import get_all_secrets, RawSecrets, RequiredSecret, SecretDescription
 
 
 class FakeRequiredSecret(RequiredSecret):
@@ -13,11 +11,17 @@ class FakeRequiredSecret(RequiredSecret):
         return SecretDescription(scope="some-scope", key="some-key", instructions="some-instructions")
 
 
-def fake_all_secrets(value="some-value") -> RawSecrets:
+def fake_all_secrets(value="some-value", use_real_secrets_for: list[str] | None = None) -> RawSecrets:
     secrets = get_all_secrets()
     raw_secrets: Dict[str, Dict[str, str]] = {}
+    real_secrets = load_secrets_from_config()
+
     for secret in secrets:
         if secret.scope not in raw_secrets:
             raw_secrets[secret.scope] = {}
-        raw_secrets[secret.scope][secret.key] = value
+        if use_real_secrets_for and secret.scope in use_real_secrets_for:
+            raw_secrets[secret.scope][secret.key] = real_secrets[secret.scope][secret.key]
+        else:
+            raw_secrets[secret.scope][secret.key] = value
+
     return raw_secrets


### PR DESCRIPTION
# Wins

* Fix missing credentials
* Add Google authentication for Vertex AI
* Temporarily disable a SUT on Huggingface until the HF client can handle its own API's datetime fields 🙄 
* Add an option for fake secrets to use specified real secrets in case they are needed for some steps (in this case, downloading a prompt file from modellab, which requires an auth token)

# Fails

I tried to extract the credential/secret logic into a dependent workflow so it could be shared between the app test and smoke test workflows. That didn't work because:

* a secrets.toml file created in the runner file system in the dependent workflow doesn't get preserved when the caller workflow runs
* the canonical way to share files between workflows is to upload them as artifacts. I didn't want to do with secrets.toml because it's full of secrets, and I couldn't find enough information about artifact ACLs to be comfortable uploading it as an artifact.
* setting the contents of the secrets.toml file as an output of the dependent job does not work, because github actions helpfully strip out outputs that include secrets.

So I just C&P'ed the secrets section into a second workflow, like a neanderthal.
 
