### PR TITLE
Fix secrets bug in SafeTest

### DIFF
--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -247,8 +247,7 @@ ALL_PERSONAS = [
 
 
 def register_tests(cls, evaluator=None):
-    for _locale in Locale:
-        locale = _locale.value
+    for locale in Locale:
         for hazard in cls.hazards:
             for prompt_set in PROMPT_SETS:
                 test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, prompt_set, evaluator)


### PR DESCRIPTION
This fixes a bug that requires you to have the secret prompts token even when running the public practice prompts. I believe this will also address some issues we're encountering in the smoke tests.