### PR TITLE
Analytics cli

### DIFF
--- a/src/modelgauge/annotation_pipeline.py
+++ b/src/modelgauge/annotation_pipeline.py
@@ -147,6 +147,8 @@ class AnnotatorSink(Sink):
         self.annotators = annotators
         self.writer = writer
         self.unfinished = defaultdict(lambda: dict())
+        self.sut_response_counts = defaultdict(lambda: 0)
+        self.annotation_counts = defaultdict(lambda: 0)
 
     def run(self):
         with self.writer:
@@ -154,6 +156,8 @@ class AnnotatorSink(Sink):
 
     def handle_item(self, item):
         sut_interaction, annotator_uid, annotation = item
+        self.sut_response_counts[sut_interaction.sut_uid] += 1
+        self.annotation_counts[annotator_uid] += 1
         if isinstance(annotation, BaseModel):
             annotation = annotation.model_dump()
         self.unfinished[sut_interaction][annotator_uid] = annotation

--- a/src/modelgauge/annotation_pipeline.py
+++ b/src/modelgauge/annotation_pipeline.py
@@ -141,6 +141,8 @@ class AnnotatorWorkers(CachingPipe):
 
 class AnnotatorSink(Sink):
     unfinished: defaultdict[SutInteraction, dict[str, str]]
+    sut_response_counts: defaultdict[str, int]
+    annotation_counts: defaultdict[str, int]
 
     def __init__(self, annotators: dict[str, Annotator], writer: JsonlAnnotatorOutput):
         super().__init__()

--- a/src/modelgauge/command_line.py
+++ b/src/modelgauge/command_line.py
@@ -101,6 +101,7 @@ def validate_uid(ctx, param, value):
     """Callback function for click.option UID validation.
     Raises a BadParameter exception if the user-supplied arg(s) are not valid UIDs.
     Applicable for parameters '--sut', '--test', and '--annotator'.
+    If no UID is provided (e.g. an empty list or `None`), the value is returned as-is.
     """
     if not value:
         return value

--- a/src/modelgauge/command_line.py
+++ b/src/modelgauge/command_line.py
@@ -102,6 +102,8 @@ def validate_uid(ctx, param, value):
     Raises a BadParameter exception if the user-supplied arg(s) are not valid UIDs.
     Applicable for parameters '--sut', '--test', and '--annotator'.
     """
+    if not value:
+        return value
     # Identify what object we are validating UIDs for.
     if "--sut" in param.opts:
         registry = SUTS

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -232,6 +232,7 @@ def run_test(
     print(test_record.model_dump_json(indent=4))
     print("Full TestRecord json written to", output_file)
 
+
 @modelgauge_cli.command()
 @sut_options_options
 @click.option(
@@ -264,12 +265,21 @@ def run_test(
     help="Directory to cache model answers (only applies to SUTs).",
     type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=pathlib.Path),
 )
+@click.option(
+    "--output-dir",
+    "-o",
+    default="airr_data/runs",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=pathlib.Path),
+)
+@click.option("--tag", type=str, help="Tag to include in the output directory name.")
 @click.option("--debug", is_flag=True, help="Show internal pipeline debugging information.")
 @click.argument(
     "input_path",
     type=click.Path(exists=True, path_type=pathlib.Path),
 )
-def run_stuff(sut_uid, annotator_uids, workers, cache_dir, debug, input_path, max_tokens, temp, top_p, top_k):
+def run_stuff(
+    sut_uid, annotator_uids, workers, cache_dir, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k
+):
     """Run rows in a CSV through some SUTs and/or annotators.
 
     If running a SUT, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.
