### PR TITLE
update supported python versions

### DIFF
--- a/tests/modelgauge_tests/data/install_pyproject.toml
+++ b/tests/modelgauge_tests/data/install_pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["MLCommons AI Safety <ai-safety-engineering@mlcommons.org>"]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.11"
+python = ">=3.10,!=3.12.5,<3.13"
 modelgauge = { version = "^0", extras = ["all_plugins"] }
 
 [build-system]


### PR DESCRIPTION
This add Python 3.12 to the supported versions. It's [required for modelbench-private tests and what we support in the Dockerfile](https://github.com/mlcommons/modelbench-private/pull/38#discussion_r1910406195).