### PR TITLE
a less janky, more local way for a specific test to request real secrets

### DIFF
--- a/src/modelgauge/config.py
+++ b/src/modelgauge/config.py
@@ -1,10 +1,11 @@
 import os
 import shutil
-import tomli
 from importlib import resources
+from typing import Dict, Mapping, Optional, Sequence
+
+import tomli
 from modelgauge import config_templates
 from modelgauge.secret_values import MissingSecretValues, RawSecrets, SecretDescription
-from typing import Dict, Mapping, Sequence
 
 DEFAULT_CONFIG_DIR = "config"
 DEFAULT_SECRETS = "secrets.toml"
@@ -35,6 +36,16 @@ def load_secrets_from_config(path: str = SECRETS_PATH) -> RawSecrets:
             assert isinstance(key, str)
             assert isinstance(value, str)
     return data
+
+
+def extract_secret_scope(scope: str, secrets: Optional[RawSecrets] = None) -> Mapping[str, str] | None:
+    if not secrets:
+        secrets = load_secrets_from_config()
+    try:
+        secret = secrets[scope]
+    except:
+        secret = None
+    return secret
 
 
 def toml_format_secrets(secrets: Sequence[SecretDescription]) -> str:

--- a/tests/modelgauge_tests/test_config.py
+++ b/tests/modelgauge_tests/test_config.py
@@ -1,9 +1,11 @@
 import os
+
 import pytest
 from modelgauge.config import (
     DEFAULT_SECRETS,
-    MissingSecretsFromConfig,
+    extract_secret_scope,
     load_secrets_from_config,
+    MissingSecretsFromConfig,
     raise_if_missing_from_config,
     write_default_config,
 )
@@ -32,6 +34,23 @@ def test_load_secrets_from_config_loads_default(tmpdir):
     secrets_file = config_dir.join(DEFAULT_SECRETS)
 
     assert load_secrets_from_config(secrets_file) == {"demo": {"api_key": "12345"}}
+
+
+def test_extract_scope(tmpdir):
+    config_dir = tmpdir.join("config")
+    write_default_config(config_dir)
+    secrets_file = config_dir.join(DEFAULT_SECRETS)
+
+    assert extract_secret_scope("demo") == {"api_key": "12345"}
+    assert extract_secret_scope("bogus") is None
+
+    secrets = load_secrets_from_config(secrets_file)
+    assert extract_secret_scope("demo", secrets) == {"api_key": "12345"}
+    assert extract_secret_scope("bogus", secrets) is None
+
+    test_secrets = {"something": {"about": "mary"}}
+    assert extract_secret_scope("something", test_secrets) == {"about": "mary"}
+    assert extract_secret_scope("somethingelse", test_secrets) is None
 
 
 def test_load_secrets_from_config_no_file(tmpdir):


### PR DESCRIPTION
A plugin validation test needs to download prompt sets from modellab, which requires a token. This gives individual tests the ability to request tokens they may need without putting real secrets in the fake secrets dict in the global namespace.


