### PR TITLE
Collapse TestItemAnnotations with PromptInteractionAnnotations and SU…

### DIFF
--- a/demo_plugin/modelgauge/tests/demo_01_simple_qa_test.py
+++ b/demo_plugin/modelgauge/tests/demo_01_simple_qa_test.py
@@ -56,10 +56,8 @@ class DemoSimpleQATest(PromptResponseTest):
 
     def measure_quality(self, item: TestItemAnnotations) -> Dict[str, float]:
         """Use the TestItem context to report how well the SUT did."""
-        # This Test only uses a single Prompt per TestItem, so only 1 interaction.
-        interaction = item.interactions[0]
         # For simplicity, this demo assumes there is only one safe answer.
-        gave_safe_answer = interaction.response.completions[0].completion.text == interaction.prompt.context
+        gave_safe_answer = item.annotated_completions[0].completion.text == item.test_item.context
         return {"gave_safe_answer": 1 if gave_safe_answer else 0}
 
     def aggregate_measurements(self, items: List[MeasuredTestItem]) -> Dict[str, float]:

--- a/demo_plugin/modelgauge/tests/demo_02_unpacking_dependency_test.py
+++ b/demo_plugin/modelgauge/tests/demo_02_unpacking_dependency_test.py
@@ -64,10 +64,8 @@ class DemoUnpackingDependencyTest(PromptResponseTest):
 
     def measure_quality(self, item: TestItemAnnotations) -> Dict[str, float]:
         """Use the TestItem context to report how well the SUT did."""
-        # This Test only uses a single Prompt per TestItem, so only 1 interaction.
-        interaction = item.interactions[0]
         # For simplicity, this demo assumes there is only one safe answer.
-        gave_safe_answer = interaction.response.completions[0].completion.text == interaction.prompt.context
+        gave_safe_answer = item.annotated_completions[0].completion.text == item.test_item.context
         return {"gave_safe_answer": 1 if gave_safe_answer else 0}
 
     def aggregate_measurements(self, items: List[MeasuredTestItem]) -> Dict[str, float]:

--- a/demo_plugin/modelgauge/tests/demo_03_using_annotation_test.py
+++ b/demo_plugin/modelgauge/tests/demo_03_using_annotation_test.py
@@ -60,7 +60,7 @@ class DemoUsingAnnotationTest(PromptResponseTest):
     def measure_quality(self, item: TestItemAnnotations) -> Dict[str, float]:
         annotator_uid = self.get_annotators()[0]
         # Retrieve the annotation we asked for in `get_annotators`
-        annotation = item.interactions[0].response.completions[0].get_annotation(annotator_uid, DemoYBadAnnotation)
+        annotation = item.annotated_completions[0].get_annotation(annotator_uid, DemoYBadAnnotation)
         is_bad = annotation.badness > 0
         return {"is_bad": 1 if is_bad else 0}
 

--- a/src/modelbench/benchmark_runner_items.py
+++ b/src/modelbench/benchmark_runner_items.py
@@ -12,9 +12,7 @@ from modelgauge.dependency_helper import FromSourceDependencyHelper
 from modelgauge.external_data import WebData
 from modelgauge.single_turn_prompt_response import (
     MeasuredTestItem,
-    PromptInteractionAnnotations,
     SUTCompletionAnnotations,
-    SUTResponseAnnotations,
     TestItem,
     TestItemAnnotations,
 )
@@ -50,11 +48,9 @@ class ModelgaugeTestWrapper:
             completion=item.sut_response.completions[0],
             annotations={k: Annotation.from_instance(v) for k, v in item.annotations.items()},
         )
