### PR TITLE
Decouple the prompt set type (practice, official) from its file name

### DIFF
--- a/src/modelbench/benchmarks.py
+++ b/src/modelbench/benchmarks.py
@@ -6,7 +6,7 @@ from typing import List, Sequence
 
 import casefy
 from modelgauge.locales import DEFAULT_LOCALE, validate_locale
-from modelgauge.prompt_sets import PROMPT_SETS, validate_prompt_set
+from modelgauge.prompt_sets import validate_prompt_set
 from modelgauge.sut import PromptResponseSUT
 
 from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1, Standards, STANDARDS
@@ -133,9 +133,9 @@ class GeneralPurposeAiChatBenchmarkV1(BenchmarkDefinition):
     - Hazard score = Fraction unsafe
     """
 
-    def __init__(self, locale: str, prompt_set: str, prompt_sets: dict = PROMPT_SETS, evaluator: str = "default"):
+    def __init__(self, locale: str, prompt_set: str, evaluator: str = "default"):
         validate_locale(locale)
-        validate_prompt_set(prompt_set, prompt_sets)
+        validate_prompt_set(prompt_set)
         self.locale = locale
         self.prompt_set = prompt_set
         self.evaluator = evaluator
@@ -148,7 +148,7 @@ class GeneralPurposeAiChatBenchmarkV1(BenchmarkDefinition):
 
     def _make_hazards(self) -> Sequence[HazardDefinition]:
         return [
-            SafeHazardV1(hazard_key, self.locale, self.prompt_set, PROMPT_SETS, self.evaluator)
+            SafeHazardV1(hazard_key, self.locale, self.prompt_set, self.evaluator)
             for hazard_key in SafeHazardV1.all_hazard_keys
         ]
 

--- a/src/modelbench/benchmarks.py
+++ b/src/modelbench/benchmarks.py
@@ -5,8 +5,9 @@ from datetime import datetime
 from typing import List, Sequence
 
 import casefy
-from modelgauge.sut import PromptResponseSUT
 from modelgauge.locales import DEFAULT_LOCALE, validate_locale
+from modelgauge.prompt_sets import PROMPT_SETS, validate_prompt_set
+from modelgauge.sut import PromptResponseSUT
 
 from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1, Standards, STANDARDS
 from modelbench.scoring import LetterGradeMixin, score_to_ordinal_grade
@@ -132,8 +133,9 @@ class GeneralPurposeAiChatBenchmarkV1(BenchmarkDefinition):
     - Hazard score = Fraction unsafe
     """
 
-    def __init__(self, locale: str, prompt_set: str, evaluator: str = "default"):
+    def __init__(self, locale: str, prompt_set: str, prompt_sets: dict = PROMPT_SETS, evaluator: str = "default"):
         validate_locale(locale)
+        validate_prompt_set(prompt_set, prompt_sets)
         self.locale = locale
         self.prompt_set = prompt_set
         self.evaluator = evaluator
@@ -146,7 +148,7 @@ class GeneralPurposeAiChatBenchmarkV1(BenchmarkDefinition):
 
     def _make_hazards(self) -> Sequence[HazardDefinition]:
         return [
-            SafeHazardV1(hazard_key, self.locale, self.prompt_set, self.evaluator)
+            SafeHazardV1(hazard_key, self.locale, self.prompt_set, PROMPT_SETS, self.evaluator)
             for hazard_key in SafeHazardV1.all_hazard_keys
         ]
 

--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -8,6 +8,7 @@ from typing import List, Mapping
 import casefy
 from modelgauge.base_test import BaseTest, PromptResponseTest
 from modelgauge.locales import display_for, validate_locale
+from modelgauge.prompt_sets import PROMPT_SETS, validate_prompt_set
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.test_registry import TESTS
@@ -64,9 +65,12 @@ class SafeHazardV1(HazardDefinition, ABC):
 
     all_hazard_keys = BaseSafeTestVersion1.hazards
 
-    def __init__(self, hazard_key: str, locale: str, prompt_set: str, evaluator="default"):
+    def __init__(
+        self, hazard_key: str, locale: str, prompt_set: str, prompt_sets: dict = PROMPT_SETS, evaluator="default"
+    ):
         assert hazard_key in self.all_hazard_keys, f"Unknown hazard key {hazard_key}."
         validate_locale(locale)
+        validate_prompt_set(prompt_set, prompt_sets)
         self.hazard_key = hazard_key
         self.locale = locale
         self.prompt_set = prompt_set
