### PR TITLE
Add hazard info to journal

### DIFF
--- a/docs/run-journal.md
+++ b/docs/run-journal.md
@@ -44,6 +44,7 @@ In order of occurrence:
 
 - starting journal - marks the beginning of the journal
 - starting run - gives basic information on the run
+- hazard info - gives information on each Hazard in the run
 - test info - gives information on each Test in the run
 - running pipeline - marks the start of the item pipeline
 - using test items - for each Test, the counts of Items available and actually used
@@ -73,6 +74,10 @@ Listed in run order. If a message isn't listed here, its fields are covered abov
     - suts - list of uids for the SUTs in the run
     - max_items - maximum number of Items per test to be run
     - thread_count - maximum number of threads per stage of pipeline
+- hazard info
+    - hazard - uid of the Hazard
+    - benchmark - uid of the Benchmark the Hazard is part of
+    - tests - list of uids of the Tests in the Hazard
 - test info
     - test - uid of Test
     - initialization - initialization record for Test

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -593,8 +593,8 @@ class BenchmarkRunner(TestRunnerBase):
                 for hazard in benchmark.hazards():
                     benchmark_run.journal.raw_entry(
                         "hazard info",
-                        benchmark=benchmark.uid,
                         hazard=hazard.uid,
+                        benchmark=benchmark.uid,
                         tests=hazard.test_uids(),
                     )
 

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -589,6 +589,15 @@ class BenchmarkRunner(TestRunnerBase):
                 max_items=benchmark_run.max_items,
                 thread_count=self.thread_count,
             )
+            for benchmark in benchmark_run.benchmarks:
+                for hazard in benchmark.hazards():
+                    benchmark_run.journal.raw_entry(
+                        "hazard info",
+                        benchmark=benchmark.uid,
+                        hazard=hazard.uid,
+                        tests=hazard.test_uids(),
+                    )
+
             for test in benchmark_run.tests:
                 benchmark_run.journal.raw_entry(
                     "test info",

--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -623,6 +623,7 @@ class TestRunJournaling(RunnerTestBase):
         assert messages == [
             "starting journal",
             "starting run",
+            "hazard info",
             "test info",
             "running pipeline",
             "using test items",


### PR DESCRIPTION
Right now there is no easy way to identify which test is associated with which hazard using the journal alone. This adds another entry to the journal with some extra hazard info.