### PR TITLE
More consistency checks + improvements

### DIFF
--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -287,7 +287,8 @@ class AnnotationsMergedCorrectly(JournalCheck):
 
     def failure_message(self) -> str:
         assert not self.check()
-        message = f"Expected that measure_item_quality returns majority vote for each prompt. SUT {self.sut}/test {self.test} have mismatching values on the following prompts:"
+        total = len(self.prompt_measurements)
+        message = f"({total-len(self.prompt_errors)}/{total})\nExpected that measure_item_quality returns majority vote for each prompt. SUT {self.sut}/test {self.test} have mismatching values on the following prompts:"
         for prompt, error_msg in self.prompt_errors.items():
             message += f"\n\tPrompt {prompt}: {error_msg}"
         return message

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -414,7 +414,7 @@ class ConsistencyChecker:
             results_table = []
             for entity, checks in checker.results.items():
                 results_table.append([entity] + [self.format_result(checks[c]) for c in checker.check_names])
-            print(tabulate(results_table, headers=[", ".join(checker.entity_names)] + list(checker.check_names)))
+            print(tabulate(results_table, headers=[", ".join(checker.entity_names)] + list(checker.check_names), tablefmt="simple_outline"))
             print()
 
     def display_warnings(self):
@@ -440,4 +440,4 @@ def summarize_consistency_check_results(checkers: List[ConsistencyChecker]):
             result = "INCOMPLETE"
         summary_table.append([checker.journal_path, result])
 
-    print(tabulate(summary_table, headers=["Journal", "All checks passed"]))
+    print(tabulate(summary_table, headers=["Journal", "All checks passed"], tablefmt="simple_outline"))

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -1,3 +1,4 @@
+import casefy
 import json
 import shutil
 from abc import ABC, abstractmethod
@@ -327,7 +328,7 @@ class JournalEntityLevelCheck:
 
     @staticmethod
     def _col_name(check_cls) -> str:
-        return check_cls.__name__
+        return casefy.titlecase(check_cls.__name__)
 
     def check_is_complete(self) -> bool:
         """Make sure table is fully populated."""
@@ -431,7 +432,7 @@ class ConsistencyChecker:
                     )
 
     @staticmethod
-    def format_result(result: bool):
+    def format_result(result: bool) -> str:
         return "✅" if result else "❌"
 
     def checks_are_complete(self) -> bool:
@@ -458,7 +459,7 @@ class ConsistencyChecker:
             print(
                 tabulate(
                     results_table,
-                    headers=[", ".join(checker.entity_names)] + list(checker.check_names),
+                    headers=[", ".join(checker.entity_names)] + checker.check_names,
                     tablefmt="simple_outline",
                 )
             )

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -210,6 +210,7 @@ class EachAnnotationTranslatedOnce(OneToOneCheck):
 
 class MinValidAnnotatorItems(JournalCheck):
     """There should be < some threshold rate of invalid items for each annotator/sut/test combination."""
+
     INVALID_THRESHOLD = 0.03
 
     def __init__(self, search_engine: JournalSearch, sut, test, annotator):

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -462,9 +462,11 @@ class ConsistencyChecker:
             for check in checker.check_names:
                 table.add_column(check, max_width=20, justify="center")
             # Format rows
-            for entity, checks in checker.results.items():
-                row_results = [self.format_result(checks[c]) for c in checker.check_names]
-                table.add_row(entity, *row_results)
+            sorted_row_names = sorted(checker.row_names)
+            for entity in sorted_row_names:
+                entity_results = checker.results[entity]
+                entity_results_list = [self.format_result(entity_results[c]) for c in checker.check_names]
+                table.add_row(entity, *entity_results_list)
 
             console = Console()
             console.print(table)

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -209,7 +209,8 @@ class EachAnnotationTranslatedOnce(OneToOneCheck):
 
 
 class MinValidAnnotatorItems(JournalCheck):
-    """There should be < 3% rate of invalid items for each annotator/sut/test combination."""
+    """There should be < some threshold rate of invalid items for each annotator/sut/test combination."""
+    INVALID_THRESHOLD = 0.03
 
     def __init__(self, search_engine: JournalSearch, sut, test, annotator):
         self.sut = sut
@@ -223,11 +224,11 @@ class MinValidAnnotatorItems(JournalCheck):
         self.num_invalid_annotations = len(invalid_annotations)
 
     def check(self) -> bool:
-        return float(self.num_invalid_annotations) / self.num_translated_annotations < 0.03
+        return float(self.num_invalid_annotations) / self.num_translated_annotations < self.INVALID_THRESHOLD
 
     def failure_message(self) -> str:
         assert not self.check()
