### PR TITLE
Benchmark scoring fix.

### DIFF
--- a/tests/modelbench_tests/data/standards_amazing.json
+++ b/tests/modelbench_tests/data/standards_amazing.json
@@ -8,18 +8,18 @@
             "llama-3.1-8b-instruct-turbo-together"
         ],
         "reference_standards": {
-            "safe_hazard-1.0-cse-en_us": 0.864,
-            "safe_hazard-1.0-dfm-en_us": 0.889,
-            "safe_hazard-1.0-hte-en_us": 0.918,
-            "safe_hazard-1.0-ipv-en_us": 0.878,
-            "safe_hazard-1.0-iwp-en_us": 0.805,
-            "safe_hazard-1.0-ncr-en_us": 0.845,
-            "safe_hazard-1.0-prv-en_us": 0.902,
-            "safe_hazard-1.0-spc-en_us": 0.876,
-            "safe_hazard-1.0-src-en_us": 0.94,
-            "safe_hazard-1.0-ssh-en_us": 0.9,
-            "safe_hazard-1.0-sxc-en_us": 0.836,
-            "safe_hazard-1.0-vcr-en_us": 0.848
+            "safe_hazard-1.0-cse-en_us-practice": 0.864,
+            "safe_hazard-1.0-dfm-en_us-practice": 0.889,
+            "safe_hazard-1.0-hte-en_us-practice": 0.918,
+            "safe_hazard-1.0-ipv-en_us-practice": 0.878,
+            "safe_hazard-1.0-iwp-en_us-practice": 0.805,
+            "safe_hazard-1.0-ncr-en_us-practice": 0.845,
+            "safe_hazard-1.0-prv-en_us-practice": 0.902,
+            "safe_hazard-1.0-spc-en_us-practice": 0.876,
+            "safe_hazard-1.0-src-en_us-practice": 0.94,
+            "safe_hazard-1.0-ssh-en_us-practice": 0.9,
+            "safe_hazard-1.0-sxc-en_us-practice": 0.836,
+            "safe_hazard-1.0-vcr-en_us-practice": 0.848
         }
     }
 }

--- a/tests/modelbench_tests/data/standards_middling.json
+++ b/tests/modelbench_tests/data/standards_middling.json
@@ -8,18 +8,18 @@
             "llama-3.1-8b-instruct-turbo-together"
         ],
         "reference_standards": {
-            "safe_hazard-1.0-cse-en_us": 0.664,
-            "safe_hazard-1.0-dfm-en_us": 0.689,
-            "safe_hazard-1.0-hte-en_us": 0.518,
-            "safe_hazard-1.0-ipv-en_us": 0.678,
-            "safe_hazard-1.0-iwp-en_us": 0.605,
-            "safe_hazard-1.0-ncr-en_us": 0.645,
-            "safe_hazard-1.0-prv-en_us": 0.502,
-            "safe_hazard-1.0-spc-en_us": 0.676,
-            "safe_hazard-1.0-src-en_us": 0.54,
-            "safe_hazard-1.0-ssh-en_us": 0.5,
-            "safe_hazard-1.0-sxc-en_us": 0.636,
-            "safe_hazard-1.0-vcr-en_us": 0.648
+            "safe_hazard-1.0-cse-en_us-practice": 0.664,
+            "safe_hazard-1.0-dfm-en_us-practice": 0.689,
+            "safe_hazard-1.0-hte-en_us-practice": 0.518,
+            "safe_hazard-1.0-ipv-en_us-practice": 0.678,
+            "safe_hazard-1.0-iwp-en_us-practice": 0.605,
+            "safe_hazard-1.0-ncr-en_us-practice": 0.645,
+            "safe_hazard-1.0-prv-en_us-practice": 0.502,
+            "safe_hazard-1.0-spc-en_us-practice": 0.676,
+            "safe_hazard-1.0-src-en_us-practice": 0.54,
+            "safe_hazard-1.0-ssh-en_us-practice": 0.5,
+            "safe_hazard-1.0-sxc-en_us-practice": 0.636,
+            "safe_hazard-1.0-vcr-en_us-practice": 0.648
         }
     }
 }

--- a/tests/modelbench_tests/data/standards_poor.json
+++ b/tests/modelbench_tests/data/standards_poor.json
@@ -8,18 +8,18 @@
             "llama-3.1-8b-instruct-turbo-together"
         ],
         "reference_standards": {
-            "safe_hazard-1.0-cse-en_us": 0.364,
-            "safe_hazard-1.0-dfm-en_us": 0.389,
-            "safe_hazard-1.0-hte-en_us": 0.318,
-            "safe_hazard-1.0-ipv-en_us": 0.378,
-            "safe_hazard-1.0-iwp-en_us": 0.305,
-            "safe_hazard-1.0-ncr-en_us": 0.345,
-            "safe_hazard-1.0-prv-en_us": 0.302,
-            "safe_hazard-1.0-spc-en_us": 0.376,
-            "safe_hazard-1.0-src-en_us": 0.34,
-            "safe_hazard-1.0-ssh-en_us": 0.3,
-            "safe_hazard-1.0-sxc-en_us": 0.336,
-            "safe_hazard-1.0-vcr-en_us": 0.348
+            "safe_hazard-1.0-cse-en_us-practice": 0.364,
+            "safe_hazard-1.0-dfm-en_us-practice": 0.389,
+            "safe_hazard-1.0-hte-en_us-practice": 0.318,
+            "safe_hazard-1.0-ipv-en_us-practice": 0.378,
+            "safe_hazard-1.0-iwp-en_us-practice": 0.305,
+            "safe_hazard-1.0-ncr-en_us-practice": 0.345,
+            "safe_hazard-1.0-prv-en_us-practice": 0.302,
+            "safe_hazard-1.0-spc-en_us-practice": 0.376,
+            "safe_hazard-1.0-src-en_us-practice": 0.34,
+            "safe_hazard-1.0-ssh-en_us-practice": 0.3,
+            "safe_hazard-1.0-sxc-en_us-practice": 0.336,
+            "safe_hazard-1.0-vcr-en_us-practice": 0.348
         }
     }
 }


### PR DESCRIPTION
Fix the problem where benchmark scoring combines official and practice prompts for the standard. Now official and practice each have their own standards.

This shifts responsibility for  knowing a benchmark's standard to the BenchmarkDefinition, in parallel with how it works for hazards. Between this and the 0.5 legacy stuff this leaves a lot of dead or deprecated code, but I didn't want to mess with too much for an emergency fix.