@@ -123,7 +127,9 @@ class SafeHazardV1(HazardDefinition, ABC):
         if not self._tests:
             self._tests = [
                 TESTS.make_instance(
-                    BaseSafeTestVersion1.create_uid(self.hazard_key, self.locale, self.prompt_set, self._evaluator),
+                    BaseSafeTestVersion1.create_uid(
+                        self.hazard_key, self.locale, self.prompt_set, PROMPT_SETS, self._evaluator
+                    ),
                     secrets=secrets,
                 )
             ]

--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -8,7 +8,7 @@ from typing import List, Mapping
 import casefy
 from modelgauge.base_test import BaseTest, PromptResponseTest
 from modelgauge.locales import display_for, validate_locale
-from modelgauge.prompt_sets import PROMPT_SETS, validate_prompt_set
+from modelgauge.prompt_sets import validate_prompt_set
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.test_registry import TESTS
@@ -65,12 +65,10 @@ class SafeHazardV1(HazardDefinition, ABC):
 
     all_hazard_keys = BaseSafeTestVersion1.hazards
 
-    def __init__(
-        self, hazard_key: str, locale: str, prompt_set: str, prompt_sets: dict = PROMPT_SETS, evaluator="default"
-    ):
+    def __init__(self, hazard_key: str, locale: str, prompt_set: str, evaluator="default"):
         assert hazard_key in self.all_hazard_keys, f"Unknown hazard key {hazard_key}."
         validate_locale(locale)
-        validate_prompt_set(prompt_set, prompt_sets)
+        validate_prompt_set(prompt_set)
         self.hazard_key = hazard_key
         self.locale = locale
         self.prompt_set = prompt_set
@@ -127,9 +125,7 @@ class SafeHazardV1(HazardDefinition, ABC):
         if not self._tests:
             self._tests = [
                 TESTS.make_instance(
-                    BaseSafeTestVersion1.create_uid(
-                        self.hazard_key, self.locale, self.prompt_set, PROMPT_SETS, self._evaluator
-                    ),
+                    BaseSafeTestVersion1.create_uid(self.hazard_key, self.locale, self.prompt_set, self._evaluator),
                     secrets=secrets,
                 )
             ]

--- a/src/modelbench/run.py
+++ b/src/modelbench/run.py
@@ -22,10 +22,10 @@ from click import echo
 from modelgauge.config import load_secrets_from_config, raise_if_missing_from_config, write_default_config
 from modelgauge.load_plugins import load_plugins
 from modelgauge.locales import DEFAULT_LOCALE, EN_US, LOCALES, validate_locale
+from modelgauge.prompt_sets import PROMPT_SETS
 from modelgauge.sut import SUT
 from modelgauge.sut_decorator import modelgauge_sut
 from modelgauge.sut_registry import SUTS
-from modelgauge.tests.safe_v1 import PROMPT_SETS
 from rich.console import Console
 from rich.table import Table
 
@@ -346,7 +346,7 @@ def update_standards_to(standards_file):
 
     benchmarks = []
     for l in [EN_US]:
-        for prompt_set in PROMPT_SETS:
+        for prompt_set in PROMPT_SETS.keys():
             benchmarks.append(GeneralPurposeAiChatBenchmarkV1(l, prompt_set, "ensemble"))
     run_result = run_benchmarks_for_suts(benchmarks, reference_suts, None)
     all_hazard_numeric_scores = defaultdict(list)

--- a/src/modelgauge/locales.py
+++ b/src/modelgauge/locales.py
@@ -9,6 +9,8 @@ DEFAULT_LOCALE = "en_us"
 
 # add the other languages after we have official and practice prompt sets
 LOCALES = (EN_US, FR_FR)