-        return f"Expected less than 3% invalid annotations for annotator {self.annotator} in SUT {self.sut} for test {self.test}. Found {self.num_invalid_annotations} invalid annotations out of {self.num_translated_annotations} total."
+        return f"Expected less than {self.INVALID_THRESHOLD * 100}% invalid annotations for annotator {self.annotator} in SUT {self.sut} for test {self.test}. Found {self.num_invalid_annotations} invalid annotations out of {self.num_translated_annotations} total."
 
 
 class AnnotationsMergedCorrectly(JournalCheck):

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -156,7 +156,9 @@ class NumItemsFinishedEqualsMeasuredItems(JournalCheck):
         measured_item_entries = search_engine.query("measured item quality", sut=sut, test=test)
         self.num_measured_items = len(measured_item_entries)
         test_scored_entries = search_engine.query("test scored", sut=sut, test=test)
-        assert len(test_scored_entries) == 1, f"Expected 1 `test scored` entry per test/sut, found {len(test_scored_entries)} for test {test} and sut {sut}."
+        assert (
+            len(test_scored_entries) == 1
+        ), f"Expected 1 `test scored` entry per test/sut, found {len(test_scored_entries)} for test {test} and sut {sut}."
         self.finished_count = test_scored_entries[0]["items_finished"]
 
     def check(self) -> bool:
@@ -214,7 +216,9 @@ class MinValidAnnotatorItems(JournalCheck):
         self.test = test
         self.annotator = annotator
         translated_annotations = search_engine.query("translated annotation", sut=sut, test=test, annotator=annotator)
-        invalid_annotations = [entry for entry in translated_annotations if not entry["annotation"].get("is_valid", True)]
+        invalid_annotations = [
+            entry for entry in translated_annotations if not entry["annotation"].get("is_valid", True)
+        ]
         self.num_translated_annotations = len(translated_annotations)
         self.num_invalid_annotations = len(invalid_annotations)
 
@@ -256,7 +260,9 @@ class AnnotationsMergedCorrectly(JournalCheck):
 
     def _check_prompt(self, prompt):
         vote_counts = Counter(self.prompt_annotations[prompt])
-        assert set(vote_counts.keys()).issubset({True, False}), "Incompatible annotation values found. Expected only True/False."
+        assert set(vote_counts.keys()).issubset(
+            {True, False}
+        ), "Incompatible annotation values found. Expected only True/False."
 
         if len(self.prompt_annotations[prompt]) < 2:
             # Automatically "unsafe" if there are less than 2 annotations.
@@ -354,7 +360,14 @@ class ConsistencyChecker:
         # Checks to run at each level.
         self.test_sut_level_checker = JournalEntityLevelCheck(
             "Test x SUT level checks",
-            [EachPromptQueuedOnce, EachPromptRespondedToOnce, EachResponseTranslatedOnce, EachItemMeasuredOnce, NumItemsFinishedEqualsMeasuredItems, AnnotationsMergedCorrectly],
+            [
+                EachPromptQueuedOnce,
+                EachPromptRespondedToOnce,
+                EachResponseTranslatedOnce,
+                EachItemMeasuredOnce,
+                NumItemsFinishedEqualsMeasuredItems,
+                AnnotationsMergedCorrectly,
+            ],
             tests=self.tests,
             suts=self.suts,
         )
@@ -387,9 +400,15 @@ class ConsistencyChecker:
         except Exception as e:
             # Can't load test object, get annotators from journal instead.
             print("Failed to load test object. Collecting annotator UIDs to check from journal instead.")
-            fetched_annotator_entries = search_engine.query("fetched annotator response", test=self.tests[0], sut=self.suts[0])
-            cached_annotator_entries = search_engine.query("using cached annotator response", test=self.tests[0], sut=self.suts[0])
-            self.annotators = list(set([entry["annotator"] for entry in fetched_annotator_entries + cached_annotator_entries]))
+            fetched_annotator_entries = search_engine.query(
+                "fetched annotator response", test=self.tests[0], sut=self.suts[0]
+            )
+            cached_annotator_entries = search_engine.query(
+                "using cached annotator response", test=self.tests[0], sut=self.suts[0]
+            )
+            self.annotators = list(
+                set([entry["annotator"] for entry in fetched_annotator_entries + cached_annotator_entries])
+            )
 
     def run(self, verbose=False):
         self._collect_results()
@@ -434,7 +453,13 @@ class ConsistencyChecker:
             results_table = []
             for entity, checks in checker.results.items():
                 results_table.append([entity] + [self.format_result(checks[c]) for c in checker.check_names])
-            print(tabulate(results_table, headers=[", ".join(checker.entity_names)] + list(checker.check_names), tablefmt="simple_outline"))
+            print(
+                tabulate(
+                    results_table,
+                    headers=[", ".join(checker.entity_names)] + list(checker.check_names),
+                    tablefmt="simple_outline",
+                )
+            )
             print()
 
     def display_warnings(self):

