### PR TITLE
Retry decorator

### DIFF
--- a/plugins/google/modelgauge/suts/google_genai_client.py
+++ b/plugins/google/modelgauge/suts/google_genai_client.py
@@ -110,7 +110,7 @@ class GoogleGenAiBaseSUT(PromptResponseSUT[GoogleGenAiRequest, GoogleGenAiRespon
             contents=prompt.text, generation_config=generation_config, safety_settings=self.safety_settings
         )
 
-    @retry(unacceptable_exceptions=[InternalServerError, ResourceExhausted, RetryError, TooManyRequests])
+    @retry(transient_exceptions=[InternalServerError, ResourceExhausted, RetryError, TooManyRequests])
     def evaluate(self, request: GoogleGenAiRequest) -> GoogleGenAiResponse:
         if self.model is None:
             # Handle lazy init.

--- a/plugins/google/modelgauge/suts/google_genai_client.py
+++ b/plugins/google/modelgauge/suts/google_genai_client.py
@@ -2,11 +2,13 @@ from abc import abstractmethod
 from typing import Dict, List, Optional
 
 import google.generativeai as genai  # type: ignore
+from google.api_core.exceptions import InternalServerError, ResourceExhausted, RetryError, TooManyRequests
 from google.generativeai.types import HarmCategory, HarmBlockThreshold  # type: ignore
 from pydantic import BaseModel
 
 from modelgauge.general import APIException
 from modelgauge.prompt import TextPrompt
+from modelgauge.retry_decorator import retry
 from modelgauge.secret_values import InjectSecret, RequiredSecret, SecretDescription
 from modelgauge.sut import REFUSAL_RESPONSE, PromptResponseSUT, SUTCompletion, SUTResponse
 from modelgauge.sut_capabilities import AcceptsTextPrompt
@@ -108,6 +110,7 @@ class GoogleGenAiBaseSUT(PromptResponseSUT[GoogleGenAiRequest, GoogleGenAiRespon
             contents=prompt.text, generation_config=generation_config, safety_settings=self.safety_settings
         )
 
+    @retry(unacceptable_exceptions=[InternalServerError, ResourceExhausted, RetryError, TooManyRequests])
     def evaluate(self, request: GoogleGenAiRequest) -> GoogleGenAiResponse:
         if self.model is None:
             # Handle lazy init.

--- a/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
@@ -87,7 +87,7 @@ class HuggingFaceChatCompletionSUT(
             **prompt.options.model_dump(),
         )
 
-    @retry(unacceptable_exceptions=[InferenceTimeoutError])  # Raised when model is unavailable or the request times out
+    @retry(transient_exceptions=[InferenceTimeoutError])  # Raised when model is unavailable or the request times out
     def evaluate(self, request: HuggingFaceChatCompletionRequest) -> HuggingFaceChatCompletionOutput:
         if self.client is None:
             self._create_client()

--- a/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
@@ -2,12 +2,11 @@ from dataclasses import asdict
 from typing import Dict, List, Optional
 
 from huggingface_hub import get_inference_endpoint, InferenceClient, InferenceEndpointStatus  # type: ignore
-from huggingface_hub.utils import HfHubHTTPError, InferenceTimeoutError  # type: ignore
+from huggingface_hub.utils import HfHubHTTPError  # type: ignore
 from pydantic import BaseModel
 
 from modelgauge.auth.huggingface_inference_token import HuggingFaceInferenceToken
 from modelgauge.prompt import TextPrompt
-from modelgauge.retry_decorator import retry
 from modelgauge.secret_values import InjectSecret
 from modelgauge.sut import PromptResponseSUT, SUTCompletion, SUTResponse, TokenProbability, TopTokens
 from modelgauge.sut_capabilities import AcceptsTextPrompt, ProducesPerTokenLogProbabilities
@@ -87,7 +86,6 @@ class HuggingFaceChatCompletionSUT(
             **prompt.options.model_dump(),
         )
 
-    @retry(transient_exceptions=[InferenceTimeoutError])  # Raised when model is unavailable or the request times out
     def evaluate(self, request: HuggingFaceChatCompletionRequest) -> HuggingFaceChatCompletionOutput:
         if self.client is None:
             self._create_client()

--- a/plugins/mistral/modelgauge/suts/mistral_client.py
+++ b/plugins/mistral/modelgauge/suts/mistral_client.py
@@ -5,9 +5,9 @@ from mistralai.utils import BackoffStrategy, RetryConfig
 from modelgauge.secret_values import RequiredSecret, SecretDescription
 
 BACKOFF_INITIAL_MILLIS = 1000
-BACKOFF_MAX_INTERVAL_MILLIS = 20_000
+BACKOFF_MAX_INTERVAL_MILLIS = 100_000
 BACKOFF_EXPONENT = 1.9
-BACKOFF_MAX_ELAPSED_MILLIS = 120_000
+BACKOFF_MAX_ELAPSED_MILLIS = 86_400_000  # 1 day
 
 
 class MistralAIAPIKey(RequiredSecret):

--- a/plugins/mistral/modelgauge/suts/mistral_client.py
+++ b/plugins/mistral/modelgauge/suts/mistral_client.py
@@ -4,9 +4,9 @@ from mistralai.utils import BackoffStrategy, RetryConfig
 
 from modelgauge.secret_values import RequiredSecret, SecretDescription
 
-BACKOFF_INITIAL_MILLIS = 500
-BACKOFF_MAX_INTERVAL_MILLIS = 10_000
-BACKOFF_EXPONENT = 1.1
+BACKOFF_INITIAL_MILLIS = 1000
+BACKOFF_MAX_INTERVAL_MILLIS = 20_000
+BACKOFF_EXPONENT = 1.9
 BACKOFF_MAX_ELAPSED_MILLIS = 120_000
 
 

--- a/plugins/mistral/modelgauge/suts/mistral_sut.py
+++ b/plugins/mistral/modelgauge/suts/mistral_sut.py
@@ -61,7 +61,7 @@ class MistralAISut(PromptResponseSUT):
             args["max_tokens"] = prompt.options.max_tokens
         return MistralAIRequest(**args)
 
-    @retry(unacceptable_exceptions=[SDKError])
+    @retry(transient_exceptions=[SDKError])
     def evaluate(self, request: MistralAIRequest) -> ChatCompletionResponse:
         response = self.client.request(request.model_dump(exclude_none=True))  # type: ignore
         return response
@@ -132,6 +132,7 @@ class MistralAIModeratedSut(PromptResponseSUT):
             args["max_tokens"] = prompt.options.max_tokens
         return MistralAIRequest(temperature=self.temperature, n=self.num_generations, **args)
 
+    @retry(transient_exceptions=[SDKError])
     def evaluate(self, request: MistralAIRequest) -> MistralAIResponseWithModerations:
         response = self.client.request(request.model_dump(exclude_none=True))  # type: ignore
         assert (

--- a/plugins/mistral/modelgauge/suts/mistral_sut.py
+++ b/plugins/mistral/modelgauge/suts/mistral_sut.py
@@ -1,8 +1,9 @@
 import warnings
 from typing import Optional
 
-from mistralai.models import ChatCompletionResponse, ClassificationResponse
+from mistralai.models import ChatCompletionResponse, ClassificationResponse, SDKError
 from modelgauge.prompt import TextPrompt
+from modelgauge.retry_decorator import retry
 from modelgauge.secret_values import InjectSecret
 from modelgauge.sut import PromptResponseSUT, SUTCompletion, SUTResponse
 from modelgauge.sut_capabilities import AcceptsTextPrompt
@@ -60,6 +61,7 @@ class MistralAISut(PromptResponseSUT):
             args["max_tokens"] = prompt.options.max_tokens
         return MistralAIRequest(**args)
 
+    @retry(unacceptable_exceptions=[SDKError])
     def evaluate(self, request: MistralAIRequest) -> ChatCompletionResponse:
         response = self.client.request(request.model_dump(exclude_none=True))  # type: ignore
         return response

--- a/plugins/nvidia/modelgauge/suts/nvidia_nim_api_client.py
+++ b/plugins/nvidia/modelgauge/suts/nvidia_nim_api_client.py
@@ -1,10 +1,12 @@
 from typing import Any, Dict, List, Optional, Union
 
 from openai import OpenAI
+from openai import APITimeoutError, ConflictError, InternalServerError, RateLimitError
 from openai.types.chat import ChatCompletion
 from pydantic import BaseModel
 
 from modelgauge.prompt import ChatPrompt, ChatRole, SUTOptions, TextPrompt
+from modelgauge.retry_decorator import retry
 from modelgauge.secret_values import (
     InjectSecret,
     RequiredSecret,
@@ -115,6 +117,7 @@ class NvidiaNIMApiClient(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
             **optional_kwargs,
         )
 
+    @retry(unacceptable_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
     def evaluate(self, request: OpenAIChatRequest) -> ChatCompletion:
         if self.client is None:
             # Handle lazy init.

--- a/plugins/nvidia/modelgauge/suts/nvidia_nim_api_client.py
+++ b/plugins/nvidia/modelgauge/suts/nvidia_nim_api_client.py
@@ -117,7 +117,7 @@ class NvidiaNIMApiClient(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
             **optional_kwargs,
         )
 
-    @retry(unacceptable_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
+    @retry(transient_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
     def evaluate(self, request: OpenAIChatRequest) -> ChatCompletion:
         if self.client is None:
             # Handle lazy init.

--- a/plugins/openai/modelgauge/suts/openai_client.py
+++ b/plugins/openai/modelgauge/suts/openai_client.py
@@ -1,10 +1,12 @@
 from typing import Any, Dict, List, Optional, Union
 
 from openai import OpenAI
+from openai import APITimeoutError, ConflictError, InternalServerError, RateLimitError
 from openai.types.chat import ChatCompletion
 from pydantic import BaseModel
 
 from modelgauge.prompt import ChatPrompt, ChatRole, SUTOptions, TextPrompt
+from modelgauge.retry_decorator import retry
 from modelgauge.secret_values import (
     InjectSecret,
     OptionalSecret,
@@ -139,6 +141,7 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
             **optional_kwargs,
         )
 
+    @retry(unacceptable_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
     def evaluate(self, request: OpenAIChatRequest) -> ChatCompletion:
         if self.client is None:
             # Handle lazy init.

--- a/plugins/openai/modelgauge/suts/openai_client.py
+++ b/plugins/openai/modelgauge/suts/openai_client.py
@@ -141,7 +141,7 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
             **optional_kwargs,
         )
 
-    @retry(unacceptable_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
+    @retry(transient_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
     def evaluate(self, request: OpenAIChatRequest) -> ChatCompletion:
         if self.client is None:
             # Handle lazy init.

--- a/src/modelgauge/retry_decorator.py
+++ b/src/modelgauge/retry_decorator.py
@@ -6,12 +6,12 @@ MAX_RETRY_DURATION = 86400  # 1 day in seconds
 MAX_BACKOFF = 60  # 1 minute in seconds
 
 
-def retry(unacceptable_exceptions=None):
+def retry(transient_exceptions=None):
     """
     A decorator that retries a function at least BASE_RETRY_COUNT times.
-    If unacceptable_exceptions are specified, it will retry for up to 1 day if any of those exceptions occur.
+    If transient_exceptions are specified, it will retry for up to 1 day if any of those exceptions occur.
     """
-    unacceptable_exceptions = tuple(unacceptable_exceptions) if unacceptable_exceptions else ()
+    transient_exceptions = tuple(transient_exceptions) if transient_exceptions else ()
 
     def decorator(func):
         @functools.wraps(func)
@@ -22,8 +22,8 @@ def retry(unacceptable_exceptions=None):
             while True:
                 try:
                     return func(*args, **kwargs)
-                except unacceptable_exceptions as e:
-                    # Keep retrying "unacceptable" exceptions for 1 day.
+                except transient_exceptions as e:
+                    # Keep retrying transient exceptions for 1 day.
                     elapsed_time = time.time() - start_time
                     if elapsed_time >= MAX_RETRY_DURATION:
                         raise

--- a/src/modelgauge/retry_decorator.py
+++ b/src/modelgauge/retry_decorator.py
@@ -6,9 +6,14 @@ MAX_RETRY_DURATION = 86400  # 1 day in seconds
 MAX_BACKOFF = 60  # 1 minute in seconds
 
 
-def retry(transient_exceptions=None):
+def retry(
+    transient_exceptions=None,
+    base_retry_count=BASE_RETRY_COUNT,
+    max_retry_duration=MAX_RETRY_DURATION,
+    max_backoff=MAX_BACKOFF,
+):
     """
-    A decorator that retries a function at least BASE_RETRY_COUNT times.
+    A decorator that retries a function at least base_retry_count times.
     If transient_exceptions are specified, it will retry for up to 1 day if any of those exceptions occur.
     """
     transient_exceptions = tuple(transient_exceptions) if transient_exceptions else ()
@@ -25,14 +30,14 @@ def retry(transient_exceptions=None):
                 except transient_exceptions as e:
                     # Keep retrying transient exceptions for 1 day.
                     elapsed_time = time.time() - start_time
-                    if elapsed_time >= MAX_RETRY_DURATION:
+                    if elapsed_time >= max_retry_duration:
                         raise
                 except:
                     # Retry all other exceptions BASE_RETRY_COUNT times.
                     attempt += 1
-                    if attempt >= BASE_RETRY_COUNT:
+                    if attempt >= base_retry_count:
                         raise
-                sleep_time = min(2**attempt, MAX_BACKOFF)  # Exponential backoff with cap
+                sleep_time = min(2**attempt, max_backoff)  # Exponential backoff with cap
                 time.sleep(sleep_time)
 
         return wrapper

--- a/src/modelgauge/retry_decorator.py
+++ b/src/modelgauge/retry_decorator.py
@@ -13,7 +13,6 @@ def retry(unacceptable_exceptions=None):
     """
     unacceptable_exceptions = tuple(unacceptable_exceptions) if unacceptable_exceptions else ()
 
-    # TODO: Is functools.wraps necessary? Test if journal works without it.
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/src/modelgauge/retry_decorator.py
+++ b/src/modelgauge/retry_decorator.py
@@ -1,5 +1,5 @@
-import time
 import functools
+import time
 
 BASE_RETRY_COUNT = 3
 MAX_RETRY_DURATION = 86400  # 1 day in seconds

--- a/src/modelgauge/retry_decorator.py
+++ b/src/modelgauge/retry_decorator.py
@@ -1,0 +1,41 @@
+import time
+import functools
+
+BASE_RETRY_COUNT = 3
+MAX_RETRY_DURATION = 86400  # 1 day in seconds
+MAX_BACKOFF = 60  # 1 minute in seconds
+
+
+def retry(unacceptable_exceptions=None):
+    """
+    A decorator that retries a function at least BASE_RETRY_COUNT times.
+    If unacceptable_exceptions are specified, it will retry for up to 1 day if any of those exceptions occur.
+    """
+    unacceptable_exceptions = tuple(unacceptable_exceptions) if unacceptable_exceptions else ()
+
+    # TODO: Is functools.wraps necessary? Test if journal works without it.
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            attempt = 0
+            start_time = time.time()
+
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except unacceptable_exceptions as e:
+                    # Keep retrying "unacceptable" exceptions for 1 day.
+                    elapsed_time = time.time() - start_time
+                    if elapsed_time >= MAX_RETRY_DURATION:
+                        raise
+                except:
+                    # Retry all other exceptions BASE_RETRY_COUNT times.
+                    attempt += 1
+                    if attempt >= BASE_RETRY_COUNT:
+                        raise
+                sleep_time = min(2**attempt, MAX_BACKOFF)  # Exponential backoff with cap
+                time.sleep(sleep_time)
+
+        return wrapper
+
+    return decorator

--- a/src/modelgauge/retry_decorator.py
+++ b/src/modelgauge/retry_decorator.py
@@ -1,9 +1,12 @@
 import functools
+import logging
 import time
 
 BASE_RETRY_COUNT = 3
 MAX_RETRY_DURATION = 86400  # 1 day in seconds
 MAX_BACKOFF = 60  # 1 minute in seconds
+
+logger = logging.getLogger(__name__)
 
 
 def retry(
@@ -32,11 +35,13 @@ def retry(
                     elapsed_time = time.time() - start_time
                     if elapsed_time >= max_retry_duration:
                         raise
-                except:
+                    logger.warning(f"Transient exception occurred: {e}. Retrying...")
+                except Exception as e:
                     # Retry all other exceptions BASE_RETRY_COUNT times.
                     attempt += 1
                     if attempt >= base_retry_count:
                         raise
+                    logger.warning(f"Exception occurred after {attempt}/{base_retry_count} attempts: {e}. Retrying...")
                 sleep_time = min(2**attempt, max_backoff)  # Exponential backoff with cap
                 time.sleep(sleep_time)
 

--- a/tests/modelgauge_tests/test_retry_decorator.py
+++ b/tests/modelgauge_tests/test_retry_decorator.py
@@ -48,13 +48,13 @@ def test_retry_unacceptable_eventually_succeeds():
     start_time = time.time()
 
     @retry(unacceptable_exceptions=[ValueError])
-    def succeed_after_twenty_seconds():
+    def succeed_eventually():
         nonlocal attempt_counter
         attempt_counter += 1
         elapsed_time = time.time() - start_time
-        if elapsed_time < 20:
+        if elapsed_time < 5:
             raise ValueError("Intentional failure")
         return "success"
 
-    assert succeed_after_twenty_seconds() == "success"
+    assert succeed_eventually() == "success"
     assert attempt_counter > BASE_RETRY_COUNT

--- a/tests/modelgauge_tests/test_retry_decorator.py
+++ b/tests/modelgauge_tests/test_retry_decorator.py
@@ -5,11 +5,16 @@ from modelgauge.retry_decorator import retry, BASE_RETRY_COUNT
 
 
 def test_retry_success():
+    attempt_counter = 0
+
     @retry()
     def always_succeed():
+        nonlocal attempt_counter
+        attempt_counter += 1
         return "success"
 
     assert always_succeed() == "success"
+    assert attempt_counter == 1
 
 
 @pytest.mark.parametrize("exceptions", [None, [ValueError]])

--- a/tests/modelgauge_tests/test_retry_decorator.py
+++ b/tests/modelgauge_tests/test_retry_decorator.py
@@ -1,0 +1,60 @@
+import pytest
+import time
+
+from modelgauge.retry_decorator import retry, BASE_RETRY_COUNT
+
+
+def test_retry_success():
+    @retry()
+    def always_succeed():
+        return "success"
+
+    assert always_succeed() == "success"
+
+
+@pytest.mark.parametrize("exceptions", [None, [ValueError]])
+def test_retry_fails_after_base_retries(exceptions):
+    attempt_counter = 0
+
+    @retry(unacceptable_exceptions=exceptions)
+    def always_fail():
+        nonlocal attempt_counter
+        attempt_counter += 1
+        raise KeyError("Intentional failure")
+
+    with pytest.raises(KeyError):
+        always_fail()
+
+    assert attempt_counter == BASE_RETRY_COUNT
+
+
+def test_retry_eventually_succeeds():
+    attempt_counter = 0
+
+    @retry(unacceptable_exceptions=[ValueError])
+    def succeed_after_two_attempts():
+        nonlocal attempt_counter
+        attempt_counter += 1
+        if attempt_counter < BASE_RETRY_COUNT:
+            raise ValueError("Intentional failure")
+        return "success"
+
+    assert succeed_after_two_attempts() == "success"
+    assert attempt_counter == BASE_RETRY_COUNT
+
+
+def test_retry_unacceptable_eventually_succeeds():
+    attempt_counter = 0
+    start_time = time.time()
+
+    @retry(unacceptable_exceptions=[ValueError])
+    def succeed_after_twenty_seconds():
+        nonlocal attempt_counter
+        attempt_counter += 1
+        elapsed_time = time.time() - start_time
+        if elapsed_time < 20:
+            raise ValueError("Intentional failure")
+        return "success"
+
+    assert succeed_after_twenty_seconds() == "success"
+    assert attempt_counter > BASE_RETRY_COUNT

--- a/tests/modelgauge_tests/test_retry_decorator.py
+++ b/tests/modelgauge_tests/test_retry_decorator.py
@@ -32,14 +32,14 @@ def test_retry_eventually_succeeds():
     attempt_counter = 0
 
     @retry(transient_exceptions=[ValueError])
-    def succeed_after_two_attempts():
+    def succeed_before_base_retry_total():
         nonlocal attempt_counter
         attempt_counter += 1
         if attempt_counter < BASE_RETRY_COUNT:
             raise ValueError("Intentional failure")
         return "success"
 
-    assert succeed_after_two_attempts() == "success"
+    assert succeed_before_base_retry_total() == "success"
     assert attempt_counter == BASE_RETRY_COUNT
 
 
@@ -47,14 +47,13 @@ def test_retry_transient_eventually_succeeds():
     attempt_counter = 0
     start_time = time.time()
 
-    @retry(transient_exceptions=[ValueError])
+    @retry(transient_exceptions=[ValueError], max_retry_duration=3, base_retry_count=1)
     def succeed_eventually():
         nonlocal attempt_counter
         attempt_counter += 1
         elapsed_time = time.time() - start_time
-        if elapsed_time < 5:
+        if elapsed_time < 1:
             raise ValueError("Intentional failure")
         return "success"
 
     assert succeed_eventually() == "success"
-    assert attempt_counter > BASE_RETRY_COUNT

--- a/tests/modelgauge_tests/test_retry_decorator.py
+++ b/tests/modelgauge_tests/test_retry_decorator.py
@@ -16,7 +16,7 @@ def test_retry_success():
 def test_retry_fails_after_base_retries(exceptions):
     attempt_counter = 0
 
-    @retry(unacceptable_exceptions=exceptions)
+    @retry(transient_exceptions=exceptions)
     def always_fail():
         nonlocal attempt_counter
         attempt_counter += 1
@@ -31,7 +31,7 @@ def test_retry_fails_after_base_retries(exceptions):
 def test_retry_eventually_succeeds():
     attempt_counter = 0
 
-    @retry(unacceptable_exceptions=[ValueError])
+    @retry(transient_exceptions=[ValueError])
     def succeed_after_two_attempts():
         nonlocal attempt_counter
         attempt_counter += 1
@@ -43,11 +43,11 @@ def test_retry_eventually_succeeds():
     assert attempt_counter == BASE_RETRY_COUNT
 
 
-def test_retry_unacceptable_eventually_succeeds():
+def test_retry_transient_eventually_succeeds():
     attempt_counter = 0
     start_time = time.time()
 
-    @retry(unacceptable_exceptions=[ValueError])
+    @retry(transient_exceptions=[ValueError])
     def succeed_eventually():
         nonlocal attempt_counter
         attempt_counter += 1


### PR DESCRIPTION
A retry decorator that SUTs can use on their `evaluate` method. It is designed around the idea that there are two types of exceptions: those that should only retried a handful of times and those that should be more persistently retried until success (e.g. rate limits).