@@ -302,32 +312,39 @@ def run_stuff(sut_uid, annotator_uids, workers, cache_dir, debug, input_path, ma
 
     # Create correct pipeline runner based on input.
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    base_subdir_name = timestamp + "-" + tag if tag else timestamp
     if sut_uid and annotators:
-        output_path = input_path.parent / pathlib.Path(input_path.stem + "-annotated-responses" + timestamp + ".jsonl")
+        output_path = output_dir / pathlib.Path(f"{base_subdir_name}-{sut_uid}-{'-'.join(annotator_uids)}")
+        output_file = output_path / "prompt-responses-annotated.jsonl"
         pipeline_runner = PromptPlusAnnotatorRunner(
             workers,
             input_path,
-            output_path,
+            output_file,
             cache_dir,
             sut_options,
             suts=suts,
             annotators=annotators,
         )
     elif sut_uid:
-        output_path = input_path.parent / pathlib.Path(input_path.stem + "-responses-" + timestamp + ".csv")
-        pipeline_runner = PromptRunner(workers, input_path, output_path, cache_dir, sut_options, suts=suts)
+        output_path = output_dir / pathlib.Path(f"{base_subdir_name}-{sut_uid}")
+        output_file = output_path / "prompt-responses.csv"
+        pipeline_runner = PromptRunner(workers, input_path, output_file, cache_dir, sut_options, suts=suts)
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             warnings.warn(f"Received SUT options but only running annotators. Options will not be used.")
-        output_path = input_path.parent / pathlib.Path(input_path.stem + "-annotations-" + timestamp + ".jsonl")
-        pipeline_runner = AnnotatorRunner(workers, input_path, output_path, cache_dir, annotators=annotators)
+        output_path = output_dir / pathlib.Path(f"{base_subdir_name}-{'-'.join(annotator_uids)}")
+        output_file = output_path / "annotations.jsonl"
+        pipeline_runner = AnnotatorRunner(workers, input_path, output_file, cache_dir, annotators=annotators)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
+
+    print(f"Creating output dir {output_path}")
+    output_path.mkdir(parents=True)
 
     with click.progressbar(
         length=pipeline_runner.num_total_items,
         label=f"Processing {pipeline_runner.num_input_items} input items"
-        + (f" * 1 SUT" if sut else "")
+        + (f" * 1 SUT" if sut_uid else "")
         + (f" * {len(annotators)} annotators" if annotators else "")
         + ":",
     ) as bar:
@@ -341,7 +358,8 @@ def run_stuff(sut_uid, annotator_uids, workers, cache_dir, debug, input_path, ma
 
         pipeline_runner.run(show_progress, debug)
 
-    print(f"output saved to {output_path}")
+    print(f"output saved to {output_file}")
+
 
 @modelgauge_cli.command()
 @sut_options_options

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -273,7 +273,7 @@ def run_test(
     "input_path",
     type=click.Path(exists=True, path_type=pathlib.Path),
 )
-def run_csv(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k):
+def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k):
     """Run rows in a CSV through some SUTs and/or annotators.
 
     If running a SUT, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -1,4 +1,4 @@
-import datetime
+import logging
 import os
 import pathlib
 import warnings
@@ -34,6 +34,8 @@ from modelgauge.sut import PromptResponseSUT
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.sut_registry import SUTS
 from modelgauge.test_registry import TESTS
+
+logger = logging.getLogger(__name__)
 
 
 @modelgauge_cli.command(name="list")
@@ -313,7 +315,7 @@ def run_csv(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
         pipeline_runner = PromptRunner(workers, input_path, output_dir, None, sut_options, tag, suts=suts)
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
-            warnings.warn(f"Received SUT options but only running annotators. Options will not be used.")
+            logger.warning(f"Received SUT options but only running annotators. Options will not be used.")
         pipeline_runner = AnnotatorRunner(workers, input_path, output_dir, None, None, tag, annotators=annotators)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -271,7 +271,7 @@ def run_test(
     "input_path",
     type=click.Path(exists=True, path_type=pathlib.Path),
 )
-def run_stuff(
+def run_csv(
     sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k
 ):
     """Run rows in a CSV through some SUTs and/or annotators.

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -260,12 +260,6 @@ def run_test(
     help="Number of worker threads, default is 10 * number of SUTs.",
 )
 @click.option(
-    "cache_dir",
-    "--cache",
-    help="Directory to cache model answers (only applies to SUTs).",
-    type=click.Path(file_okay=False, dir_okay=True, writable=True, path_type=pathlib.Path),
-)
-@click.option(
     "--output-dir",
     "-o",
     default="airr_data/runs",
@@ -278,7 +272,7 @@ def run_test(
     type=click.Path(exists=True, path_type=pathlib.Path),
 )
 def run_stuff(
-    sut_uid, annotator_uids, workers, cache_dir, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k
+    sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k
 ):
     """Run rows in a CSV through some SUTs and/or annotators.
 
@@ -302,10 +296,6 @@ def run_stuff(
         annotator_uid: ANNOTATORS.make_instance(annotator_uid, secrets=secrets) for annotator_uid in annotator_uids
     }
 
-    if cache_dir:
-        print(f"Creating cache dir {cache_dir}")
-        cache_dir.mkdir(exist_ok=True)
-
     # Get all SUT options
     sut_options = create_sut_options(max_tokens, temp, top_p, top_k)
     print(sut_options)
@@ -316,18 +306,18 @@ def run_stuff(
             workers,
             input_path,
             output_dir,
-            cache_dir,
+            None,
             sut_options,
             tag,
             suts=suts,
             annotators=annotators,
         )
     elif sut_uid:
-        pipeline_runner = PromptRunner(workers, input_path, output_dir, cache_dir, sut_options, tag, suts=suts)
+        pipeline_runner = PromptRunner(workers, input_path, output_dir, None, sut_options, tag, suts=suts)
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             warnings.warn(f"Received SUT options but only running annotators. Options will not be used.")
-        pipeline_runner = AnnotatorRunner(workers, input_path, output_dir, cache_dir, None, tag, annotators=annotators)
+        pipeline_runner = AnnotatorRunner(workers, input_path, output_dir, None, None, tag, annotators=annotators)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
 

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -302,7 +302,7 @@ def run_stuff(sut_uid, annotator_uids, workers, cache_dir, debug, input_path, ma
 
     # Create correct pipeline runner based on input.
     timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-    if sut and annotators:
+    if sut_uid and annotators:
         output_path = input_path.parent / pathlib.Path(input_path.stem + "-annotated-responses" + timestamp + ".jsonl")
         pipeline_runner = PromptPlusAnnotatorRunner(
             workers,
@@ -313,7 +313,7 @@ def run_stuff(sut_uid, annotator_uids, workers, cache_dir, debug, input_path, ma
             suts=suts,
             annotators=annotators,
         )
-    elif sut:
+    elif sut_uid:
         output_path = input_path.parent / pathlib.Path(input_path.stem + "-responses-" + timestamp + ".csv")
         pipeline_runner = PromptRunner(workers, input_path, output_path, cache_dir, sut_options, suts=suts)
     elif annotators:

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -296,7 +296,6 @@ def run_csv(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
 
     # Get all SUT options
     sut_options = create_sut_options(max_tokens, temp, top_p, top_k)
-    print(sut_options)
 
     # Create correct pipeline runner based on input.
     if sut_uid and annotators:

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -271,9 +271,7 @@ def run_test(
     "input_path",
     type=click.Path(exists=True, path_type=pathlib.Path),
 )
-def run_csv(
-    sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k
-):
+def run_csv(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k):
     """Run rows in a CSV through some SUTs and/or annotators.
 
     If running a SUT, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -50,7 +50,7 @@ class PipelineRunner(ABC):
         pass
 
     def output_dir(self):
-        output_path = self.root_dir / self.sub_dir_name
+        output_path = self.root_dir / self.run_id
         if not output_path.exists():
             print(f"Creating output dir {output_path}")
             output_path.mkdir(parents=True)
@@ -108,10 +108,9 @@ class PromptRunner(PipelineRunner):
         return "prompt-responses.csv"
 
     @property
-    def sub_dir_name(self):
+    def run_id(self):
         base_subdir_name = self.start_time + "-" + self.tag if self.tag else self.start_time
-        sub_dir = pathlib.Path(f"{base_subdir_name}-{'-'.join(self.suts.keys())}")
-        return sub_dir
+        return f"{base_subdir_name}-{'-'.join(self.suts.keys())}"
 
     def _initialize_segments(self):
         self._add_prompt_segments(self.suts, include_sink=True)
@@ -132,10 +131,9 @@ class PromptPlusAnnotatorRunner(PipelineRunner):
         return "prompt-responses-annotated.jsonl"
 
     @property
-    def sub_dir_name(self):
+    def run_id(self):
         base_subdir_name = self.start_time + "-" + self.tag if self.tag else self.start_time
-        sub_dir = pathlib.Path(f"{base_subdir_name}-{'-'.join(self.suts.keys())}-{'-'.join(self.annotators.keys())}")
-        return sub_dir
+        return f"{base_subdir_name}-{'-'.join(self.suts.keys())}-{'-'.join(self.annotators.keys())}"
 
     def _initialize_segments(self):
         # Hybrid pipeline: prompt source + annotator sink
@@ -157,10 +155,9 @@ class AnnotatorRunner(PipelineRunner):
         return "annotations.jsonl"
 
     @property
-    def sub_dir_name(self):
+    def run_id(self):
         base_subdir_name = self.start_time + "-" + self.tag if self.tag else self.start_time
-        sub_dir = pathlib.Path(f"{base_subdir_name}-{'-'.join(self.annotators.keys())}")
-        return sub_dir
+        return f"{base_subdir_name}-{'-'.join(self.annotators.keys())}"
 
     def _initialize_segments(self):
         self._add_annotator_segments(self.annotators, include_source=True)

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -114,18 +114,23 @@ class PipelineRunner(ABC):
         self.pipeline_segments.append(AnnotatorSink(annotators, output))
 
     def _annotator_metadata(self):
-        metadata = {
+        counts = self.pipeline_segments[-1].annotation_counts
+        return {
             "annotators": [
                 {
                     "uid": uid,
                 }
                 for uid, annotator in self.annotators.items()
-            ]
+            ],
+            "annotations": {
+                "count": sum(counts.values()),
+                "by_annotator": {uid: {"count": count} for uid, count in counts.items()},
+            },
         }
-        return metadata
 
     def _sut_metadata(self):
-        metadata = {
+        counts = self.pipeline_segments[-1].sut_response_counts
+        return {
             "suts": [
                 {
                     "uid": uid,
@@ -133,9 +138,12 @@ class PipelineRunner(ABC):
                     "sut_options": self.sut_options.model_dump(exclude_none=True),
                 }
                 for uid, sut in self.suts.items()
-            ]
+            ],
+            "responses": {
+                "count": sum(counts.values()),
+                "by_sut": {uid: {"count": count} for uid, count in counts.items()},
+            },
         }
-        return metadata
 
     def _write_metadata(self):
         with open(self.output_dir() / "metadata.json", "w") as f:

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 import datetime
 import json
-import pathlib
 
 from modelgauge.annotation_pipeline import (
     AnnotatorAssigner,

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import datetime
 import json
+import logging
 
 from modelgauge.annotation_pipeline import (
     AnnotatorAssigner,
@@ -19,6 +20,8 @@ from modelgauge.prompt_pipeline import (
     CsvPromptInput,
     CsvPromptOutput,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class PipelineRunner(ABC):
@@ -71,7 +74,7 @@ class PipelineRunner(ABC):
     def output_dir(self):
         output_path = self.root_dir / self.run_id
         if not output_path.exists():
-            print(f"Creating output dir {output_path}")
+            logger.info(f"Creating output dir {output_path}")
             output_path.mkdir(parents=True)
         return output_path
 
@@ -83,7 +86,7 @@ class PipelineRunner(ABC):
         )
         pipeline.run()
         self.finish_time = datetime.datetime.now()
-        print(f"\noutput saved to {self.output_dir() / self.output_file_name}")
+        logger.info(f"\noutput saved to {self.output_dir() / self.output_file_name}")
         self._write_metadata()
 
     @staticmethod

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -164,12 +164,14 @@ class PromptSink(Sink):
         self.suts = suts
         self.writer = writer
         self.unfinished = defaultdict(lambda: dict())
+        self.sut_response_counts = {s: 0 for s in suts}
 
     def run(self):
         with self.writer:
             super().run()
 
     def handle_item(self, item: SutInteraction):
+        self.sut_response_counts[item.sut_uid] += 1
         self.unfinished[item.prompt][item.sut_uid] = item.response.text
         if len(self.unfinished[item.prompt]) == len(self.suts):
             self.writer.write(item.prompt, self.unfinished[item.prompt])

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -158,13 +158,14 @@ class PromptSutWorkers(CachingPipe):
 
 class PromptSink(Sink):
     unfinished: defaultdict[TestItem, dict[str, str]]
+    sut_response_counts: defaultdict[str, int]
 
     def __init__(self, suts: dict[str, SUT], writer: PromptOutput):
         super().__init__()
         self.suts = suts
         self.writer = writer
         self.unfinished = defaultdict(lambda: dict())
-        self.sut_response_counts = {s: 0 for s in suts}
+        self.sut_response_counts = defaultdict(lambda: 0)
 
     def run(self):
         with self.writer:

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -377,12 +377,12 @@ def test_check_secrets_checks_annotators_in_test():
         check_secrets({}, test_uids=["some-test"])
 
 
-def test_run_stuff_sut_only_output_name(tmp_path):
+def test_run_csv_sut_only_output_name(tmp_path):
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-stuff", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
+        ["run-csv", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -396,12 +396,12 @@ def test_run_stuff_sut_only_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_stuff_sut_only_metadata(tmp_path):
+def test_run_csv_sut_only_metadata(tmp_path):
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-stuff", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
+        ["run-csv", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
     out_path = Path(re.findall(r"\S+\.csv", result.stdout)[0])
@@ -429,12 +429,12 @@ def test_run_stuff_sut_only_metadata(tmp_path):
     assert metadata["responses"] == {"count": 2, "by_sut": {"demo_yes_no": {"count": 2}}}
 
 
-def test_run_stuff_with_tag_output_name(tmp_path):
+def test_run_csv_with_tag_output_name(tmp_path):
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-stuff", "--sut", "demo_yes_no", "--output-dir", tmp_path, "--tag", "test", str(in_path)],
+        ["run-csv", "--sut", "demo_yes_no", "--output-dir", tmp_path, "--tag", "test", str(in_path)],
         catch_exceptions=False,
     )
 
@@ -445,12 +445,12 @@ def test_run_stuff_with_tag_output_name(tmp_path):
     assert re.match(r"\d{8}-\d{6}-test-demo_yes_no", out_path.parent.name)  # Subdir name
 
 
-def test_run_stuff_sut_and_annotator_output_name(tmp_path):
+def test_run_csv_sut_and_annotator_output_name(tmp_path):
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-stuff", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-csv", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -464,12 +464,12 @@ def test_run_stuff_sut_and_annotator_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_stuff_sut_and_annotator_metadata(tmp_path):
+def test_run_csv_sut_and_annotator_metadata(tmp_path):
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-stuff", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-csv", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -502,12 +502,12 @@ def test_run_stuff_sut_and_annotator_metadata(tmp_path):
     assert metadata["annotations"] == {"count": 2, "by_annotator": {"demo_annotator": {"count": 2}}}
 
 
-def test_run_stuff_annotators_only_output_name(tmp_path):
+def test_run_csv_annotators_only_output_name(tmp_path):
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-stuff", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-csv", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -521,12 +521,12 @@ def test_run_stuff_annotators_only_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_stuff_annotators_only_metadata(tmp_path):
+def test_run_csv_annotators_only_metadata(tmp_path):
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-stuff", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-csv", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import logging
 import re
 from pathlib import Path
 from unittest.mock import patch
@@ -22,6 +23,8 @@ from modelgauge.test_registry import TESTS
 from tests.modelgauge_tests.fake_annotator import FakeAnnotator
 from tests.modelgauge_tests.fake_secrets import FakeRequiredSecret
 from tests.modelgauge_tests.fake_test import FakeTest
+
+LOGGER = logging.getLogger(__name__)
 
 
 def run_cli(*args) -> Result:
@@ -140,7 +143,8 @@ def create_prompts_file(path):
     return in_path
 
 
-def test_run_prompts_normal(tmp_path):
+def test_run_prompts_normal(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -151,7 +155,7 @@ def test_run_prompts_normal(tmp_path):
 
     assert result.exit_code == 0
 
-    out_path = re.findall(r"\S+\.csv", result.stdout)[0]
+    out_path = re.findall(r"\S+\.csv", caplog.text)[0]
     with open(tmp_path / out_path, "r") as f:
         reader = csv.DictReader(f)
 
@@ -207,7 +211,8 @@ def test_run_prompts_invalid_annotator(sut_uid, tmp_path):
     assert re.search(r"Invalid value for '-a' / '--annotator': Unknown uid: '\['unknown-uid'\]'", result.output)
 
 
-def test_run_prompts_with_annotators(tmp_path):
+def test_run_prompts_with_annotators(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -226,7 +231,7 @@ def test_run_prompts_with_annotators(tmp_path):
     )
     assert result.exit_code == 0
 
-    out_path = re.findall(r"\S+\.jsonl", result.stdout)[0]
+    out_path = re.findall(r"\S+\.jsonl", caplog.text)[0]
     output = []
     with jsonlines.open(tmp_path / out_path) as reader:
         output.append(reader.read())
@@ -302,7 +307,8 @@ def create_prompt_responses_file(path):
     return in_path
 
 
-def test_run_annotators(tmp_path):
+def test_run_annotators(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -317,7 +323,7 @@ def test_run_annotators(tmp_path):
     )
     assert result.exit_code == 0
 
-    out_path = re.findall(r"\S+\.jsonl", result.stdout)[0]
+    out_path = re.findall(r"\S+\.jsonl", caplog.text)[0]
     with jsonlines.open(tmp_path / out_path) as reader:
         assert reader.read() == {
             "UID": "p1",
@@ -377,7 +383,8 @@ def test_check_secrets_checks_annotators_in_test():
         check_secrets({}, test_uids=["some-test"])
 
 
-def test_run_csv_sut_only_output_name(tmp_path):
+def test_run_csv_sut_only_output_name(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -388,7 +395,7 @@ def test_run_csv_sut_only_output_name(tmp_path):
 
     assert result.exit_code == 0
 
-    out_path = Path(re.findall(r"\S+\.csv", result.stdout)[0])
+    out_path = Path(re.findall(r"\S+\.csv", caplog.text)[0])
 
     assert out_path.exists()
     assert out_path.name == "prompt-responses.csv"  # File name
@@ -396,7 +403,8 @@ def test_run_csv_sut_only_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_csv_sut_only_metadata(tmp_path):
+def test_run_csv_sut_only_metadata(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -404,7 +412,7 @@ def test_run_csv_sut_only_metadata(tmp_path):
         ["run-csv", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
-    out_path = Path(re.findall(r"\S+\.csv", result.stdout)[0])
+    out_path = Path(re.findall(r"\S+\.csv", caplog.text)[0])
     metadata_path = out_path.parent / "metadata.json"
     with open(metadata_path, "r") as f:
         metadata = json.load(f)
@@ -429,7 +437,8 @@ def test_run_csv_sut_only_metadata(tmp_path):
     assert metadata["responses"] == {"count": 2, "by_sut": {"demo_yes_no": {"count": 2}}}
 
 
-def test_run_csv_with_tag_output_name(tmp_path):
+def test_run_csv_with_tag_output_name(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -440,12 +449,13 @@ def test_run_csv_with_tag_output_name(tmp_path):
 
     assert result.exit_code == 0
 
-    out_path = Path(re.findall(r"\S+\.csv", result.stdout)[0])
+    out_path = Path(re.findall(r"\S+\.csv", caplog.text)[0])
 
     assert re.match(r"\d{8}-\d{6}-test-demo_yes_no", out_path.parent.name)  # Subdir name
 
 
-def test_run_csv_sut_and_annotator_output_name(tmp_path):
+def test_run_csv_sut_and_annotator_output_name(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -456,7 +466,7 @@ def test_run_csv_sut_and_annotator_output_name(tmp_path):
 
     assert result.exit_code == 0
 
-    out_path = Path(re.findall(r"\S+\.jsonl", result.stdout)[0])
+    out_path = Path(re.findall(r"\S+\.jsonl", caplog.text)[0])
 
     assert out_path.exists()
     assert out_path.name == "prompt-responses-annotated.jsonl"  # File name
@@ -464,7 +474,8 @@ def test_run_csv_sut_and_annotator_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_csv_sut_and_annotator_metadata(tmp_path):
+def test_run_csv_sut_and_annotator_metadata(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -475,7 +486,7 @@ def test_run_csv_sut_and_annotator_metadata(tmp_path):
 
     assert result.exit_code == 0
 
-    out_path = Path(re.findall(r"\S+\.jsonl", result.stdout)[0])
+    out_path = Path(re.findall(r"\S+\.jsonl", caplog.text)[0])
     metadata_path = out_path.parent / "metadata.json"
     with open(metadata_path, "r") as f:
         metadata = json.load(f)
@@ -502,7 +513,8 @@ def test_run_csv_sut_and_annotator_metadata(tmp_path):
     assert metadata["annotations"] == {"count": 2, "by_annotator": {"demo_annotator": {"count": 2}}}
 
 
-def test_run_csv_annotators_only_output_name(tmp_path):
+def test_run_csv_annotators_only_output_name(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -513,7 +525,7 @@ def test_run_csv_annotators_only_output_name(tmp_path):
 
     assert result.exit_code == 0
 
-    out_path = Path(re.findall(r"\S+\.jsonl", result.stdout)[0])
+    out_path = Path(re.findall(r"\S+\.jsonl", caplog.text)[0])
 
     assert out_path.exists()
     assert out_path.name == "annotations.jsonl"  # File name
@@ -521,7 +533,8 @@ def test_run_csv_annotators_only_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_csv_annotators_only_metadata(tmp_path):
+def test_run_csv_annotators_only_metadata(caplog, tmp_path):
+    caplog.set_level(logging.INFO)
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
@@ -532,7 +545,7 @@ def test_run_csv_annotators_only_metadata(tmp_path):
 
     assert result.exit_code == 0
 
-    out_path = Path(re.findall(r"\S+\.jsonl", result.stdout)[0])
+    out_path = Path(re.findall(r"\S+\.jsonl", caplog.text)[0])
     metadata_path = out_path.parent / "metadata.json"
     with open(metadata_path, "r") as f:
         metadata = json.load(f)

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -408,7 +408,24 @@ def test_run_stuff_sut_only_metadata(tmp_path):
     metadata_path = out_path.parent / "metadata.json"
     with open(metadata_path, "r") as f:
         metadata = json.load(f)
-    assert metadata == {}
+
+    assert re.match(r"\d{8}-\d{6}-demo_yes_no", metadata["run_id"])
+    assert "started" in metadata["run_info"]
+    assert "finished" in metadata["run_info"]
+    assert "duration" in metadata["run_info"]
+    assert metadata["input"] == {"source": in_path.name, "num_items": 2}
+    assert metadata["suts"] == [
+        {
+            "uid": "demo_yes_no",
+            "initialization_record": {
+                "args": ["demo_yes_no"],
+                "class_name": "DemoYesNoSUT",
+                "kwargs": {},
+                "module": "modelgauge.suts.demo_01_yes_no_sut",
+            },
+            "sut_options": {"max_tokens": 100},
+        }
+    ]
 
 
 def test_run_stuff_with_tag_output_name(tmp_path):
@@ -461,7 +478,25 @@ def test_run_stuff_sut_and_annotator_metadata(tmp_path):
     metadata_path = out_path.parent / "metadata.json"
     with open(metadata_path, "r") as f:
         metadata = json.load(f)
-    assert metadata == {}
+
+    assert re.match(r"\d{8}-\d{6}-demo_yes_no-demo_annotator", metadata["run_id"])
+    assert "started" in metadata["run_info"]
+    assert "finished" in metadata["run_info"]
+    assert "duration" in metadata["run_info"]
+    assert metadata["input"] == {"source": in_path.name, "num_items": 2}
+    assert metadata["suts"] == [
+        {
+            "uid": "demo_yes_no",
+            "initialization_record": {
+                "args": ["demo_yes_no"],
+                "class_name": "DemoYesNoSUT",
+                "kwargs": {},
+                "module": "modelgauge.suts.demo_01_yes_no_sut",
+            },
+            "sut_options": {"max_tokens": 100},
+        }
+    ]
+    assert metadata["annotators"] == [{"uid": "demo_annotator"}]
 
 
 def test_run_stuff_annotators_only_output_name(tmp_path):
@@ -498,5 +533,10 @@ def test_run_stuff_annotators_only_metadata(tmp_path):
     metadata_path = out_path.parent / "metadata.json"
     with open(metadata_path, "r") as f:
         metadata = json.load(f)
-    assert metadata == {}
 
+    assert re.match(r"\d{8}-\d{6}-demo_annotator", metadata["run_id"])
+    assert "started" in metadata["run_info"]
+    assert "finished" in metadata["run_info"]
+    assert "duration" in metadata["run_info"]
+    assert metadata["input"] == {"source": in_path.name, "num_items": 2}
+    assert metadata["annotators"] == [{"uid": "demo_annotator"}]

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import re
 from pathlib import Path
 from unittest.mock import patch
@@ -395,6 +396,21 @@ def test_run_stuff_sut_only_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
+def test_run_stuff_sut_only_metadata(tmp_path):
+    in_path = create_prompts_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main.modelgauge_cli,
+        ["run-stuff", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
+        catch_exceptions=False,
+    )
+    out_path = Path(re.findall(r"\S+\.csv", result.stdout)[0])
+    metadata_path = out_path.parent / "metadata.json"
+    with open(metadata_path, "r") as f:
+        metadata = json.load(f)
+    assert metadata == {}
+
+
 def test_run_stuff_with_tag_output_name(tmp_path):
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
@@ -430,6 +446,24 @@ def test_run_stuff_sut_and_annotator_output_name(tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
+def test_run_stuff_sut_and_annotator_metadata(tmp_path):
+    in_path = create_prompts_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main.modelgauge_cli,
+        ["run-stuff", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+
+    out_path = Path(re.findall(r"\S+\.jsonl", result.stdout)[0])
+    metadata_path = out_path.parent / "metadata.json"
+    with open(metadata_path, "r") as f:
+        metadata = json.load(f)
+    assert metadata == {}
+
+
 def test_run_stuff_annotators_only_output_name(tmp_path):
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
@@ -447,3 +481,22 @@ def test_run_stuff_annotators_only_output_name(tmp_path):
     assert out_path.name == "annotations.jsonl"  # File name
     assert re.match(r"\d{8}-\d{6}-demo_annotator", out_path.parent.name)  # Subdir name
     assert out_path.parent.parent == tmp_path  # Parent dir
+
+
+def test_run_stuff_annotators_only_metadata(tmp_path):
+    in_path = create_prompt_responses_file(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        main.modelgauge_cli,
+        ["run-stuff", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+
+    out_path = Path(re.findall(r"\S+\.jsonl", result.stdout)[0])
+    metadata_path = out_path.parent / "metadata.json"
+    with open(metadata_path, "r") as f:
+        metadata = json.load(f)
+    assert metadata == {}
+

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -426,6 +426,7 @@ def test_run_stuff_sut_only_metadata(tmp_path):
             "sut_options": {"max_tokens": 100},
         }
     ]
+    assert metadata["responses"] == {"count": 2, "by_sut": {"demo_yes_no": {"count": 2}}}
 
 
 def test_run_stuff_with_tag_output_name(tmp_path):
@@ -496,7 +497,9 @@ def test_run_stuff_sut_and_annotator_metadata(tmp_path):
             "sut_options": {"max_tokens": 100},
         }
     ]
+    assert metadata["responses"] == {"count": 2, "by_sut": {"demo_yes_no": {"count": 2}}}
     assert metadata["annotators"] == [{"uid": "demo_annotator"}]
+    assert metadata["annotations"] == {"count": 2, "by_annotator": {"demo_annotator": {"count": 2}}}
 
 
 def test_run_stuff_annotators_only_output_name(tmp_path):
@@ -540,3 +543,4 @@ def test_run_stuff_annotators_only_metadata(tmp_path):
     assert "duration" in metadata["run_info"]
     assert metadata["input"] == {"source": in_path.name, "num_items": 2}
     assert metadata["annotators"] == [{"uid": "demo_annotator"}]
+    assert metadata["annotations"] == {"count": 2, "by_annotator": {"demo_annotator": {"count": 2}}}

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -383,13 +383,13 @@ def test_check_secrets_checks_annotators_in_test():
         check_secrets({}, test_uids=["some-test"])
 
 
-def test_run_csv_sut_only_output_name(caplog, tmp_path):
+def test_run_job_sut_only_output_name(caplog, tmp_path):
     caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-csv", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
+        ["run-job", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -403,13 +403,13 @@ def test_run_csv_sut_only_output_name(caplog, tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_csv_sut_only_metadata(caplog, tmp_path):
+def test_run_job_sut_only_metadata(caplog, tmp_path):
     caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-csv", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
+        ["run-job", "--sut", "demo_yes_no", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
     out_path = Path(re.findall(r"\S+\.csv", caplog.text)[0])
@@ -437,13 +437,13 @@ def test_run_csv_sut_only_metadata(caplog, tmp_path):
     assert metadata["responses"] == {"count": 2, "by_sut": {"demo_yes_no": {"count": 2}}}
 
 
-def test_run_csv_with_tag_output_name(caplog, tmp_path):
+def test_run_job_with_tag_output_name(caplog, tmp_path):
     caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-csv", "--sut", "demo_yes_no", "--output-dir", tmp_path, "--tag", "test", str(in_path)],
+        ["run-job", "--sut", "demo_yes_no", "--output-dir", tmp_path, "--tag", "test", str(in_path)],
         catch_exceptions=False,
     )
 
@@ -454,13 +454,13 @@ def test_run_csv_with_tag_output_name(caplog, tmp_path):
     assert re.match(r"\d{8}-\d{6}-test-demo_yes_no", out_path.parent.name)  # Subdir name
 
 
-def test_run_csv_sut_and_annotator_output_name(caplog, tmp_path):
+def test_run_job_sut_and_annotator_output_name(caplog, tmp_path):
     caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-csv", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-job", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -474,13 +474,13 @@ def test_run_csv_sut_and_annotator_output_name(caplog, tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_csv_sut_and_annotator_metadata(caplog, tmp_path):
+def test_run_job_sut_and_annotator_metadata(caplog, tmp_path):
     caplog.set_level(logging.INFO)
     in_path = create_prompts_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-csv", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-job", "--sut", "demo_yes_no", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -513,13 +513,13 @@ def test_run_csv_sut_and_annotator_metadata(caplog, tmp_path):
     assert metadata["annotations"] == {"count": 2, "by_annotator": {"demo_annotator": {"count": 2}}}
 
 
-def test_run_csv_annotators_only_output_name(caplog, tmp_path):
+def test_run_job_annotators_only_output_name(caplog, tmp_path):
     caplog.set_level(logging.INFO)
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-csv", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-job", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 
@@ -533,13 +533,13 @@ def test_run_csv_annotators_only_output_name(caplog, tmp_path):
     assert out_path.parent.parent == tmp_path  # Parent dir
 
 
-def test_run_csv_annotators_only_metadata(caplog, tmp_path):
+def test_run_job_annotators_only_metadata(caplog, tmp_path):
     caplog.set_level(logging.INFO)
     in_path = create_prompt_responses_file(tmp_path)
     runner = CliRunner()
     result = runner.invoke(
         main.modelgauge_cli,
-        ["run-csv", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
+        ["run-job", "--annotator", "demo_annotator", "--output-dir", tmp_path, str(in_path)],
         catch_exceptions=False,
     )
 


### PR DESCRIPTION
First attempt at an analytics CLI tool: `run-csv`.
To summarize, each run results in a new directory containing the output results file and a metadata json file.

The output structure is largely based off of the sample dvc directory in the modelbench-private `dvc-experiments` branch. However, I was not able to follow it 100%. Here are the key differences:
- The metadata lists `suts` instead of one `sut`. This is because the pipeline runner is shared with the already-exisiting `run-csv-ITEMS` which allows for multi-sut runs.
- I changed the `prompts` metadata key to `input` in order to generalize to runs where the input is prompts + responses.
- It is not currently possible to include `provider` and `provider_id` in the metadata. The best I could do is include the SUT initialization record. Annotators do not have initialization records, however, which maybe we should fix.
- I excluded the `unique_count` for responses in the metadata because it would be kind of difficult to keep track of. If it's super important, we can include it in a later PR.
- There is no cache (see convo in [discord](https://discord.com/channels/1137054779013615616/1347654502328832091/1347669163052761200)) 

Some questions

- Would it be better to include the full path to the input source? 
- Any advice on how to make the unit tests less repetitive would be appreciated.
- Also open to better names for the cli tool.