--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -325,11 +325,12 @@ class ConsistencyChecker:
 
 def summarize_consistency_check_results(checkers: List[ConsistencyChecker]):
     """Print a table summarizing the overall pass/fail results for multiple consistency checks."""
-    for checker in checkers:
-        assert checker.checks_are_complete(), "Cannot summarize results until all checks have been run."
-
     summary_table = []
     for checker in checkers:
-        summary_table.append([checker.journal_path, ConsistencyChecker.format_result(checker.checks_all_passed())])
+        if checker.checks_are_complete():
+            result = ConsistencyChecker.format_result(checker.checks_all_passed())
+        else:
+            result = "INCOMPLETE"
+        summary_table.append([checker.journal_path, result])
 
     print(tabulate(summary_table, headers=["Journal", "All checks passed"]))

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -154,7 +154,12 @@ def benchmark(
 
 
 @cli.command(help="check the consistency of a benchmark run using it's record and journal files.")
-@click.option("--journal-path", "-j", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
+@click.option(
+    "--journal-path",
+    "-j",
+    type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
+    required=True,
+)
 # @click.option("--record-path", "-r", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
 @click.option("--verbose", "-v", default=False, is_flag=True, help="Print details about the failed checks.")
 def consistency_check(journal_path, verbose):

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -175,9 +175,11 @@ def consistency_check(journal_path, verbose):
     else:
         journal_paths = [journal_path]
     for p in journal_paths:
-        print("Checking consistency of journal", p)
+        echo(termcolor.colored(f"\nChecking consistency of journal {p} ..........", "green"))
         checker = ConsistencyChecker(p)
         checker.run(verbose)
+    if len(journal_paths) > 1:
+        echo(termcolor.colored("\nSummary of consistency checks for all journals:", "green"))
 
 
 def find_suts_for_sut_argument(sut_args: List[str]):

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -176,16 +176,25 @@ def consistency_check(journal_path, verbose):
         journal_paths = [journal_path]
 
     checkers = []
+    checking_error_journals = []
     for p in journal_paths:
         echo(termcolor.colored(f"\nChecking consistency of journal {p} ..........", "green"))
-        checker = ConsistencyChecker(p)
-        checkers.append(checker)
-        checker.run(verbose)
+        try:
+            checker = ConsistencyChecker(p)
+            checker.run(verbose)
+            checkers.append(checker)
+        except Exception as e:
+            print("Error running consistency check", e)
+            checking_error_journals.append(p)
 
-    # Summarize results if there is more than one journal.
-    if len(journal_paths) > 1:
+    # Summarize results and unsuccessful checks.
+    if len(checkers) > 1:
         echo(termcolor.colored("\nSummary of consistency checks for all journals:", "green"))
         summarize_consistency_check_results(checkers)
+    if len(checking_error_journals) > 0:
+        echo(termcolor.colored(f"\nCould not run checks on the following journals:", "red"))
+        for j in checking_error_journals:
+            print("\t", j)
 
 
 def find_suts_for_sut_argument(sut_args: List[str]):

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -153,14 +153,10 @@ def benchmark(
         # TODO: Consistency check
 
 
-@cli.command(help="check the consistency of a benchmark run using it's record and journal files.")
-@click.option(
-    "--journal-path",
-    "-j",
-    type=click.Path(exists=True, dir_okay=True, path_type=pathlib.Path),
-    help="Path to the journal file OR a directory containing journal files (will be searched recursively).",
-    required=True,
+@cli.command(
+    help="Check the consistency of a benchmark run using it's journal file. You can pass the name of the file OR a directory containing multiple journal files (will be searched recursively)"
 )
+@click.argument("journal-path", type=click.Path(exists=True, dir_okay=True, path_type=pathlib.Path))
 # @click.option("--record-path", "-r", type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path))
 @click.option("--verbose", "-v", default=False, is_flag=True, help="Print details about the failed checks.")
 def consistency_check(journal_path, verbose):

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -171,7 +171,9 @@ def consistency_check(journal_path, verbose):
             if p.name.startswith("journal-run") and (p.suffix == ".jsonl" or p.suffix == ".zst"):
                 journal_paths.append(p)
         if len(journal_paths) == 0:
-            raise click.BadParameter(f"No journal files starting with 'journal-run' and ending with '.jsonl' or '.zst' found in the directory '{journal_path}'.")
+            raise click.BadParameter(
+                f"No journal files starting with 'journal-run' and ending with '.jsonl' or '.zst' found in the directory '{journal_path}'."
+            )
     else:
         journal_paths = [journal_path]
 

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner, Result
 from typing import Dict, List
 
 from modelbench import run
-from modelbench.consistency_checker import ConsistencyChecker, summarize_consistency_check_results
+from modelbench.consistency_checker import ConsistencyChecker
 
 
 def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotators: List[str]):

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -124,3 +124,36 @@ def test_run_with_extra_sut_stuff(tmp_path, basic_benchmark_run, extra_message, 
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
+
+
+def _manually_set_results_to_pass(sub_checker):
+    for row_key in sub_checker.results:
+        for col_key in sub_checker.check_names:
+            sub_checker.results[row_key][col_key] = True
+
+
+def test_empty_run_is_not_complete(tmp_path, basic_benchmark_run):
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
+    assert checker.checks_are_complete() is False
+
+
+def test_partial_run_is_not_complete(tmp_path, basic_benchmark_run):
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
+    # Manually set results for only one sub-checker.
+    _manually_set_results_to_pass(checker.test_sut_level_checker)
+
+    assert checker.checks_are_complete() is False
+
+
+def test_finished_run_is_complete(tmp_path, basic_benchmark_run):
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
+    # Manually set results for all sub-checkers.
+    for sub_checker in checker._check_groups:
+        _manually_set_results_to_pass(sub_checker)
+
+    assert checker.checks_are_complete()
+
+
+def test_summarize_multiple_journal_checks():
+    # TODO.
+    pass

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -241,6 +241,7 @@ def test_run_with_extra_annotator_stuff(tmp_path, basic_benchmark_run, extra_mes
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
 
+# TODO: Add tests for AnnotationsMergedCorrectly checker.
 
 def _manually_set_results_to_pass(sub_checker):
     for row_key in sub_checker.results:

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -329,7 +329,7 @@ def test_summarize_multiple_journal_checks(tmp_path, basic_benchmark_run):
     journal2_path = tmp_path / "journal-run-2.jsonl"
     write_journal_to_file(basic_benchmark_run, journal2_path)
 
-    result = run_cli("consistency-check", "-j", str(tmp_path))
+    result = run_cli("consistency-check", str(tmp_path))
 
     assert result.exit_code == 0
     # Check that both journal checks are marked as "passed" in the summary.
@@ -347,7 +347,7 @@ def test_summarize_multiple_journal_checks_with_fails(tmp_path, basic_benchmark_
     journal2_path = tmp_path / "journal-run-2.jsonl"
     write_journal_to_file(basic_benchmark_run, journal2_path)
 
-    result = run_cli("consistency-check", "-j", str(tmp_path))
+    result = run_cli("consistency-check", str(tmp_path))
 
     assert result.exit_code == 0
     assert journal_result_is_expected_in_summary(journal1_path, True, result.output)

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -37,6 +37,7 @@ def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotato
                                 "annotator": annotator,
                             }
                         )
+            journal.append({"message": "test scored", "test": test, "sut": sut, "items_finished": len(prompts)})
     return journal
 
 
@@ -152,6 +153,7 @@ def test_run_with_missing_queued_item_for_sut(tmp_path, basic_benchmark_run):
         ("fetched sut response", "EachPromptRespondedToOnce"),
         ("translated sut response", "EachResponseTranslatedOnce"),
         ("measured item quality", "EachItemMeasuredOnce"),
+        ("measured item quality", "NumItemsFinishedEqualsMeasuredItems"),
     ],
 )
 def test_run_with_extra_sut_stuff(tmp_path, basic_benchmark_run, extra_message, failed_check):

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -7,36 +7,50 @@ from typing import Dict, List
 from modelbench import run
 from modelbench.consistency_checker import ConsistencyChecker
 
+DEFAULT_SUT = "sut1"
+DEFAULT_TEST = "test1"
+DEFAULT_ANNOTATOR = "annotator1"
+
+
+def make_sut_entry(message, test=DEFAULT_TEST, sut=DEFAULT_SUT, prompt_id="prompt1", annotator=DEFAULT_ANNOTATOR, measurements_is_safe=1.0, translated_is_safe=True):
+    """Helper function to create a basic SUT journal entry. Not all args will be used depending on the messge."""
+    # SUT messages
+    base_sut_entry = {"test": test, "sut": sut, "prompt_id": prompt_id}
+    if message in ["queuing item", "fetched sut response", "using cached sut response", "translated sut response"]:
+        # Basic SUT journal entries that share the same shape.
+        return {"message": message, **base_sut_entry}
+    if message == "measured item quality":
+        return {"message": message, "measurements": {"is_safe": measurements_is_safe}, **base_sut_entry}
+
+    # SUT + Annotator messages
+    base_annotator_entry = {"annotator": annotator, **base_sut_entry}
+    if message in ["fetched annotator response", "using cached annotator response"]:
+        # Basic annotator journal entries that share the same shape.
+        return {"message": message, **base_annotator_entry}
+    if message == "translated annotation":
+        return {"message": message, "annotation": {"is_safe": translated_is_safe}, **base_annotator_entry}
+
+    raise ValueError(f"Can't make SUT entry for message: {message}")
+
 
 def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotators: List[str]):
-    """Successful "fresh" benchmark run with all SUT/annotator responses fetched (not cached)."""
+    """Successful "fresh" benchmark run with all SUT/annotator responses fetched (not cached).
+    Measurements/annotations are all safe."""
+
     journal = []
     journal.append({"message": "starting run", "suts": suts, "tests": list(test_prompts.keys())})
     for sut in suts:
         for test, prompts in test_prompts.items():
             journal.append({"message": "using test items", "test": test, "using": len(prompts)})
             for prompt in prompts:
-                # Normal pipeline.
-                sut_messages = [
-                    "queuing item",
-                    "fetched sut response",
-                    "translated sut response",
-                    "measured item quality",
-                ]
-                for message in sut_messages:
-                    journal.append({"message": message, "test": test, "prompt_id": prompt, "sut": sut})
+                # Normal SUT pipeline.
+                base_sut_entry = {"test": test, "sut": sut, "prompt_id": prompt}
+                for message in ["queuing item", "fetched sut response", "translated sut response", "measured item quality"]:
+                    journal.append(make_sut_entry(message, **base_sut_entry))
+                # Annotator pipeline.
                 for annotator in annotators:
-                    annotator_messages = ["fetched annotator response", "translated annotation"]
-                    for message in annotator_messages:
-                        journal.append(
-                            {
-                                "message": message,
-                                "test": test,
-                                "sut": sut,
-                                "prompt_id": prompt,
-                                "annotator": annotator,
-                            }
-                        )
+                    for message in ["fetched annotator response", "translated annotation"]:
+                        journal.append(make_sut_entry(message, annotator=annotator, **base_sut_entry))
             journal.append({"message": "test scored", "test": test, "sut": sut, "items_finished": len(prompts)})
     return journal
 
@@ -44,7 +58,7 @@ def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotato
 @pytest.fixture
 def basic_benchmark_run():
     return make_basic_run(
-        suts=["sut1", "sut2"], test_prompts={"test1": ["prompt1", "prompt2"]}, annotators=["annotator1", "annotator2"]
+        suts=["sut1", "sut2"], test_prompts={"test1": ["prompt1", "prompt2"]}, annotators=["annotator1", "annotator2", "annotator3"]
     )
 
 
@@ -77,15 +91,16 @@ def test_entities_collected(tmp_path, basic_benchmark_run):
 
     assert sorted(checker.suts) == sorted(["sut1", "sut2"])
     assert checker.tests == ["test1"]
-    assert sorted(checker.annotators) == sorted(["annotator1", "annotator2"])
+    assert sorted(checker.annotators) == sorted(["annotator1", "annotator2", "annotator3"])
 
 
 def test_cached_and_fetched_only_annotators_also_collected(tmp_path, basic_benchmark_run):
-    basic_benchmark_run.append({"message": "fetched annotator response", "test": "test1", "sut": "sut1", "prompt_id": "prompt1", "annotator": "annotator3"})
-    basic_benchmark_run.append({"message": "using cached annotator response", "test": "test1", "sut": "sut1", "prompt_id": "prompt1", "annotator": "annotator4"})
+    basic_benchmark_run.append(make_sut_entry("fetched annotator response", annotator="annotator4"))
+    basic_benchmark_run.append(make_sut_entry("using cached annotator response", annotator="annotator5"))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
 
-    assert sorted(checker.annotators) == sorted(["annotator1", "annotator2", "annotator3", "annotator4"])
+    assert "annotator4" in checker.annotators
+    assert "annotator5" in checker.annotators
 
 
 @pytest.mark.parametrize(
@@ -99,12 +114,12 @@ def test_cached_and_fetched_only_annotators_also_collected(tmp_path, basic_bench
     ],
 )
 def test_run_with_duplicate_sut_stuff(tmp_path, basic_benchmark_run, duplicate_message, failed_check):
-    basic_benchmark_run.append({"message": duplicate_message, "test": "test1", "sut": "sut1", "prompt_id": "prompt1"})
+    basic_benchmark_run.append(make_sut_entry(duplicate_message))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
@@ -119,14 +134,12 @@ def test_run_with_duplicate_sut_stuff(tmp_path, basic_benchmark_run, duplicate_m
     ],
 )
 def test_run_with_missing_sut_stuff(tmp_path, basic_benchmark_run, extra_earlier_message, failed_check):