-        a = PromptInteractionAnnotations(
-            prompt=item.test_item,
-            response=SUTResponseAnnotations(completions=[annotations]),
+        measurement = self.actual_test.measure_quality(
+            TestItemAnnotations(test_item=item.test_item, annotated_completions=[annotations])
         )
-        measurement = self.actual_test.measure_quality(TestItemAnnotations(test_item=item.test_item, interactions=[a]))
         item.add_measurement(measurement)
 
     def aggregate_measurements(self, items: List["TestRunItem"]):

--- a/src/modelgauge/default_annotator_set.py
+++ b/src/modelgauge/default_annotator_set.py
@@ -9,10 +9,8 @@ class DefaultAnnotatorSet(AnnotatorSet):
     annotators: List[str] = ["llama_guard_2"]
 
     def evaluate(self, item: TestItemAnnotations) -> Dict[str, float]:
-        annotation = (
-            item.interactions[0]
-            .response.completions[0]
-            .get_annotation(DefaultAnnotatorSet.annotators[0], LlamaGuardAnnotation)
+        annotation = item.annotated_completions[0].get_annotation(
+            DefaultAnnotatorSet.annotators[0], LlamaGuardAnnotation
         )
         return {"is_safe": float(annotation.is_safe)}
 

--- a/src/modelgauge/private_ensemble_annotator_set.py
+++ b/src/modelgauge/private_ensemble_annotator_set.py
@@ -36,7 +36,7 @@ class EnsembleAnnotatorSet(AnnotatorSet):
         ]
 
     def evaluate(self, item: TestItemAnnotations) -> Dict[str, float]:
-        annotated_completion = item.interactions[0].response.completions[0]
+        annotated_completion = item.annotated_completions[0]
         individual_annotations = {}
         for annotator_id in self.annotators:
             if annotator_id in annotated_completion.annotations:

--- a/src/modelgauge/records.py
+++ b/src/modelgauge/records.py
@@ -2,7 +2,7 @@ from modelgauge.base_test import TestResult
 from modelgauge.general import current_local_datetime
 from modelgauge.record_init import InitializationRecord
 from modelgauge.single_turn_prompt_response import (
-    PromptInteractionAnnotations,
+    SUTCompletionAnnotations,
     TestItem,
 )
 from pydantic import AwareDatetime, BaseModel, Field
@@ -15,7 +15,7 @@ class TestItemRecord(BaseModel):
     # TODO: This duplicates the list of prompts across test_item and interactions.
     # Maybe just copy the TestItem context.
     test_item: TestItem
-    interactions: List[PromptInteractionAnnotations]
+    annotated_completions: List[SUTCompletionAnnotations]
     measurements: Dict[str, float]
 
     __test__ = False

--- a/src/modelgauge/simple_test_runner.py
+++ b/src/modelgauge/simple_test_runner.py
@@ -11,9 +11,7 @@ from modelgauge.prompt import TextPrompt
 from modelgauge.records import TestItemExceptionRecord, TestItemRecord, TestRecord
 from modelgauge.single_turn_prompt_response import (
     MeasuredTestItem,
-    PromptInteractionAnnotations,
     SUTCompletionAnnotations,
-    SUTResponseAnnotations,
     TestItem,
     TestItemAnnotations,
 )
@@ -118,7 +116,6 @@ def _process_test_item(
     annotators: List[CompletionAnnotator],
     annotator_caches: Dict[str, Cache],
 ) -> TestItemRecord:
-    interactions: List[PromptInteractionAnnotations] = []
     try:
         if isinstance(item.prompt, TextPrompt):
             sut_request = sut.translate_text_prompt(item.prompt)
@@ -147,20 +144,14 @@ def _process_test_item(
 
             annotations[annotator.uid] = Annotation.from_instance(annotation)
         annotated_completions.append(SUTCompletionAnnotations(completion=completion, annotations=annotations))
-    interactions.append(
-        PromptInteractionAnnotations(
-            prompt=item,
-            response=SUTResponseAnnotations(completions=annotated_completions),
-        )
-    )
     annotated = TestItemAnnotations(
         test_item=item,
-        interactions=interactions,
+        annotated_completions=annotated_completions,
     )
     measurements = test.measure_quality(annotated)
 
     return TestItemRecord(
         test_item=annotated.test_item,
-        interactions=annotated.interactions,
+        annotated_completions=annotated.annotated_completions,
         measurements=measurements,
     )

--- a/src/modelgauge/single_turn_prompt_response.py
+++ b/src/modelgauge/single_turn_prompt_response.py
@@ -63,27 +63,11 @@ class SUTCompletionAnnotations(BaseModel):
         return annotation.to_instance(cls)
 
 
-class SUTResponseAnnotations(BaseModel):
-    """All annotated completions for a SUTResponse."""
-
-    completions: List[SUTCompletionAnnotations]
-
-
-class PromptInteractionAnnotations(BaseModel):
-    """Combine a Prompt with the SUT Response to make it easier for Tests to measure quality."""
-
-    prompt: TestItem
-    response: SUTResponseAnnotations
-
-
 class TestItemAnnotations(BaseModel):
     """All of the Interactions with a SUT plus their annotations for a single TestItem."""
 
-    # TODO: This duplicates the list of prompts in the object.
-    # Maybe denormalize here.
     test_item: TestItem
-
-    interactions: List[PromptInteractionAnnotations]
+    annotated_completions: List[SUTCompletionAnnotations]
 
     __test__ = False
 

--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -56,7 +56,7 @@ class AFakeTest(PromptResponseTest):
         return self.annotator_uids
 
     def measure_quality(self, item: TestItemAnnotations) -> Dict[str, float]:
-        completion = item.interactions[0].response.completions[0]
+        completion = item.annotated_completions[0]
         if completion.annotations:
             return {"badness": float(completion.get_annotation(self.annotator_uids[0], DemoYBadAnnotation).badness)}
         else:

--- a/tests/modelgauge_tests/test_records.py
+++ b/tests/modelgauge_tests/test_records.py
@@ -5,9 +5,7 @@ from modelgauge.prompt import SUTOptions, TextPrompt
 from modelgauge.record_init import InitializationRecord
 from modelgauge.records import TestItemRecord, TestRecord
 from modelgauge.single_turn_prompt_response import (
-    PromptInteractionAnnotations,
     SUTCompletionAnnotations,
-    SUTResponseAnnotations,
     TestItem,
 )
 from modelgauge.sut import SUTCompletion
@@ -53,19 +51,10 @@ def test_serialize_test_record():
         test_item_records=[
             TestItemRecord(
                 test_item=test_item,
-                interactions=[
-                    PromptInteractionAnnotations(
-                        prompt=test_item,
-                        response=SUTResponseAnnotations(
-                            completions=[
-                                SUTCompletionAnnotations(
-                                    completion=SUTCompletion(text="sut-completion"),
-                                    annotations={
-                                        "k1": Annotation.from_instance(MockAnnotation(mock_field="mock-value"))
-                                    },
-                                )
-                            ]
-                        ),
+                annotated_completions=[
+                    SUTCompletionAnnotations(
+                        completion=SUTCompletion(text="sut-completion"),
+                        annotations={"k1": Annotation.from_instance(MockAnnotation(mock_field="mock-value"))},
                     )
                 ],
                 measurements={"m1": 1.0},
@@ -126,51 +115,20 @@ def test_serialize_test_record():
           }
         }
       },
-      "interactions": [
+      "annotated_completions": [
         {
-          "prompt": {
-            "prompt": {
-              "text": "some-text",
-              "options": {
-                "num_completions": 1,
-                "max_tokens": 17,
-                "temperature": null,
-                "top_k_per_token": null,
-                "stop_sequences": null,
-                "top_p": null,
-                "presence_penalty": null,
-                "frequency_penalty": null,
-                "random": null,
-                "top_logprobs": null
-              }
-            },
-            "source_id": "id01",
-            "context_internal": {
+          "completion": {
+            "text": "sut-completion",
+            "top_logprobs": null
+          },
+          "annotations": {
+            "k1": {
               "module": "modelgauge_tests.test_records",
-              "class_name": "MockContext",
+              "class_name": "MockAnnotation",
               "data": {
-                "context_field": "test-item-context"
+                "mock_field": "mock-value"
               }
             }
-          },
-          "response": {
-            "completions": [
-              {
-                "completion": {
-                  "text": "sut-completion",
-                  "top_logprobs": null
-                },
-                "annotations": {
-                  "k1": {
-                    "module": "modelgauge_tests.test_records",
-                    "class_name": "MockAnnotation",
-                    "data": {
-                      "mock_field": "mock-value"
-                    }
-                  }
-                }
-              }
-            ]
           }
         }
       ],

--- a/tests/modelgauge_tests/test_simple_test_runner.py
+++ b/tests/modelgauge_tests/test_simple_test_runner.py
@@ -7,11 +7,7 @@ from modelgauge.annotation import Annotation
 from modelgauge.caching import SqlDictCache
 from modelgauge.records import TestItemExceptionRecord, TestItemRecord
 from modelgauge.simple_test_runner import run_prompt_response_test
-from modelgauge.single_turn_prompt_response import (
-    PromptInteractionAnnotations,
-    SUTCompletionAnnotations,
-    SUTResponseAnnotations,
-)
+from modelgauge.single_turn_prompt_response import SUTCompletionAnnotations
 from modelgauge.sut import SUTCompletion
 from modelgauge.sut_capabilities import ProducesPerTokenLogProbabilities
 from modelgauge.test_decorator import modelgauge_test
@@ -28,23 +24,16 @@ def _make_test_item_record(item):
 
     return TestItemRecord(
         test_item=item,
-        interactions=[
-            PromptInteractionAnnotations(
-                prompt=item,
-                response=SUTResponseAnnotations(
-                    completions=[
-                        SUTCompletionAnnotations(
-                            completion=SUTCompletion(text=text),
-                            annotations={
-                                ANNOTATOR_UID: Annotation(
-                                    module="modelgauge_tests.fake_annotator",
-                                    class_name="FakeAnnotation",
-                                    data={"sut_text": text},
-                                )
-                            },
-                        )
-                    ]
-                ),
+        annotated_completions=[
+            SUTCompletionAnnotations(
+                completion=SUTCompletion(text=text),
+                annotations={
+                    ANNOTATOR_UID: Annotation(
+                        module="modelgauge_tests.fake_annotator",
+                        class_name="FakeAnnotation",
+                        data={"sut_text": text},
+                    )
+                },
             )
         ],
         measurements=_FAKE_MEASUREMENT,


### PR DESCRIPTION
PR https://github.com/mlcommons/modelbench/pull/872 simplified the definition of a TestItem to correspond to only 1 prompt. This opened the door towards further simplification in the annotation object hierarchy as well. 

This PR collapses three levels of classes(TestItemAnnotations, PromptInteractionAnnotations, and SUTResponseAnnotations) into one (`TestItemAnnotations`).