+# all the languages we have official and practice prompt sets for
+PUBLISHED_LOCALES = (EN_US,)
 
 
 def is_valid(locale: str) -> bool:

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -25,13 +25,13 @@ TEST_PROMPT_SETS = {
 PROMPT_SET_DOWNLOAD_HOST = "ailuminate.mlcommons.org"
 
 
-def prompt_set_file_base_name(prompt_set: str) -> str:
-    filename = PROMPT_SETS.get(prompt_set, TEST_PROMPT_SETS.get(prompt_set, ""))
+def prompt_set_file_base_name(prompt_set: str, prompt_sets: dict = PROMPT_SETS) -> str:
+    filename = prompt_sets.get(prompt_set, None)
     return filename
 
 
-def validate_prompt_set(prompt_set: str) -> bool:
-    filename = prompt_set_file_base_name(prompt_set)
+def validate_prompt_set(prompt_set: str, prompt_sets: dict = PROMPT_SETS) -> bool:
+    filename = prompt_set_file_base_name(prompt_set, prompt_sets)
     if not filename:
-        raise ValueError(f"Invalid prompt set {prompt_set}. Must be one of {PROMPT_SETS.keys()}.")
+        raise ValueError(f"Invalid prompt set {prompt_set}. Must be one of {prompt_sets.keys()}.")
     return True

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -1,0 +1,37 @@
+from modelgauge.secret_values import RequiredSecret, SecretDescription
+
+
+class ModellabFileDownloadToken(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="modellab_files",
+            key="token",
+            instructions="Please ask MLCommons admin for permission.",
+        )
+
+
+# file name format:
+# {prefix}_{version}_{type}(_{locale})_prompt_set_release
+PROMPT_SETS = {
+    "practice": "airr_official_1.0_practice_prompt_set_release",
+    "official": "airr_official_1.0_heldback_prompt_set_release",
+    "practice_fr": "airr_official_1.0_practice_fr_fr_prompt_set_release",
+}
+TEST_PROMPT_SETS = {
+    "fake-prompts": "fake-prompts",
+}
+
+PROMPT_SET_DOWNLOAD_HOST = "ailuminate.mlcommons.org"
+
+
+def prompt_set_file_base_name(prompt_set: str) -> str:
+    filename = PROMPT_SETS.get(prompt_set, TEST_PROMPT_SETS.get(prompt_set, ""))
+    return filename
+
+
+def validate_prompt_set(prompt_set: str) -> bool:
+    filename = prompt_set_file_base_name(prompt_set)
+    if not filename:
+        raise ValueError(f"Invalid prompt set {prompt_set}. Must be one of {PROMPT_SETS.keys()}.")
+    return True

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -18,10 +18,6 @@ PROMPT_SETS = {
     "official": "airr_official_1.0_heldback_prompt_set_release",
     "practice_fr_fr": "airr_official_1.0_practice_fr_fr_prompt_set_release",
 }
-TEST_PROMPT_SETS = {
-    "fake-prompts": "fake-prompts",
-}
-
 PROMPT_SET_DOWNLOAD_HOST = "ailuminate.mlcommons.org"
 
 

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -16,7 +16,7 @@ class ModellabFileDownloadToken(RequiredSecret):
 PROMPT_SETS = {
     "practice": "airr_official_1.0_practice_prompt_set_release",
     "official": "airr_official_1.0_heldback_prompt_set_release",
-    "practice_fr": "airr_official_1.0_practice_fr_fr_prompt_set_release",
+    "practice_fr_fr": "airr_official_1.0_practice_fr_fr_prompt_set_release",
 }
 TEST_PROMPT_SETS = {
     "fake-prompts": "fake-prompts",

--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -83,8 +83,8 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
     annotators: AnnotatorSet
 
     @staticmethod
-    def create_uid(hazard: str, locale: str, prompt_set: str, evaluator=None):
-        validate_prompt_set(prompt_set)
+    def create_uid(hazard: str, locale: str, prompt_set: str, prompt_sets: dict = PROMPT_SETS, evaluator=None):
+        validate_prompt_set(prompt_set, prompt_sets)
         validate_locale(locale)
         if evaluator is None or evaluator == "default":
             postfix = ""
@@ -100,6 +100,7 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
         locale: str,
         persona_types: List[SafePersonasVersion1],
         prompt_set: str,
+        prompt_sets: dict = PROMPT_SETS,
         token: Optional[ModellabFileDownloadToken] = None,
     ):
         self._check_annotators()
@@ -109,13 +110,13 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
         assert len(set(persona_types)) == len(
             persona_types
         ), f"Must specify a unique set of persona types, but got {persona_types}"
-        validate_prompt_set(prompt_set)
+        validate_prompt_set(prompt_set, prompt_sets)
         validate_locale(locale)
 
         self.hazard = hazard
         self.locale = locale
         self.persona_types = persona_types
-        self.prompt_set_file_base_name = prompt_set_file_base_name(prompt_set)
+        self.prompt_set_file_base_name = prompt_set_file_base_name(prompt_set, prompt_sets)
         self.token = token
 
     @classmethod
@@ -225,12 +226,12 @@ def register_tests(cls, evaluator=None):
     for locale in LOCALES:
         for hazard in cls.hazards:
             for prompt_set in PROMPT_SETS.keys():
-                test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, prompt_set, evaluator)
+                test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, prompt_set, PROMPT_SETS, evaluator)
                 token = None
                 # only practice prompt sets in English are publicly available for now
                 if prompt_set == "official" or locale != EN_US:
                     token = InjectSecret(ModellabFileDownloadToken)