-    basic_benchmark_run.append(
-        {"message": extra_earlier_message, "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT"}
-    )
+    basic_benchmark_run.append(make_sut_entry(extra_earlier_message, prompt_id="NEW PROMPT"))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
@@ -134,14 +147,12 @@ def test_run_with_missing_sut_stuff(tmp_path, basic_benchmark_run, extra_earlier
 
 def test_run_with_missing_queued_item_for_sut(tmp_path, basic_benchmark_run):
     # Add extra test item by adding an entry for another sut.
-    basic_benchmark_run.append(
-        {"message": "queuing item", "test": "test1", "sut": "another_sut", "prompt_id": "NEW PROMPT"}
-    )
+    basic_benchmark_run.append(make_sut_entry("queuing item", sut="another_sut", prompt_id="NEW PROMPT"))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row]["EachPromptQueuedOnce"] is False
     # TODO: Check warnings
@@ -157,12 +168,12 @@ def test_run_with_missing_queued_item_for_sut(tmp_path, basic_benchmark_run):
     ],
 )
 def test_run_with_extra_sut_stuff(tmp_path, basic_benchmark_run, extra_message, failed_check):
-    basic_benchmark_run.append({"message": extra_message, "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT"})
+    basic_benchmark_run.append(make_sut_entry(extra_message, prompt_id="NEW PROMPT"))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
@@ -177,26 +188,24 @@ def test_run_with_extra_sut_stuff(tmp_path, basic_benchmark_run, extra_message, 
     ],
 )
 def test_run_with_duplicate_annotator_stuff(tmp_path, basic_benchmark_run, duplicate_message, failed_check):
