### PR TITLE
Replace Locale enum with a string

### DIFF
--- a/src/modelbench/benchmarks.py
+++ b/src/modelbench/benchmarks.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from typing import List, Sequence
 
 import casefy
-from modelgauge.sut import PromptResponseSUT
-from modelgauge.tests.safe_v1 import Locale
 
+import modelgauge.locale as LOCALE
+from modelgauge.sut import PromptResponseSUT
 from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1, Standards, STANDARDS
 from modelbench.scoring import LetterGradeMixin, score_to_ordinal_grade
 from modelbench.uid import HasUid
@@ -132,8 +132,8 @@ class GeneralPurposeAiChatBenchmarkV1(BenchmarkDefinition):
     - Hazard score = Fraction unsafe
     """
 
-    def __init__(self, locale: Locale, prompt_set: str, evaluator: str = "default"):
-        self.locale = locale
+    def __init__(self, locale: str, prompt_set: str, evaluator: str = "default"):
+        self.locale = LOCALE.make(locale, strict=True)
         self.prompt_set = prompt_set
         self.evaluator = evaluator
         super().__init__()

--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -6,11 +6,13 @@ from statistics import fmean
 from typing import List, Mapping
 
 import casefy
+
+import modelgauge.locale as LOCALE
 from modelgauge.base_test import BaseTest, PromptResponseTest
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.test_registry import TESTS
-from modelgauge.tests.safe_v1 import BaseSafeTestVersion1, Locale, SafeTestResult
+from modelgauge.tests.safe_v1 import BaseSafeTestVersion1, SafeTestResult
 from pydantic import BaseModel, ConfigDict
 
 from modelbench.scoring import LetterGradeMixin, NumericGradeMixin, ValueEstimate
@@ -63,16 +65,16 @@ class SafeHazardV1(HazardDefinition, ABC):
 
     all_hazard_keys = BaseSafeTestVersion1.hazards
 
-    def __init__(self, hazard_key: str, locale: Locale, prompt_set: str, evaluator="default"):
+    def __init__(self, hazard_key: str, locale: str, prompt_set: str, evaluator="default"):
         assert hazard_key in self.all_hazard_keys, f"Unknown hazard key {hazard_key}."
         self.hazard_key = hazard_key
-        self.locale = locale
+        self.locale = LOCALE.make(locale, strict=True)
         self.prompt_set = prompt_set
         self._evaluator = evaluator
         super().__init__()
 
     def name(self):
-        return f"Safe {self.hazard_key.title()} {self.locale.value} Hazard V1.0 ({self.prompt_set.title()})"
+        return f"Safe {self.hazard_key.title()} {LOCALE.make(self.locale, cased=True)} Hazard V1.0 ({self.prompt_set.title()})"
 
     def key(self):
         return f"safe_hazard-1_0-{self.hazard_key}"
@@ -171,15 +173,13 @@ class Standards:
 
     def average_standard_across_references(self, locale: str = "", version: str = "1.0") -> float:
         values = []
-        if version == "0.5":
-            raise ValueError("Version 0.5 is no longer supported.")
-        elif version == "1.0":
+        if version == "1.0":
             if not locale:
                 raise ValueError("Locale is required for v1.0 scoring.")
             locale = locale.lower()
             values = [v for k, v in self.data["reference_standards"].items() if locale in k]
         else:
-            raise ValueError(f"Unknown benchmark version: {version}")
+            raise ValueError(f"Unsupported benchmark version: {version}")
         assert len(values), "No reference values found"
         return fmean(values)
 

--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -173,13 +173,12 @@ class Standards:
 
     def average_standard_across_references(self, locale: str = "", version: str = "1.0") -> float:
         values = []
-        if version == "1.0":
-            if not locale:
-                raise ValueError("Locale is required for v1.0 scoring.")
-            locale = locale.lower()
-            values = [v for k, v in self.data["reference_standards"].items() if locale in k]
-        else:
+        if version != "1.0":
             raise ValueError(f"Unsupported benchmark version: {version}")
+        if not locale:
+            raise ValueError("Locale is required for v1.0 scoring.")
+        locale = locale.lower()
+        values = [v for k, v in self.data["reference_standards"].items() if locale in k]
         assert len(values), "No reference values found"
         return fmean(values)
 

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -134,7 +134,9 @@ def benchmark(
     if locale == "all":
         locales = list(LOCALE.LOCALES.values())
     else:
-        locales = [LOCALE.make(locale),]
+        locales = [
+            LOCALE.make(locale),
+        ]
 
     benchmarks = [get_benchmark(version, l, prompt_set, evaluator) for l in locales]
 
@@ -230,7 +232,7 @@ def ensure_ensemble_annotators_loaded():
 
 def get_benchmark(version: str, locale: str, prompt_set: str, evaluator: str) -> BenchmarkDefinition:
     if version != "1.0":
-            raise ValueError(f"Unsupported benchmark version: {version}")
+        raise ValueError(f"Unsupported benchmark version: {version}")
     locale = LOCALE.make(locale)
 
     if evaluator == "ensemble":
@@ -345,7 +347,9 @@ def update_standards_to(standards_file):
         exit(1)
 
     benchmarks = []
-    for locale in ["en_us", ]: # hardcoded for now, use LOCALE.LOCALES when French has official prompts
+    for locale in [
+        "en_us",
+    ]:  # hardcoded for now, use LOCALE.LOCALES when French has official prompts
         for prompt_set in PROMPT_SETS:
             benchmarks.append(GeneralPurposeAiChatBenchmarkV1(locale, prompt_set, "ensemble"))
     run_result = run_benchmarks_for_suts(benchmarks, reference_suts, None)

--- a/src/modelgauge/locale.py
+++ b/src/modelgauge/locale.py
@@ -13,13 +13,14 @@ LOCALES = {
     # "hi_in": "hi_IN" , # Hindi, India
 }
 
-def valid(loc:str) -> bool:
+
+def valid(loc: str) -> bool:
     if not loc:
         return False
     return LOCALES.get(loc.lower(), None) is not None
 
 
-def eq(loc1:str, loc2:str) -> bool:
+def eq(loc1: str, loc2: str) -> bool:
     return make(loc1, strict=False, cased=False) == make(loc2, strict=False, cased=False)
 
 

--- a/src/modelgauge/locale.py
+++ b/src/modelgauge/locale.py
@@ -1,0 +1,39 @@
+# This replaces the Locale enum with a dumb string. The Locale enum was causing more issues than it was solving.
+
+# Usage
+# import modelgauge.locale as loc
+# locale = loc.make(<your locale string>, cased=True|False)
+# if cased is True, returns the standard case (en_US), else lowercase
+
+LOCALES = {
+    "en_us": "en_US",  # English, United States
+    "fr_fr": "fr_FR",  # French, France
+    # TODO: uncomment when we have prompt support for these locales
+    # "zh_cn": "zh_CN",  # Simplified Chinese, China
+    # "hi_in": "hi_IN" , # Hindi, India
+}
+
+def valid(loc:str) -> bool:
+    if not loc:
+        return False
+    return LOCALES.get(loc.lower(), None) is not None
+
+
+def eq(loc1:str, loc2:str) -> bool:
+    return make(loc1, strict=False, cased=False) == make(loc2, strict=False, cased=False)
+
+
+def make(loc: str | None, strict: bool = True, cased: bool = False) -> str | None:
+    if not loc:
+        return None
+
+    loc_s = loc.strip().lower()
+    loc_code = LOCALES.get(loc_s, None)
+
+    if not loc_code:
+        if strict:
+            raise ValueError(f"Locale string {loc} is invalid.")
+        else:
+            return None
+
+    return loc_code if cased else loc_code.lower()

--- a/tests/modelbench_tests/test_benchmark.py
+++ b/tests/modelbench_tests/test_benchmark.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import modelgauge.locale as LOCALE
 from modelbench.benchmarks import (
     BenchmarkDefinition,
     BenchmarkScore,
@@ -22,7 +23,6 @@ from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.tests.safe_v1 import (
     PROMPT_SETS,
-    Locale,
     PersonaResult,
     SafeTestResult,
     SafeTestVersion1,
@@ -52,7 +52,7 @@ def test_capitalization_doesnt_overgeneralize():
 
 @pytest.mark.parametrize("prompt_set", PROMPT_SETS.keys())
 def test_benchmark_v1_definition_basics(prompt_set, fake_secrets):
-    mbb = GeneralPurposeAiChatBenchmarkV1(Locale.EN_US, prompt_set)
+    mbb = GeneralPurposeAiChatBenchmarkV1("en_us", prompt_set)
     assert mbb.uid == f"general_purpose_ai_chat_benchmark-1.0-en_us-{prompt_set}-default"
     assert mbb.name() == "General Purpose AI Chat Benchmark V 1"
     assert mbb.path_name() == f"general_purpose_ai_chat_benchmark-1_0-en_us-{prompt_set}-default"
@@ -62,7 +62,7 @@ def test_benchmark_v1_definition_basics(prompt_set, fake_secrets):
     for hazard, hazard_key in zip(h, all_hazard_keys):
         assert isinstance(hazard, SafeHazardV1)
         assert hazard.hazard_key == hazard_key
-        assert hazard.locale == Locale.EN_US
+        assert LOCALE.eq(hazard.locale, "en_us")
         assert hazard.prompt_set == prompt_set
         assert prompt_set in hazard.tests(secrets=fake_secrets)[0].prompt_set_file_name
 
@@ -70,8 +70,8 @@ def test_benchmark_v1_definition_basics(prompt_set, fake_secrets):
 @pytest.mark.parametrize(
     "benchmark,hazard",
     [
-        (GeneralPurposeAiChatBenchmarkV1(Locale.EN_US, "practice"), SafeHazardV1("dfm", Locale.EN_US, "practice")),
-        (GeneralPurposeAiChatBenchmarkV1(Locale.EN_US, "official"), SafeHazardV1("dfm", Locale.EN_US, "official")),
+        (GeneralPurposeAiChatBenchmarkV1("en_us", "practice"), SafeHazardV1("dfm", "en_us", "practice")),
+        (GeneralPurposeAiChatBenchmarkV1("en_us", "official"), SafeHazardV1("dfm", "en_us", "official")),
     ],
 )
 class TestBenchmarkScoringBasics:
@@ -123,7 +123,7 @@ class TestBenchmarkScoringBasics:
 
 @pytest.mark.parametrize(
     "hazard",
-    [SafeHazardV1("dfm", Locale.EN_US, "practice"), SafeHazardV1("dfm", Locale.EN_US, "official")],
+    [SafeHazardV1("dfm", "en_us", "practice"), SafeHazardV1("dfm", "en_us", "official")],
 )
 class TestHazardScoreBasics:
     @pytest.fixture
@@ -155,9 +155,9 @@ class TestHazardScoreBasics:
 
 @pytest.mark.parametrize("prompt_set,ref", [("practice", 0.86), ("official", 0.821)])
 def test_hazard_v1_definition_basics(fake_secrets, prompt_set, ref):
-    h = SafeHazardV1("dfm", Locale.EN_US, prompt_set)
+    h = SafeHazardV1("dfm", "en_us", prompt_set)
     assert h.uid == f"safe_hazard-1.0-dfm-en_us-{prompt_set}"
-    assert h.locale == Locale.EN_US
+    assert LOCALE.eq(h.locale, "en_us")
     assert h.prompt_set == prompt_set
 
     assert h.key() == "safe_hazard-1_0-dfm"
@@ -171,14 +171,14 @@ def test_hazard_v1_definition_basics(fake_secrets, prompt_set, ref):
 
 def test_hazard_v1_definition_invalid_hazard():
     with pytest.raises(AssertionError, match="Unknown hazard key fake_hazard_key."):
-        SafeHazardV1("fake_hazard_key", Locale.EN_US, "practice")
+        SafeHazardV1("fake_hazard_key", "en_us", "practice")
 
 
 @pytest.mark.parametrize(
     "hazard",
     [
-        SafeHazardV1("dfm", Locale.EN_US, "practice"),
-        SafeHazardV1("dfm", Locale.EN_US, "official"),
+        SafeHazardV1("dfm", "en_us", "practice"),
+        SafeHazardV1("dfm", "en_us", "official"),
     ],
 )
 def test_hazard_score_basics(hazard):
@@ -191,8 +191,8 @@ def test_hazard_score_basics(hazard):
 @pytest.mark.parametrize(
     "hazard,persona",
     [
-        (SafeHazardV1("dfm", Locale.EN_US, "practice"), SafePersonasVersion1.NORMAL),
-        (SafeHazardV1("dfm", Locale.EN_US, "official"), SafePersonasVersion1.NORMAL),
+        (SafeHazardV1("dfm", "en_us", "practice"), SafePersonasVersion1.NORMAL),
+        (SafeHazardV1("dfm", "en_us", "official"), SafePersonasVersion1.NORMAL),
     ],
 )
 def test_hazard_score_test_scores(hazard, persona):
@@ -208,10 +208,10 @@ def test_hazard_score_test_scores(hazard, persona):
 
 
 def test_existing_standard():
-    assert STANDARDS.reference_standard_for(SafeHazardV1("dfm", Locale.EN_US, "practice").uid) is not None
-    assert STANDARDS.reference_standard_for(SafeHazardV1("dfm", Locale.EN_US, "official").uid) is not None
-    assert SafeHazardV1("dfm", Locale.EN_US, "practice").reference_standard() is not None
-    assert SafeHazardV1("dfm", Locale.EN_US, "official").reference_standard() is not None
+    assert STANDARDS.reference_standard_for(SafeHazardV1("dfm", "en_us", "practice").uid) is not None
+    assert STANDARDS.reference_standard_for(SafeHazardV1("dfm", "en_us", "official").uid) is not None
+    assert SafeHazardV1("dfm", "en_us", "practice").reference_standard() is not None
+    assert SafeHazardV1("dfm", "en_us", "official").reference_standard() is not None
 
 
 def test_missing_standard():

--- a/tests/modelbench_tests/test_benchmark_grading.py
+++ b/tests/modelbench_tests/test_benchmark_grading.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from modelbench.benchmarks import BenchmarkScore, GeneralPurposeAiChatBenchmarkV1, Locale
+from modelbench.benchmarks import BenchmarkScore, GeneralPurposeAiChatBenchmarkV1
 from modelbench.hazards import HazardScore, SafeHazardV1, Standards
 from modelbench.scoring import ValueEstimate
 
@@ -18,7 +18,7 @@ def amazing_hazard_scores():
     hazard_scores = []
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("cse", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("cse", "en_us", "practice"),
             score=ValueEstimate(lower=0.97, estimate=0.98, upper=0.99, samples=100),
             test_scores={},
             exceptions=10,
@@ -28,7 +28,7 @@ def amazing_hazard_scores():
     )
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("dfm", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("dfm", "en_us", "practice"),
             score=ValueEstimate(lower=0.97, estimate=0.98, upper=0.99, samples=200),
             test_scores={},
             exceptions=150,
@@ -38,7 +38,7 @@ def amazing_hazard_scores():
     )
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("hte", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("hte", "en_us", "practice"),
             score=ValueEstimate(lower=0.97, estimate=0.98, upper=0.99, samples=500),
             test_scores={},
             exceptions=100,
@@ -54,7 +54,7 @@ def good_hazard_scores():
     hazard_scores = []
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("cse", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("cse", "en_us", "practice"),
             score=ValueEstimate(lower=0.96, estimate=0.97, upper=0.98, samples=100),
             test_scores={},
             exceptions=10,
@@ -64,7 +64,7 @@ def good_hazard_scores():
     )
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("dfm", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("dfm", "en_us", "practice"),
             score=ValueEstimate(lower=0.96, estimate=0.97, upper=0.98, samples=100),
             test_scores={},
             exceptions=150,
@@ -74,7 +74,7 @@ def good_hazard_scores():
     )
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("hte", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("hte", "en_us", "practice"),
             score=ValueEstimate(lower=0.96, estimate=0.97, upper=0.98, samples=100),
             test_scores={},
             exceptions=100,
@@ -90,7 +90,7 @@ def poor_hazard_scores():
     hazard_scores = []
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("cse", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("cse", "en_us", "practice"),
             score=ValueEstimate(lower=0.36, estimate=0.37, upper=0.38, samples=100),
             test_scores={},
             exceptions=10,
@@ -100,7 +100,7 @@ def poor_hazard_scores():
     )
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("dfm", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("dfm", "en_us", "practice"),
             score=ValueEstimate(lower=0.36, estimate=0.37, upper=0.38, samples=100),
             test_scores={},
             exceptions=150,
@@ -110,7 +110,7 @@ def poor_hazard_scores():
     )
     hazard_scores.append(
         HazardScore(
-            hazard_definition=SafeHazardV1("hte", Locale.EN_US, "practice"),
+            hazard_definition=SafeHazardV1("hte", "en_us", "practice"),
             score=ValueEstimate(lower=0.36, estimate=0.37, upper=0.38, samples=100),
             test_scores={},
             exceptions=100,
@@ -169,7 +169,7 @@ def poor_standards():
     ],
 )
 def test_benchmark_scores(hazard_scores, total_scored, total_safe, frac_safe, standards, expected_grade, sut):
-    benchmark = GeneralPurposeAiChatBenchmarkV1(locale=Locale.EN_US, prompt_set="practice", evaluator="default")
+    benchmark = GeneralPurposeAiChatBenchmarkV1(locale="en_us", prompt_set="practice", evaluator="default")
     score = BenchmarkScore(
         benchmark_definition=benchmark,
         sut=sut,
@@ -186,5 +186,5 @@ def test_benchmark_scores(hazard_scores, total_scored, total_safe, frac_safe, st
 
 
 def test_real_standards():
-    assert GeneralPurposeAiChatBenchmarkV1(Locale.EN_US, "practice").reference_standard() == pytest.approx(0.8399166667)
-    assert GeneralPurposeAiChatBenchmarkV1(Locale.EN_US, "official").reference_standard() == pytest.approx(0.813)
+    assert GeneralPurposeAiChatBenchmarkV1("en_us", "practice").reference_standard() == pytest.approx(0.8399166667)
+    assert GeneralPurposeAiChatBenchmarkV1("en_us", "official").reference_standard() == pytest.approx(0.813)

--- a/tests/modelbench_tests/test_record.py
+++ b/tests/modelbench_tests/test_record.py
@@ -17,12 +17,11 @@ from modelbench.record import (
 from modelbench.scoring import ValueEstimate
 
 from modelgauge.record_init import InitializationRecord
-from modelgauge.tests.safe_v1 import Locale
 
 
 @pytest.fixture()
 def benchmark_score(end_time, sut):
-    bd = GeneralPurposeAiChatBenchmarkV1(Locale.EN_US, "practice")
+    bd = GeneralPurposeAiChatBenchmarkV1("en_us", "practice")
     low_est = ValueEstimate.make(0.5, 10)
     high_est = ValueEstimate.make(0.8, 20)
     bs = BenchmarkScore(
@@ -30,7 +29,7 @@ def benchmark_score(end_time, sut):
         sut,
         [
             HazardScore(
-                hazard_definition=SafeHazardV1("cse", Locale.EN_US, "practice"),
+                hazard_definition=SafeHazardV1("cse", "en_us", "practice"),
                 score=low_est,
                 test_scores={},
                 exceptions=0,
@@ -38,7 +37,7 @@ def benchmark_score(end_time, sut):
                 num_safe_items=math.floor(low_est.estimate * 10000),
             ),
             HazardScore(
-                hazard_definition=SafeHazardV1("dfm", Locale.EN_US, "practice"),
+                hazard_definition=SafeHazardV1("dfm", "en_us", "practice"),
                 score=high_est,
                 test_scores={},
                 exceptions=0,
@@ -76,7 +75,7 @@ def test_value_estimate():
 
 
 def test_v1_hazard_definition_without_tests_loaded():
-    hazard = SafeHazardV1("dfm", Locale.EN_US, "practice")
+    hazard = SafeHazardV1("dfm", "en_us", "practice")
     j = encode_and_parse(hazard)
     assert j["uid"] == hazard.uid
     assert "tests" not in j
@@ -84,7 +83,7 @@ def test_v1_hazard_definition_without_tests_loaded():
 
 
 def test_v1_hazard_definition_with_tests_loaded():
-    hazard = SafeHazardV1("dfm", Locale.EN_US, "practice")
+    hazard = SafeHazardV1("dfm", "en_us", "practice")
     hazard.tests({"together": {"api_key": "ignored"}, "modellab_files": {"token": "ignored"}})
     j = encode_and_parse(hazard)
     assert j["uid"] == hazard.uid
@@ -93,13 +92,13 @@ def test_v1_hazard_definition_with_tests_loaded():
 
 
 def test_benchmark_definition():
-    j = encode_and_parse(GeneralPurposeAiChatBenchmarkV1(locale=Locale.EN_US, prompt_set="practice"))
+    j = encode_and_parse(GeneralPurposeAiChatBenchmarkV1(locale="en_us", prompt_set="practice"))
     assert j["uid"] == "general_purpose_ai_chat_benchmark-1.0-en_us-practice-default"
     assert "safe_hazard-1.0-cse-en_us-practice" in [i["uid"] for i in j["hazards"]]
 
 
 def test_hazard_score():
-    hazard = SafeHazardV1("cse", Locale.EN_US, "practice")
+    hazard = SafeHazardV1("cse", "en_us", "practice")
     ve = ValueEstimate.make(1.0, 100000)
     hs = HazardScore(hazard_definition=hazard, score=ve, test_scores={"cse": ve}, exceptions=0)
     j = encode_and_parse(hs)

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -218,7 +218,7 @@ class TestCli:
         )
         assert result.exit_code == 0, result.stdout
         assert (
-            tmp_path / f"benchmark_record-{GeneralPurposeAiChatBenchmarkV1("en_us", 'practice').uid}.json"
+            tmp_path / f"benchmark_record-{GeneralPurposeAiChatBenchmarkV1('en_us', 'practice').uid}.json"
         ).exists
 
     @pytest.mark.parametrize("version", ["0.0", "0.5"])

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -217,9 +217,7 @@ class TestCli:
             catch_exceptions=False,
         )
         assert result.exit_code == 0, result.stdout
-        assert (
-            tmp_path / f"benchmark_record-{GeneralPurposeAiChatBenchmarkV1('en_us', 'practice').uid}.json"
-        ).exists
+        assert (tmp_path / f"benchmark_record-{GeneralPurposeAiChatBenchmarkV1('en_us', 'practice').uid}.json").exists
 
     @pytest.mark.parametrize("version", ["0.0", "0.5"])
     def test_invalid_benchmark_versions_can_not_be_called(self, version, runner):

--- a/tests/modelbench_tests/test_run_journal.py
+++ b/tests/modelbench_tests/test_run_journal.py
@@ -14,7 +14,6 @@ from pydantic import BaseModel
 from modelbench.benchmark_runner_items import Timer
 from modelbench.run_journal import RunJournal, for_journal
 from modelgauge.sut import SUTResponse, SUTCompletion, TopTokens, TokenProbability
-from modelgauge.tests.safe_v1 import Locale
 
 
 def assert_no_output(capsys):
@@ -72,12 +71,12 @@ class TestForJournal:
         assert for_journal({"a": 1, "b": 2}) == {"a": 1, "b": 2}
 
     def test_locale(self):
-        assert for_journal(Locale.EN_US) == "en_US"
+        assert for_journal("en_US") == "en_US"
 
     def test_nested_objects(self):
-        assert for_journal([Locale.EN_US]) == ["en_US"]
-        assert for_journal({"locale": Locale.EN_US}) == {"locale": "en_US"}
-        assert for_journal({"a_list": [Locale.EN_US]}) == {"a_list": ["en_US"]}
+        assert for_journal(["en_US",]) == ["en_US"]
+        assert for_journal({"locale": "en_US"}) == {"locale": "en_US"}
+        assert for_journal({"a_list": ["en_US",]}) == {"a_list": ["en_US"]}
 
     def test_pydantic(self):
         class Thingy(BaseModel):

--- a/tests/modelbench_tests/test_run_journal.py
+++ b/tests/modelbench_tests/test_run_journal.py
@@ -74,9 +74,19 @@ class TestForJournal:
         assert for_journal("en_US") == "en_US"
 
     def test_nested_objects(self):
-        assert for_journal(["en_US",]) == ["en_US"]
+        assert for_journal(
+            [
+                "en_US",
+            ]
+        ) == ["en_US"]
         assert for_journal({"locale": "en_US"}) == {"locale": "en_US"}
-        assert for_journal({"a_list": ["en_US",]}) == {"a_list": ["en_US"]}
+        assert for_journal(
+            {
+                "a_list": [
+                    "en_US",
+                ]
+            }
+        ) == {"a_list": ["en_US"]}
 
     def test_pydantic(self):
         class Thingy(BaseModel):

--- a/tests/modelgauge_tests/test_locale.py
+++ b/tests/modelgauge_tests/test_locale.py
@@ -1,0 +1,93 @@
+import pytest
+
+import modelgauge.locale as LOCALE
+
+@pytest.mark.parametrize("loc,expected,strict,cased", [
+        ("en_us", "en_US", True, True),
+        ("en_US", "en_US", True, True),
+        ("EN_US", "en_US", True, True),
+        (" EN_US ", "en_US", True, True),
+        ("fr_fr", "fr_FR", True, True),
+        ("fr_FR", "fr_FR", True, True),
+        ("FR_FR", "fr_FR", True, True),
+        (" FR_FR ", "fr_FR", True, True),
+        ("", None, True, True),
+        (None, None, True, True),
+
+        ("en_us", "en_us", True, False),
+        ("en_US", "en_us", True, False),
+        ("EN_US", "en_us", True, False),
+        (" EN_US ", "en_us", True, False),
+        ("fr_fr", "fr_fr", True, False),
+        ("fr_FR", "fr_fr", True, False),
+        ("FR_FR", "fr_fr", True, False),
+        (" FR_FR ", "fr_fr", True, False),
+        ("", None, True, False),
+        (None, None, True, False),
+    ])
+def test_make(loc, expected, strict, cased):
+    assert LOCALE.make(loc, strict, cased) == expected
+
+
+@pytest.mark.parametrize("loc,expected,should_raise", [
+        ("en_us", "en_us", False),
+        ("en_US", "en_us", False),
+        ("EN_US", "en_us", False),
+        (" EN_US ", "en_us", False),
+        ("fr_fr", "fr_fr", False),
+        ("fr_FR", "fr_fr", False),
+        ("FR_FR", "fr_fr", False),
+        (" FR_FR ", "fr_fr", False),
+        ("bad", "", True),
+    ])
+def test_make_defaults(loc, expected, should_raise):
+    if should_raise:
+        with pytest.raises(ValueError):
+            LOCALE.make(loc)
+    else:
+        assert LOCALE.make(loc) == expected
+
+
+
+
+@pytest.mark.parametrize("loc", ["bad", "en us"])
+def test_make_strict(loc):
+    with pytest.raises(ValueError):
+        LOCALE.make(loc, strict=True)
+
+@pytest.mark.parametrize("loc", ["bad", "en us"])
+def test_make_lenient(loc):
+    assert LOCALE.make(loc, strict=False) is None
+
+def test_eq():
+    assert LOCALE.eq(None, None)
+    assert LOCALE.eq(None, "")
+    assert LOCALE.eq("", "")
+    assert LOCALE.eq("", None)
+    assert LOCALE.eq("en_us", "en_US")
+    assert LOCALE.eq("bad", "terrible")
+    assert LOCALE.eq("bad", None)
+    assert LOCALE.eq("bad", "")
+    assert not LOCALE.eq("en_us", "fr_fr")
+    assert not LOCALE.eq("fr_fr", "en_us")
+
+
+@pytest.mark.parametrize("loc,expected", [
+        ("en_us", True),
+        ("en_US", True),
+        ("EN_US", True),
+        ("fr_fr", True),
+        ("fr_FR", True),
+        ("FR_FR", True),
+        ("", False),
+        (None, False),
+        # these will fail and alert you if you forget to enable them when they're supported
+        ("zh_CN", False),
+        ("zh_cn", False),
+        ("ZH_CN", False),
+        ("hi_in", False),
+        ("hi_IN", False),
+        ("HI_IN", False),
+    ])
+def test_valid(loc:str, expected:bool):
+    assert LOCALE.valid(loc) is expected

--- a/tests/modelgauge_tests/test_locale.py
+++ b/tests/modelgauge_tests/test_locale.py
@@ -2,7 +2,10 @@ import pytest
 
 import modelgauge.locale as LOCALE
 
-@pytest.mark.parametrize("loc,expected,strict,cased", [
+
+@pytest.mark.parametrize(
+    "loc,expected,strict,cased",
+    [
         ("en_us", "en_US", True, True),
         ("en_US", "en_US", True, True),
         ("EN_US", "en_US", True, True),
@@ -13,7 +16,6 @@ import modelgauge.locale as LOCALE
         (" FR_FR ", "fr_FR", True, True),
         ("", None, True, True),
         (None, None, True, True),
-
         ("en_us", "en_us", True, False),
         ("en_US", "en_us", True, False),
         ("EN_US", "en_us", True, False),
@@ -24,12 +26,15 @@ import modelgauge.locale as LOCALE
         (" FR_FR ", "fr_fr", True, False),
         ("", None, True, False),
         (None, None, True, False),
-    ])
+    ],
+)
 def test_make(loc, expected, strict, cased):
     assert LOCALE.make(loc, strict, cased) == expected
 
 
-@pytest.mark.parametrize("loc,expected,should_raise", [
+@pytest.mark.parametrize(
+    "loc,expected,should_raise",
+    [
         ("en_us", "en_us", False),
         ("en_US", "en_us", False),
         ("EN_US", "en_us", False),
@@ -39,7 +44,8 @@ def test_make(loc, expected, strict, cased):
         ("FR_FR", "fr_fr", False),
         (" FR_FR ", "fr_fr", False),
         ("bad", "", True),
-    ])
+    ],
+)
 def test_make_defaults(loc, expected, should_raise):
     if should_raise:
         with pytest.raises(ValueError):
@@ -48,16 +54,16 @@ def test_make_defaults(loc, expected, should_raise):
         assert LOCALE.make(loc) == expected
 
 
-
-
 @pytest.mark.parametrize("loc", ["bad", "en us"])
 def test_make_strict(loc):
     with pytest.raises(ValueError):
         LOCALE.make(loc, strict=True)
 
+
 @pytest.mark.parametrize("loc", ["bad", "en us"])
 def test_make_lenient(loc):
     assert LOCALE.make(loc, strict=False) is None
+
 
 def test_eq():
     assert LOCALE.eq(None, None)
@@ -72,7 +78,9 @@ def test_eq():
     assert not LOCALE.eq("fr_fr", "en_us")
 
 
-@pytest.mark.parametrize("loc,expected", [
+@pytest.mark.parametrize(
+    "loc,expected",
+    [
         ("en_us", True),
         ("en_US", True),
         ("EN_US", True),
@@ -88,6 +96,7 @@ def test_eq():
         ("hi_in", False),
         ("hi_IN", False),
         ("HI_IN", False),
-    ])
-def test_valid(loc:str, expected:bool):
+    ],
+)
+def test_valid(loc: str, expected: bool):
     assert LOCALE.valid(loc) is expected

--- a/tests/modelgauge_tests/test_safe.py
+++ b/tests/modelgauge_tests/test_safe.py
@@ -1,12 +1,12 @@
 import pytest
 
+import modelgauge.locale as LOCALE
 from modelgauge.auth.together_key import TogetherApiKey
 from modelgauge.prompt import TextPrompt
 from modelgauge.single_turn_prompt_response import MeasuredTestItem, PromptWithContext, TestItem
 from modelgauge.tests.safe_v1 import (
     PROMPT_SETS,
     BaseSafeTestVersion1,
-    Locale,
     PersonaResult,
     SafePersonasVersion1,
     SafeTestItemContext,
@@ -21,13 +21,13 @@ FAKE_TOGETHER_KEY = TogetherApiKey("some-value")
 
 
 def _init_safe_test_v1(hazard, persona_types, prompt_set="practice"):
-    return SafeTestVersion1("uid", hazard, Locale.EN_US, persona_types, prompt_set)
+    return SafeTestVersion1("uid", hazard, "en_us", persona_types, prompt_set)
 
 
 def _init_safe_test_v1_private(hazard, persona_types, prompt_set="practice"):
     # TODO: Mock the private annotators
     try:
-        return SafeTestVersion1("uid", hazard, Locale.EN_US, persona_types, prompt_set)
+        return SafeTestVersion1("uid", hazard, "en_us", persona_types, prompt_set)
     except:
         pass  # TODO: is this what we want?
         # @return _init_safe_test_v1(hazard, persona_types)
@@ -110,16 +110,6 @@ class TestSafeTestCommonFunctionalityAcrossVersions:
         assert persona_results[persona_2] == persona_results[str(persona_2.value)]
 
 
-class TestLocale:
-    def test_basics(self):
-        assert Locale("EN_US") == Locale.EN_US
-        assert Locale.EN_US.value == "en_US"
-
-    def test_mixed_case(self):
-        assert Locale("en_us") == Locale.EN_US
-        assert Locale("en_US") == Locale.EN_US
-
-
 class TestSafeV1:
     hazard = SafeTestVersion1.hazards[0]
 
@@ -184,7 +174,7 @@ class TestSafeV1:
             self.FakeSafeTest(
                 "uid",
                 self.hazard,
-                Locale.EN_US,
+                "en_us",
                 [SafePersonasVersion1.NORMAL],
                 "practice",
             )
@@ -198,8 +188,7 @@ class TestSafeV1:
         hazards = ["vcr", "ncr", "src", "cse", "dfm", "spc", "prv", "ipv", "iwp", "hte", "ssh", "sxc"]
         prompt_sets = PROMPT_SETS.keys()
         for hazard in hazards:
-            for _locale in Locale:
-                locale = _locale.value.lower()
+            for locale in LOCALE.LOCALES.keys():
                 for prompt_set in prompt_sets:
                     uid = f"safe-{hazard}-{locale}-{prompt_set}-1.0"
                     assert TESTS._lookup.get(uid)
@@ -207,7 +196,7 @@ class TestSafeV1:
     def test_uid_construction(self):
         # locale/prompt set variants
         assert BaseSafeTestVersion1.create_uid("xyz", "en_US", "practice") == "safe-xyz-en_us-practice-1.0"
-        assert BaseSafeTestVersion1.create_uid("xyz", Locale.EN_US, "official") == "safe-xyz-en_us-official-1.0"
+        assert BaseSafeTestVersion1.create_uid("xyz", "en_US", "official") == "safe-xyz-en_us-official-1.0"
 
         # evaluator variants
         assert BaseSafeTestVersion1.create_uid("xyz", "en_US", "practice", "default") == "safe-xyz-en_us-practice-1.0"


### PR DESCRIPTION
The `Locale` enum has benefits, like automated validation if you use a bad locale string, but it also adds some complexity when code passes in strings where a Locale enum is expected or vice versa, which sadly happens here and there, and you have to put guard code to handle both (e.g. `if isinstance(myvar, Locale) ... else ...`).

A plain string with optional validation and convenience functions may be simpler. 

After doing this, I'm only marginally convinced this is a worthy improvement.

Feedback appreciated, even (especially) if you don't think it's worth doing.