-                TESTS.register(cls, test_uid, hazard, locale, ALL_PERSONAS, prompt_set, token)
+                TESTS.register(cls, test_uid, hazard, locale, ALL_PERSONAS, prompt_set, PROMPT_SETS, token)
 
 
 def register_private_annotator_tests(private_annotators, evaluator):

--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -11,23 +11,19 @@ from modelgauge.dependency_helper import DependencyHelper
 from modelgauge.external_data import ExternalData, WebData
 from modelgauge.locales import EN_US, LOCALES, validate_locale
 from modelgauge.prompt import SUTOptions, TextPrompt
-from modelgauge.secret_values import InjectSecret, RequiredSecret, SecretDescription
+from modelgauge.prompt_sets import (  # usort: skip
+    PROMPT_SET_DOWNLOAD_HOST,
+    PROMPT_SETS,
+    ModellabFileDownloadToken,
+    prompt_set_file_base_name,
+    validate_prompt_set,
+)
+from modelgauge.secret_values import InjectSecret
 from modelgauge.single_turn_prompt_response import MeasuredTestItem, PromptWithContext, TestItem, TestItemAnnotations
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.test_decorator import modelgauge_test
 from modelgauge.test_registry import TESTS
 from pydantic import BaseModel
-
-
-# TODO: agree on a standard for this
-# The strings in PROMPT_SETS are additionally decorated with the locale string in lowercase
-# upon download. This is to support downloading the "same" prompt set for different locales
-# and keep all of them downloaded locally.
-PROMPT_SETS = {
-    "practice": "airr_official_1.0_practice_prompt_set_release",
-    "official": "airr_official_1.0_heldback_prompt_set_release",
-}
-PROMPT_SET_DOWNLOAD_HOST = "ailuminate.mlcommons.org"
 
 
 class SafeTestItemContext(BaseModel):
@@ -41,16 +37,6 @@ class PersonaResult(BaseModel):
 
 class SafeTestResult(BaseModel):
     persona_results: Mapping[str, PersonaResult]
-
-
-class ModellabFileDownloadToken(RequiredSecret):
-    @classmethod
-    def description(cls) -> SecretDescription:
-        return SecretDescription(
-            scope="modellab_files",
-            key="token",
-            instructions="Please ask MLCommons admin for permission.",
-        )
 
 
 class SafePersonasVersion1(str, Enum):
@@ -98,7 +84,7 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
 
     @staticmethod
     def create_uid(hazard: str, locale: str, prompt_set: str, evaluator=None):
-        assert prompt_set in PROMPT_SETS
+        validate_prompt_set(prompt_set)
         validate_locale(locale)
         if evaluator is None or evaluator == "default":
             postfix = ""
@@ -123,13 +109,13 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
         assert len(set(persona_types)) == len(
             persona_types
         ), f"Must specify a unique set of persona types, but got {persona_types}"
-        assert prompt_set in PROMPT_SETS, f"Invalid prompt set {prompt_set}. Must be one of {PROMPT_SETS.keys()}."
+        validate_prompt_set(prompt_set)
         validate_locale(locale)
 
         self.hazard = hazard
         self.locale = locale
         self.persona_types = persona_types
-        self.prompt_set_file_name = PROMPT_SETS[prompt_set]
+        self.prompt_set_file_base_name = prompt_set_file_base_name(prompt_set)
         self.token = token
 
     @classmethod
@@ -138,23 +124,14 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
         if not hasattr(cls, "annotators") or cls.annotators is None:
             raise NotImplementedError("Concrete SafeTestVersion1 classes must set class-attribute `annotators`.")
 
-    def __localize_filename(self) -> str:
-        # TODO implement a better standard for prompt file names by locale
-        if self.locale != EN_US:
-            tail = f"_{self.locale}"
-        else:
-            tail = ""
-        filename = f"{self.prompt_set_file_name}{tail}"
-        return filename
-
     def get_dependencies(self) -> Mapping[str, ExternalData]:
         prompt_set_base_download_url = f"https://{PROMPT_SET_DOWNLOAD_HOST}/files/download"
         headers = None
         if self.token is not None:
             headers = {"auth-token": self.token.value}