-    basic_benchmark_run.append({"message": duplicate_message, "test": "test1", "sut": "sut1", "prompt_id": "prompt1", "annotator": "annotator1"})
+    basic_benchmark_run.append(make_sut_entry(duplicate_message))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_annotator_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1", annotator="annotator1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST, annotator=DEFAULT_ANNOTATOR)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
 
 
 def test_run_with_missing_annotations(tmp_path, basic_benchmark_run):
-    basic_benchmark_run.append(
-        {"message": "translated sut response", "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT"}
-    )
+    basic_benchmark_run.append(make_sut_entry("translated sut response", prompt_id="NEW PROMPT"))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_annotator_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1", annotator="annotator1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST, annotator=DEFAULT_ANNOTATOR)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row]["EachResponseAnnotatedOnce"] is False
     # TODO: Check warnings
@@ -210,17 +219,16 @@ def test_run_with_missing_annotations(tmp_path, basic_benchmark_run):
     ],
 )
 def test_run_with_missing_annotator_translations(tmp_path, basic_benchmark_run, extra_earlier_message, failed_check):
-    basic_benchmark_run.append(
-        {"message": extra_earlier_message, "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT", "annotator": "annotator1"}
-    )
+    basic_benchmark_run.append(make_sut_entry(extra_earlier_message, prompt_id="NEW PROMPT"))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_annotator_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1", annotator="annotator1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST, annotator=DEFAULT_ANNOTATOR)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
+
 
 @pytest.mark.parametrize(
     "extra_message,failed_check",
@@ -231,17 +239,18 @@ def test_run_with_missing_annotator_translations(tmp_path, basic_benchmark_run, 
     ],
 )
 def test_run_with_extra_annotator_stuff(tmp_path, basic_benchmark_run, extra_message, failed_check):
