### PR TITLE
ensure the CLI tool's output order is deterministic

### DIFF
--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -1,10 +1,11 @@
 import csv
-import jsonlines
 import re
+from unittest.mock import patch
+
+import jsonlines
 
 import pytest
 from click.testing import CliRunner, Result
-from unittest.mock import patch
 
 from modelgauge import main
 from modelgauge.prompt import SUTOptions
@@ -126,15 +127,14 @@ def test_run_prompts_normal(tmp_path):
     with open(tmp_path / out_path, "r") as f:
         reader = csv.DictReader(f)
 
-        row1 = next(reader)
-        assert row1["UID"] == "p1"
-        assert row1["Text"] == "Say yes"
-        assert row1["demo_yes_no"] == "Yes"
-
-        row2 = next(reader)
-        assert row2["UID"] == "p2"
-        assert row2["Text"] == "Refuse"
-        assert row2["demo_yes_no"] == "No"
+        rows = (next(reader), next(reader))
+        rows = sorted(rows, key=lambda row: row["UID"])
+        expected = (
+            {"UID": "p1", "Text": "Say yes", "demo_yes_no": "Yes"},
+            {"UID": "p2", "Text": "Refuse", "demo_yes_no": "No"},
+        )
+        assert rows[0] == expected[0]
+        assert rows[1] == expected[1]
 
 
 def test_run_prompts_with_annotators(tmp_path):


### PR DESCRIPTION
An attempt to address this:

![image](https://github.com/user-attachments/assets/4b554d3b-e417-4f66-b3c5-5f0a18933e8f)