-        source_url = f"{prompt_set_base_download_url}/{self.__localize_filename()}.csv"
+        source_url = f"{prompt_set_base_download_url}/{self.prompt_set_file_base_name}.csv"
         return {
-            self.prompt_set_file_name: WebData(
+            self.prompt_set_file_base_name: WebData(
                 source_url=source_url,
                 headers=headers,
             )
@@ -171,7 +148,7 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
             temperature=0.01,
         )
         test_items: List[TestItem] = []
-        data_file = dependency_helper.get_local_path(self.prompt_set_file_name)
+        data_file = dependency_helper.get_local_path(self.prompt_set_file_base_name)
 
         # We're not using a context manager here for better exception handling,
         # so the operator has some insight into why things aren't working.
@@ -247,7 +224,7 @@ ALL_PERSONAS = [
 def register_tests(cls, evaluator=None):
     for locale in LOCALES:
         for hazard in cls.hazards:
-            for prompt_set in PROMPT_SETS:
+            for prompt_set in PROMPT_SETS.keys():
                 test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, prompt_set, evaluator)
                 token = None
                 # only practice prompt sets in English are publicly available for now

--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -83,8 +83,8 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
     annotators: AnnotatorSet
 
     @staticmethod
-    def create_uid(hazard: str, locale: str, prompt_set: str, prompt_sets: dict = PROMPT_SETS, evaluator=None):
-        validate_prompt_set(prompt_set, prompt_sets)
+    def create_uid(hazard: str, locale: str, prompt_set: str, evaluator=None):
+        validate_prompt_set(prompt_set)
         validate_locale(locale)
         if evaluator is None or evaluator == "default":
             postfix = ""
@@ -100,7 +100,6 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
         locale: str,
         persona_types: List[SafePersonasVersion1],
         prompt_set: str,
-        prompt_sets: dict = PROMPT_SETS,
         token: Optional[ModellabFileDownloadToken] = None,
     ):
         self._check_annotators()
@@ -110,13 +109,13 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
         assert len(set(persona_types)) == len(
             persona_types
         ), f"Must specify a unique set of persona types, but got {persona_types}"
-        validate_prompt_set(prompt_set, prompt_sets)
+        validate_prompt_set(prompt_set)
         validate_locale(locale)
 
         self.hazard = hazard
         self.locale = locale
         self.persona_types = persona_types
-        self.prompt_set_file_base_name = prompt_set_file_base_name(prompt_set, prompt_sets)
+        self.prompt_set_file_base_name = prompt_set_file_base_name(prompt_set)
         self.token = token
 
     @classmethod
@@ -226,12 +225,9 @@ def register_tests(cls, evaluator=None):
     for locale in LOCALES:
         for hazard in cls.hazards:
             for prompt_set in PROMPT_SETS.keys():
-                test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, prompt_set, PROMPT_SETS, evaluator)
-                token = None
-                # only practice prompt sets in English are publicly available for now
-                if prompt_set == "official" or locale != EN_US:
-                    token = InjectSecret(ModellabFileDownloadToken)
-                TESTS.register(cls, test_uid, hazard, locale, ALL_PERSONAS, prompt_set, PROMPT_SETS, token)
+                test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, prompt_set, evaluator)
+                token = InjectSecret(ModellabFileDownloadToken)
+                TESTS.register(cls, test_uid, hazard, locale, ALL_PERSONAS, prompt_set, token)
 
 
 def register_private_annotator_tests(private_annotators, evaluator):

--- a/tests/modelbench_tests/test_benchmark.py
+++ b/tests/modelbench_tests/test_benchmark.py
@@ -5,29 +5,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from modelbench.benchmarks import (
-    BenchmarkDefinition,
-    BenchmarkScore,
-    GeneralPurposeAiChatBenchmarkV1,
-)
-from modelbench.hazards import (
-    HazardDefinition,
-    HazardScore,
-    SafeHazardV1,
-    STANDARDS,
-)
+from modelbench.benchmarks import BenchmarkDefinition, BenchmarkScore, GeneralPurposeAiChatBenchmarkV1
+from modelbench.hazards import STANDARDS, HazardDefinition, HazardScore, SafeHazardV1  # usort: skip
 from modelbench.scoring import ValueEstimate
 from modelgauge.base_test import BaseTest
 from modelgauge.locales import EN_US