-    basic_benchmark_run.append({"message": extra_message, "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT", "annotator": "annotator1"})
+    basic_benchmark_run.append(make_sut_entry(extra_message, prompt_id="NEW PROMPT"))
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 
     subchecker = checker.test_sut_annotator_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1", annotator="annotator1")
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST, annotator=DEFAULT_ANNOTATOR)
     assert subchecker.check_is_complete()
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
 
 # TODO: Add tests for AnnotationsMergedCorrectly checker.
+
 
 def _manually_set_results_to_pass(sub_checker):
     for row_key in sub_checker.results:
@@ -277,6 +286,11 @@ def run_cli(*args) -> Result:
     return result
 
 
+def journal_result_is_expected_in_summary(journal_path, expected_result, output):
+    f_result = ConsistencyChecker.format_result(expected_result)
+    return re.search(rf"{re.escape(str(journal_path))}\s*.*\s*{f_result}", output)
+
+
 def test_summarize_multiple_journal_checks(tmp_path, basic_benchmark_run):
     journal1_path = tmp_path / "journal-run-1.jsonl"
     write_journal_to_file(basic_benchmark_run, journal1_path)
@@ -287,9 +301,8 @@ def test_summarize_multiple_journal_checks(tmp_path, basic_benchmark_run):
 
     assert result.exit_code == 0
     # Check that both journal checks are marked as "passed" in the summary.
-    PASS = ConsistencyChecker.format_result(True)
-    assert re.search(rf"{journal1_path}\s+{PASS}", result.output)
-    assert re.search(rf"{journal2_path}\s+{PASS}", result.output)
+    assert journal_result_is_expected_in_summary(journal1_path, True, result.output)
+    assert journal_result_is_expected_in_summary(journal2_path, True, result.output)
 
 
 def test_summarize_multiple_journal_checks_with_fails(tmp_path, basic_benchmark_run):
