### PR TITLE
Increase mistral backoff

### DIFF
--- a/plugins/mistral/modelgauge/suts/mistral_client.py
+++ b/plugins/mistral/modelgauge/suts/mistral_client.py
@@ -5,9 +5,9 @@ from mistralai.utils import BackoffStrategy, RetryConfig
 from modelgauge.secret_values import RequiredSecret, SecretDescription
 
 BACKOFF_INITIAL_MILLIS = 1000
-BACKOFF_MAX_INTERVAL_MILLIS = 20_000
+BACKOFF_MAX_INTERVAL_MILLIS = 100_000
 BACKOFF_EXPONENT = 1.9
-BACKOFF_MAX_ELAPSED_MILLIS = 120_000
+BACKOFF_MAX_ELAPSED_MILLIS = 86_400_000  # 1 day
 
 
 class MistralAIAPIKey(RequiredSecret):

--- a/plugins/mistral/modelgauge/suts/mistral_client.py
+++ b/plugins/mistral/modelgauge/suts/mistral_client.py
@@ -4,9 +4,9 @@ from mistralai.utils import BackoffStrategy, RetryConfig
 
 from modelgauge.secret_values import RequiredSecret, SecretDescription
 
-BACKOFF_INITIAL_MILLIS = 500
-BACKOFF_MAX_INTERVAL_MILLIS = 10_000
-BACKOFF_EXPONENT = 1.1
+BACKOFF_INITIAL_MILLIS = 1000
+BACKOFF_MAX_INTERVAL_MILLIS = 20_000
+BACKOFF_EXPONENT = 1.9
 BACKOFF_MAX_ELAPSED_MILLIS = 120_000
 
 


### PR DESCRIPTION
This results in 0 rate limit exceptions on my machine on a test of 1200 samples. 