+
+from modelgauge.prompt_sets import PROMPT_SETS
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
-from modelgauge.tests.safe_v1 import (
-    PROMPT_SETS,
-    PersonaResult,
-    SafeTestResult,
-    SafeTestVersion1,
-    SafePersonasVersion1,
-)
+from modelgauge.tests.safe_v1 import PersonaResult, SafePersonasVersion1, SafeTestResult, SafeTestVersion1
 
 
 @pytest.mark.parametrize("ai", ("ai", "AI", "aI", "Ai"))
@@ -64,7 +51,7 @@ def test_benchmark_v1_definition_basics(prompt_set, fake_secrets):
         assert hazard.hazard_key == hazard_key
         assert hazard.locale == EN_US
         assert hazard.prompt_set == prompt_set
-        assert prompt_set in hazard.tests(secrets=fake_secrets)[0].prompt_set_file_name
+        assert prompt_set in hazard.tests(secrets=fake_secrets)[0].prompt_set_file_base_name
 
 
 @pytest.mark.parametrize(

--- a/tests/modelbench_tests/test_record.py
+++ b/tests/modelbench_tests/test_record.py
@@ -81,7 +81,7 @@ def test_v1_hazard_definition_without_tests_loaded():
 
 def test_v1_hazard_definition_with_tests_loaded():
     hazard = SafeHazardV1("dfm", EN_US, "practice")
-    hazard.tests({"together": {"api_key": "ignored"}})
+    hazard.tests({"together": {"api_key": "fake"}, "modellab_files": {"token": "fake"}})
     j = encode_and_parse(hazard)
     assert j["uid"] == hazard.uid
     assert j["tests"] == ["safe-dfm-en_us-practice-1.0"]

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -15,7 +15,7 @@ from modelbench.run import cli, find_suts_for_sut_argument, get_benchmark
 from modelbench.scoring import ValueEstimate
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.locales import DEFAULT_LOCALE, EN_US, FR_FR, LOCALES
-from modelgauge.prompt_sets import PROMPT_SETS
+from modelgauge.prompt_sets import PROMPT_SETS, TEST_PROMPT_SETS
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.sut import PromptResponseSUT
@@ -68,7 +68,7 @@ def test_find_suts(sut):
 class TestCli:
     class MyBenchmark(BenchmarkDefinition):
         def _make_hazards(self) -> Sequence[HazardDefinition]:
-            return [SafeHazardV1(hazard, EN_US, "practice") for hazard in SafeHazardV1.all_hazard_keys]
+            return [SafeHazardV1(hazard, EN_US, "practice", PROMPT_SETS) for hazard in SafeHazardV1.all_hazard_keys]
 
         @property
         def uid(self):
@@ -77,7 +77,7 @@ class TestCli:
     def mock_score(
         self,
         sut: PromptResponseSUT,
-        benchmark=GeneralPurposeAiChatBenchmarkV1(EN_US, "practice"),
+        benchmark=GeneralPurposeAiChatBenchmarkV1(EN_US, "practice", PROMPT_SETS),
     ):
         est = ValueEstimate.make(0.123456, 100)
         return BenchmarkScore(
@@ -134,7 +134,11 @@ class TestCli:
         if prompt_set is not None:
             benchmark_options.extend(["--prompt-set", prompt_set])
         benchmark = get_benchmark(
-            version, locale if locale else DEFAULT_LOCALE, prompt_set if prompt_set else "practice", "default"
+            version,
+            locale if locale else DEFAULT_LOCALE,
+            prompt_set if prompt_set else "practice",
+            PROMPT_SETS,
+            "default",
         )
         command_options = [
             "benchmark",
@@ -169,7 +173,11 @@ class TestCli:
         if prompt_set is not None:
             benchmark_options.extend(["--prompt-set", prompt_set])
         benchmark = get_benchmark(
-            version, locale if locale else DEFAULT_LOCALE, prompt_set if prompt_set else "practice", "default"
+            version,
+            locale if locale else DEFAULT_LOCALE,
+            prompt_set if prompt_set else "practice",
+            PROMPT_SETS,
+            "default",
         )
 
         mock = MagicMock(return_value=[self.mock_score("fake-2", benchmark), self.mock_score("fake-2", benchmark)])

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -9,20 +9,16 @@ import pytest
 from click.testing import CliRunner
 
 from modelbench.benchmark_runner import BenchmarkRun, BenchmarkRunner
-from modelbench.benchmarks import (
-    BenchmarkDefinition,
-    BenchmarkScore,
-    GeneralPurposeAiChatBenchmarkV1,
-)
-from modelbench.hazards import HazardScore, HazardDefinition, SafeHazardV1
-from modelbench.run import benchmark, cli, find_suts_for_sut_argument, get_benchmark
+from modelbench.benchmarks import BenchmarkDefinition, BenchmarkScore, GeneralPurposeAiChatBenchmarkV1
+from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1
+from modelbench.run import cli, find_suts_for_sut_argument, get_benchmark
 from modelbench.scoring import ValueEstimate
 from modelgauge.base_test import PromptResponseTest
-from modelgauge.locales import DEFAULT_LOCALE, EN_US, FR_FR, LOCALES, display_for, is_valid
+from modelgauge.locales import DEFAULT_LOCALE, EN_US, FR_FR, LOCALES
+from modelgauge.prompt_sets import PROMPT_SETS
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.sut import PromptResponseSUT
-from modelgauge.tests.safe_v1 import PROMPT_SETS
 
 from modelgauge_tests.fake_sut import FakeSUT
 

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -15,7 +15,7 @@ from modelbench.run import cli, find_suts_for_sut_argument, get_benchmark
 from modelbench.scoring import ValueEstimate
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.locales import DEFAULT_LOCALE, EN_US, FR_FR, LOCALES
-from modelgauge.prompt_sets import PROMPT_SETS, TEST_PROMPT_SETS
+from modelgauge.prompt_sets import PROMPT_SETS
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.sut import PromptResponseSUT
@@ -68,7 +68,7 @@ def test_find_suts(sut):
 class TestCli:
     class MyBenchmark(BenchmarkDefinition):
         def _make_hazards(self) -> Sequence[HazardDefinition]:
-            return [SafeHazardV1(hazard, EN_US, "practice", PROMPT_SETS) for hazard in SafeHazardV1.all_hazard_keys]
+            return [SafeHazardV1(hazard, EN_US, "practice") for hazard in SafeHazardV1.all_hazard_keys]
 
         @property
         def uid(self):
@@ -77,7 +77,7 @@ class TestCli:
     def mock_score(
         self,
         sut: PromptResponseSUT,
-        benchmark=GeneralPurposeAiChatBenchmarkV1(EN_US, "practice", PROMPT_SETS),
+        benchmark=GeneralPurposeAiChatBenchmarkV1(EN_US, "practice"),
     ):
         est = ValueEstimate.make(0.123456, 100)
         return BenchmarkScore(
@@ -137,7 +137,6 @@ class TestCli:
             version,
             locale if locale else DEFAULT_LOCALE,
             prompt_set if prompt_set else "practice",
-            PROMPT_SETS,
             "default",
         )
         command_options = [
@@ -176,7 +175,6 @@ class TestCli:
             version,
             locale if locale else DEFAULT_LOCALE,
             prompt_set if prompt_set else "practice",
-            PROMPT_SETS,
             "default",
         )
 

--- a/tests/modelgauge_tests/fake_dependency_helper.py
+++ b/tests/modelgauge_tests/fake_dependency_helper.py
@@ -1,8 +1,9 @@
 import csv
 import io
 import os
-from modelgauge.dependency_helper import DependencyHelper
 from typing import List, Mapping
+
+from modelgauge.dependency_helper import DependencyHelper
 
 
 class FakeDependencyHelper(DependencyHelper):

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -1,5 +1,10 @@
 import pytest
-from modelgauge.prompt_sets import prompt_set_file_base_name, PROMPT_SETS, TEST_PROMPT_SETS, validate_prompt_set
+from modelgauge.prompt_sets import (
+    PROMPT_SETS,
+    TEST_PROMPT_SETS,
+    prompt_set_file_base_name,
+    validate_prompt_set,
+)  # usort: skip
 
 
 def test_file_base_name():

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -1,7 +1,6 @@
 import pytest
 from modelgauge.prompt_sets import (
     PROMPT_SETS,
-    TEST_PROMPT_SETS,
     prompt_set_file_base_name,
     validate_prompt_set,
 )  # usort: skip
@@ -9,7 +8,6 @@ from modelgauge.prompt_sets import (
 
 def test_file_base_name():
     assert prompt_set_file_base_name("bad") is None
-    assert prompt_set_file_base_name("fake-prompts", TEST_PROMPT_SETS) == "fake-prompts"
     assert prompt_set_file_base_name("practice") == PROMPT_SETS["practice"]
     assert prompt_set_file_base_name("practice", PROMPT_SETS) == PROMPT_SETS["practice"]
 
@@ -17,7 +15,5 @@ def test_file_base_name():
 def test_validate_prompt_set():
     for s in PROMPT_SETS.keys():
         assert validate_prompt_set(s, PROMPT_SETS)
-    for s in TEST_PROMPT_SETS.keys():
-        assert validate_prompt_set(s, TEST_PROMPT_SETS)
     with pytest.raises(ValueError):
         validate_prompt_set("should raise")

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -8,15 +8,16 @@ from modelgauge.prompt_sets import (
 
 
 def test_file_base_name():
-    assert prompt_set_file_base_name("bad") == ""
-    assert prompt_set_file_base_name("fake-prompts") == "fake-prompts"
+    assert prompt_set_file_base_name("bad") is None
+    assert prompt_set_file_base_name("fake-prompts", TEST_PROMPT_SETS) == "fake-prompts"
     assert prompt_set_file_base_name("practice") == PROMPT_SETS["practice"]
+    assert prompt_set_file_base_name("practice", PROMPT_SETS) == PROMPT_SETS["practice"]
 
 
 def test_validate_prompt_set():
     for s in PROMPT_SETS.keys():
-        assert validate_prompt_set(s)
+        assert validate_prompt_set(s, PROMPT_SETS)
     for s in TEST_PROMPT_SETS.keys():
-        assert validate_prompt_set(s)
+        assert validate_prompt_set(s, TEST_PROMPT_SETS)
     with pytest.raises(ValueError):
         validate_prompt_set("should raise")

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -1,0 +1,17 @@
+import pytest
+from modelgauge.prompt_sets import prompt_set_file_base_name, PROMPT_SETS, TEST_PROMPT_SETS, validate_prompt_set
+
+
+def test_file_base_name():
+    assert prompt_set_file_base_name("bad") == ""
+    assert prompt_set_file_base_name("fake-prompts") == "fake-prompts"
+    assert prompt_set_file_base_name("practice") == PROMPT_SETS["practice"]
+
+
+def test_validate_prompt_set():
+    for s in PROMPT_SETS.keys():
+        assert validate_prompt_set(s)
+    for s in TEST_PROMPT_SETS.keys():
+        assert validate_prompt_set(s)
+    with pytest.raises(ValueError):
+        validate_prompt_set("should raise")

--- a/tests/modelgauge_tests/test_safe.py
+++ b/tests/modelgauge_tests/test_safe.py
@@ -3,9 +3,10 @@ import pytest
 from modelgauge.auth.together_key import TogetherApiKey
 from modelgauge.locales import EN_US, FR_FR, LOCALES
 from modelgauge.prompt import TextPrompt
+from modelgauge.prompt_sets import PROMPT_SETS
 from modelgauge.single_turn_prompt_response import MeasuredTestItem, PromptWithContext, TestItem
+from modelgauge.test_registry import TESTS
 from modelgauge.tests.safe_v1 import (
-    PROMPT_SETS,
     BaseSafeTestVersion1,
     PersonaResult,
     SafePersonasVersion1,
@@ -13,18 +14,17 @@ from modelgauge.tests.safe_v1 import (
     SafeTestResult,
     SafeTestVersion1,
 )
-from modelgauge.test_registry import TESTS
 
 from modelgauge_tests.fake_dependency_helper import FakeDependencyHelper, make_csv
 
 FAKE_TOGETHER_KEY = TogetherApiKey("some-value")
 
 
-def _init_safe_test_v1(hazard, persona_types, prompt_set="practice"):
+def _init_safe_test_v1(hazard, persona_types, prompt_set="fake-prompts"):
     return SafeTestVersion1("uid", hazard, EN_US, persona_types, prompt_set)
 
 
-def _init_safe_test_v1_private(hazard, persona_types, prompt_set="practice"):
+def _init_safe_test_v1_private(hazard, persona_types, prompt_set="fake-prompts"):
     # TODO: Mock the private annotators
     try:
         return SafeTestVersion1("uid", hazard, EN_US, persona_types, prompt_set)


### PR DESCRIPTION
# Story 
https://github.com/mlcommons/modelbench/issues/781

# Rationale

## Filenames
https://github.com/mlcommons/modelbench/pull/744

## Test Items
https://github.com/mlcommons/modelbench/pull/780

# Main Change

New uploaded files need to be added to the `PROMPT_SETS` dict in `src/modelgauge/prompt_sets.py` and they need to contain the whole key. E.g. if you want to use the key "demo_hi_in" then your prompt file name should include "demo_hi_in" in it.

To use new prompt sets in modellab, you need to add them to the modellab drop down, and to the modelrunner list of prompt sets. We may want to change that so it's less manual.