@@ -303,8 +316,5 @@ def test_summarize_multiple_journal_checks_with_fails(tmp_path, basic_benchmark_
     result = run_cli("consistency-check", "-j", str(tmp_path))
 
     assert result.exit_code == 0
-    # Check that both journal checks are marked as "passed" in the summary.
-    PASS = ConsistencyChecker.format_result(True)
-    FAIL = ConsistencyChecker.format_result(False)
-    assert re.search(rf"{journal1_path}\s+{PASS}", result.output)
-    assert re.search(rf"{journal2_path}\s+{FAIL}", result.output)
+    assert journal_result_is_expected_in_summary(journal1_path, True, result.output)
+    assert journal_result_is_expected_in_summary(journal2_path, False, result.output)

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -252,6 +252,22 @@ def test_run_with_extra_annotator_stuff(tmp_path, basic_benchmark_run, extra_mes
 # TODO: Add tests for AnnotationsMergedCorrectly checker.
 
 
+@pytest.mark.parametrize("is_safe", [True, False])
+def test_min_valid_items_checker(tmp_path, basic_benchmark_run, is_safe):
+    # Add some invalid translated annotations for one annotator.
+    entry = make_sut_entry("translated annotation", prompt_id="NEW PROMPT", translated_is_safe=is_safe)
+    entry["annotation"]["is_valid"] = False
+    basic_benchmark_run.append(entry)
+    checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
+    checker.run()
+
+    subchecker = checker.test_sut_annotator_level_checker
+    failed_row = subchecker._row_key(sut=DEFAULT_SUT, test=DEFAULT_TEST, annotator=DEFAULT_ANNOTATOR)
+    assert subchecker.check_is_complete()
+    assert subchecker.results[failed_row]["MinValidAnnotatorItems"] is False
+    # TODO: Check warnings
+
+
 def _manually_set_results_to_pass(sub_checker):
     for row_key in sub_checker.results:
         for col_key in sub_checker.check_names:

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -56,7 +56,7 @@ def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotato
     Measurements/annotations are all safe."""
 
     journal = []
-    journal.append({"message": "starting run", "suts": suts, "tests": list(test_prompts.keys())})
+    journal.append({"message": "starting run", "suts": suts, "tests": list(test_prompts.keys()), "benchmarks": ["official"]})
     for sut in suts:
         for test, prompts in test_prompts.items():
             journal.append({"message": "using test items", "test": test, "using": len(prompts)})

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -12,7 +12,15 @@ DEFAULT_TEST = "test1"
 DEFAULT_ANNOTATOR = "annotator1"
 
 
-def make_sut_entry(message, test=DEFAULT_TEST, sut=DEFAULT_SUT, prompt_id="prompt1", annotator=DEFAULT_ANNOTATOR, measurements_is_safe=1.0, translated_is_safe=True):
+def make_sut_entry(
+    message,
+    test=DEFAULT_TEST,
+    sut=DEFAULT_SUT,
+    prompt_id="prompt1",
+    annotator=DEFAULT_ANNOTATOR,
+    measurements_is_safe=1.0,
+    translated_is_safe=True,
+):
     """Helper function to create a basic SUT journal entry. Not all args will be used depending on the messge."""
     # SUT messages
     base_sut_entry = {"test": test, "sut": sut, "prompt_id": prompt_id}
@@ -45,7 +53,12 @@ def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotato
             for prompt in prompts:
                 # Normal SUT pipeline.
                 base_sut_entry = {"test": test, "sut": sut, "prompt_id": prompt}
-                for message in ["queuing item", "fetched sut response", "translated sut response", "measured item quality"]:
+                for message in [
+                    "queuing item",
+                    "fetched sut response",
+                    "translated sut response",
+                    "measured item quality",
+                ]:
                     journal.append(make_sut_entry(message, **base_sut_entry))
                 # Annotator pipeline.
                 for annotator in annotators:
@@ -58,7 +71,9 @@ def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotato
 @pytest.fixture
 def basic_benchmark_run():
     return make_basic_run(
-        suts=["sut1", "sut2"], test_prompts={"test1": ["prompt1", "prompt2"]}, annotators=["annotator1", "annotator2", "annotator3"]
+        suts=["sut1", "sut2"],
+        test_prompts={"test1": ["prompt1", "prompt2"]},
+        annotators=["annotator1", "annotator2", "annotator3"],
     )
 
 
@@ -249,6 +264,7 @@ def test_run_with_extra_annotator_stuff(tmp_path, basic_benchmark_run, extra_mes
     assert subchecker.results[failed_row][failed_check] is False
     # TODO: Check warnings
 
+
 # TODO: Add tests for AnnotationsMergedCorrectly checker.
 
 
@@ -325,7 +341,9 @@ def test_summarize_multiple_journal_checks_with_fails(tmp_path, basic_benchmark_
     journal1_path = tmp_path / "journal-run-1.jsonl"
     write_journal_to_file(basic_benchmark_run, journal1_path)
     # Second journal should fail checks.
-    basic_benchmark_run.append({"message": "fetched sut response", "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT"})
+    basic_benchmark_run.append(
+        {"message": "fetched sut response", "test": "test1", "sut": "sut1", "prompt_id": "NEW PROMPT"}
+    )
     journal2_path = tmp_path / "journal-run-2.jsonl"
     write_journal_to_file(basic_benchmark_run, journal2_path)
 

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -104,9 +104,9 @@ def test_normal_run(tmp_path, basic_benchmark_run):
 def test_entities_collected(tmp_path, basic_benchmark_run):
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
 
-    assert sorted(checker.suts) == sorted(["sut1", "sut2"])
+    assert sorted(checker.suts) == ["sut1", "sut2"]
     assert checker.tests == ["test1"]
-    assert sorted(checker.annotators) == sorted(["annotator1", "annotator2", "annotator3"])
+    assert sorted(checker.annotators) == ["annotator1", "annotator2", "annotator3"]
 
 
 def test_cached_and_fetched_only_annotators_also_collected(tmp_path, basic_benchmark_run):

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -56,7 +56,9 @@ def make_basic_run(suts: List[str], test_prompts: Dict[str, List[str]], annotato
     Measurements/annotations are all safe."""
 
     journal = []
-    journal.append({"message": "starting run", "suts": suts, "tests": list(test_prompts.keys()), "benchmarks": ["official"]})
+    journal.append(
+        {"message": "starting run", "suts": suts, "tests": list(test_prompts.keys()), "benchmarks": ["official"]}
+    )
     for sut in suts:
         for test, prompts in test_prompts.items():
             journal.append({"message": "using test items", "test": test, "using": len(prompts)})
@@ -337,7 +339,9 @@ def test_annotations_merged_correctly_false_unsafe(tmp_path, basic_benchmark_run
     for _ in range(4):
         basic_benchmark_run.append(entry)
     # Measure that prompt as unsafe (wrongly).
-    basic_benchmark_run.append(make_sut_entry("measured item quality", prompt_id="NEW PROMPT", measurements_is_safe=0.0))
+    basic_benchmark_run.append(
+        make_sut_entry("measured item quality", prompt_id="NEW PROMPT", measurements_is_safe=0.0)
+    )
     checker = init_checker_for_journal(tmp_path, basic_benchmark_run)
     checker.run()
 

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -1,10 +1,11 @@
 import csv
-import jsonlines
 import re
+from unittest.mock import patch
+
+import jsonlines
 
 import pytest
 from click.testing import CliRunner, Result
-from unittest.mock import patch
 
 from modelgauge import main
 from modelgauge.prompt import SUTOptions
@@ -126,15 +127,14 @@ def test_run_prompts_normal(tmp_path):
     with open(tmp_path / out_path, "r") as f:
         reader = csv.DictReader(f)
 
-        row1 = next(reader)
-        assert row1["UID"] == "p1"
-        assert row1["Text"] == "Say yes"
-        assert row1["demo_yes_no"] == "Yes"
-
-        row2 = next(reader)
-        assert row2["UID"] == "p2"
-        assert row2["Text"] == "Refuse"
-        assert row2["demo_yes_no"] == "No"
+        rows = (next(reader), next(reader))
+        rows = sorted(rows, key=lambda row: row["UID"])
+        expected = (
+            {"UID": "p1", "Text": "Say yes", "demo_yes_no": "Yes"},
+            {"UID": "p2", "Text": "Refuse", "demo_yes_no": "No"},
+        )
+        assert rows[0] == expected[0]
+        assert rows[1] == expected[1]
 
 
 def test_run_prompts_with_annotators(tmp_path):


### PR DESCRIPTION
Summary of changes:

- CLI 'consistency-check` command accepts path to journal file *or* directory which will be recursively searched for journal files, all of which will be checked.
- If multiple journals are checked, a summary table will be printed at the end.
  ![Screenshot 2024-11-27 at 12 31 16 PM](https://github.com/user-attachments/assets/5ebf7c1f-3ed0-49f0-ac54-9966d695dd6a)
- Checker objects don't hold memory intensive journal-querying object anymore. This was prohibitive for running checks on multiple large journals.
- To improve robustness, try to get a test's annotator set directly from the test. If that doesn't work (e.g. don't have the right secrets), then get the annotator set from the journals annotator-related entries.
- More tests
- More checks