### PR TITLE
Fix cache bug

### DIFF
--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -326,6 +326,7 @@ class TestRunSutWorker(IntermediateCachingPipe):
         # Add SUT UID to key to avoid collisions.
         return f"annotator: {sut_uid}\n {key}"
 
+
 class TestRunAnnotationWorker(IntermediateCachingPipe):
     def __init__(self, test_run: TestRunBase, cache: MBCache, thread_count=1, cache_path=None):
         super().__init__(cache, thread_count)

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -324,7 +324,7 @@ class TestRunSutWorker(IntermediateCachingPipe):
     def make_cache_key(sut_request, sut_uid):
         key = sut_request.model_dump_json(exclude_none=True)
         # Add SUT UID to key to avoid collisions.
-        return f"annotator: {sut_uid}\n {key}"
+        return f"sut: {sut_uid}\n {key}"
 
 
 class TestRunAnnotationWorker(IntermediateCachingPipe):

--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -401,25 +401,15 @@ class TestRunners(RunnerTestBase):
         runner.run()
 
     def test_sut_caching(self, item_from_test, a_wrapped_test, tmp_path):
-        sut = MagicMock(spec=PromptResponseSUT)
-        sut.uid = "magic-sut"
-        sut.translate_text_prompt.return_value = TogetherChatRequest(model="foo", messages=[])
-        sut.evaluate.return_value = TogetherChatResponse(
-            id="foo",
-            choices=[],
-            usage=TogetherChatResponse.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
-            created=0,
-            model="foo",
-            object="foo",
-        )
+        sut = FakeSUT("magic-sut")
         run = self.a_run(tmp_path, suts=[sut])
         bsw = TestRunSutWorker(run, DiskCache(tmp_path))
 
         bsw.handle_item(TestRunItem(a_wrapped_test, item_from_test, sut))
-        assert sut.evaluate.call_count == 1
+        assert sut.evaluate_calls == 1
 
         bsw.handle_item(TestRunItem(a_wrapped_test, item_from_test, sut))
-        assert sut.evaluate.call_count == 1
+        assert sut.evaluate_calls == 1
 
     def test_sut_caching_no_collisions(self, item_from_test, a_wrapped_test, tmp_path):
         sut_one = FakeSUT("sut_one")

--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -8,7 +8,7 @@ from modelbench.benchmark_runner import *
 from modelbench.cache import InMemoryCache
 from modelbench.hazards import HazardDefinition, HazardScore
 from modelbench.scoring import ValueEstimate
-from modelgauge.annotators.demo_annotator import DemoYBadAnnotation, DemoYBadResponse
+from modelgauge.annotators.demo_annotator import DemoYBadAnnotation, DemoYBadResponse, DemoYBadRequest
 from modelgauge.annotators.llama_guard_annotator import LlamaGuardAnnotation
 from modelgauge.dependency_helper import DependencyHelper
 from modelgauge.external_data import ExternalData
@@ -168,8 +168,8 @@ class RunnerTestBase:
 
     @pytest.fixture()
     def exploding_sut(self):
-        real_sut = MagicMock()
-        real_sut.evaluate.side_effect = ValueError("sut done broke")
+        real_sut = FakeSUT("exploding_sut")
+        real_sut.evaluate = MagicMock(side_effect=ValueError("sut done broke"))
         return real_sut
 
     @pytest.fixture()
@@ -556,7 +556,7 @@ class TestRunJournaling(RunnerTestBase):
         run = self.a_run(tmp_path, suts=[a_sut], benchmarks=[benchmark])
         cache = InMemoryCache()
         cache_key = TestRunAnnotationWorker.make_cache_key(
-            '{"text":"Hello, is it me you\'re looking for?"}',
+            DemoYBadRequest(text="Hello, is it me you're looking for?"),
             "demo_annotator",
         )
         cache[cache_key] = DemoYBadResponse(score=1.0)

--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -12,7 +12,6 @@ from modelgauge.annotators.demo_annotator import DemoYBadAnnotation, DemoYBadRes
 from modelgauge.annotators.llama_guard_annotator import LlamaGuardAnnotation
 from modelgauge.dependency_helper import DependencyHelper
 from modelgauge.external_data import ExternalData
-from modelgauge.load_plugins import load_plugins
 from modelgauge.prompt import TextPrompt
 from modelgauge.record_init import InitializationRecord
 from modelgauge.secret_values import get_all_secrets, RawSecrets
@@ -20,7 +19,6 @@ from modelgauge.single_turn_prompt_response import MeasuredTestItem, PromptWithC
 from modelgauge.sut import SUTCompletion, SUTResponse
 from modelgauge.sut_registry import SUTS
 from modelgauge.suts.demo_01_yes_no_sut import DemoYesNoResponse
-from modelgauge.suts.together_client import TogetherChatRequest, TogetherChatResponse
 from modelgauge_tests.fake_annotator import FakeAnnotator
 
 from modelbench_tests.test_run_journal import FakeJournal, reader_for

--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -510,7 +510,9 @@ class TestRunJournaling(RunnerTestBase):
         run = self.a_run(tmp_path, suts=[a_sut])
         cache = InMemoryCache()
         bsw = TestRunSutWorker(run, cache)
-        cache['{"text":"Hello!"}'] = DemoYesNoResponse(number_of_words=1, text="No")
+        request = a_sut.translate_text_prompt(item_from_test.prompts[0].prompt)
+        key = bsw.make_cache_key(request, "demo_yes_no")
+        cache[key] = DemoYesNoResponse(number_of_words=1, text="No")
 
         bsw.handle_item(TestRunItem(a_wrapped_test, item_from_test, a_sut))
 


### PR DESCRIPTION
This fixes the cache collision bug for SUTs in modelbench. I also added some more cache testing.

This is a simple fix-- it just prepends the SUT UID to the cache key. We should discuss if it makes sense for all the SUTs to share one cache or if we would benefit from having one cache per SUT. Same for the annotators.