### PR TITLE
add evaluator-type to hazard UID

### DIFF
--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -137,6 +137,7 @@ class SafeHazardV1(HazardDefinition, ABC):
         "hazard": "self.hazard_key",
         "locale": "self.locale",
         "prompt_set": "self.prompt_set",
+        "evaluator": "self._evaluator",
     }
 
 
@@ -169,13 +170,22 @@ class Standards:
             self.data = json.load(f)["standards"]
 
     def reference_standard_for(self, name):
-        # for a demo run, we want to use the practice reference standard
-        if name.endswith("-demo"):
-            name = name.replace("-demo", "-practice")
+        """
+        The Hazard uid now expresses more than we care about when determining which reference standard to use,
+        so we need to create a key from it that is less specific.
 
-        if name not in self.data["reference_standards"]:
+        For a key like "safe_hazard-1.0-vcr-en_us-practice-default", "-default" refers to the evaluator used, so we
+        will omit that.
+        """
+        key = "-".join(name.split("-")[0:-1])
+
+        # for a demo run, we want to use the practice reference standard
+        if key.endswith("-demo"):
+            key = key.replace("-demo", "-practice")
+
+        if key not in self.data["reference_standards"]:
             raise ValueError(f"No standard yet for {name}. Run `modelbench calibrate --update` to add one.")
-        return self.data["reference_standards"][name]
+        return self.data["reference_standards"][key]
 
     def average_standard_across_references(self, locale: str = "", version: str = "1.0") -> float:
         assert version == "1.0", "Only version 1.0 is supported."

--- a/tests/modelbench_tests/test_benchmark.py
+++ b/tests/modelbench_tests/test_benchmark.py
@@ -138,20 +138,22 @@ class TestHazardScoreBasics:
         assert hazard_score(probability).grade_label() == expected_label
 
 
-@pytest.mark.parametrize("prompt_set,ref", [("practice", 0.86), ("official", 0.821)])
-def test_hazard_v1_definition_basics(fake_secrets, prompt_set, ref):
-    h = SafeHazardV1("dfm", EN_US, prompt_set)
-    assert h.uid == f"safe_hazard-1.0-dfm-en_us-{prompt_set}"
+@pytest.mark.parametrize("prompt_set,ref,evaluator", [("practice", 0.86, "default"), ("official", 0.821, "ensemble")])
+def test_hazard_v1_definition_basics(fake_secrets, prompt_set, ref, evaluator):
+    h = SafeHazardV1("dfm", EN_US, prompt_set, evaluator=evaluator)
+    assert h.uid == f"safe_hazard-1.0-dfm-en_us-{prompt_set}-{evaluator.lower()}"
     assert h.locale == EN_US
     assert h.prompt_set == prompt_set
 
     assert h.key() == "safe_hazard-1_0-dfm"
     assert h.name() == f"Safe Dfm en_US Hazard V1.0 ({prompt_set.title()})"
     assert h.reference_standard() == ref
-    tests = h.tests(secrets=fake_secrets)
-    assert len(tests) == 1
-    for t in tests:
-        assert t.__class__ == SafeTestVersion1
+    # ensemble evaluators require modules that are not present
+    if not evaluator == "ensemble":
+        tests = h.tests(secrets=fake_secrets)
+        assert len(tests) == 1
+        for t in tests:
+            assert t.__class__ == SafeTestVersion1
 
 
 def test_hazard_v1_definition_invalid_hazard():

--- a/tests/modelbench_tests/test_record.py
+++ b/tests/modelbench_tests/test_record.py
@@ -89,7 +89,7 @@ def test_v1_hazard_definition_with_tests_loaded():
 def test_benchmark_definition():
     j = encode_and_parse(GeneralPurposeAiChatBenchmarkV1(locale=EN_US, prompt_set="practice"))
     assert j["uid"] == "general_purpose_ai_chat_benchmark-1.0-en_us-practice-default"
-    assert "safe_hazard-1.0-cse-en_us-practice" in [i["uid"] for i in j["hazards"]]
+    assert "safe_hazard-1.0-cse-en_us-practice-default" in [i["uid"] for i in j["hazards"]]
 
 
 def test_hazard_score():


### PR DESCRIPTION
This is a very simple addition of the evaluator type to the hazard UID. Maybe we want something more specific, as the evaluator types may not be sufficiently distinct as to be repeatable?