### PR TITLE
Accept official CSV prompt files and database dumps as inputs

### DIFF
--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -12,7 +12,8 @@ from modelgauge.sut import PromptResponseSUT, SUT, SUTOptions, SUTResponse
 
 PROMPT_CSV_INPUT_COLUMNS = {
     "default": {"id": "UID", "text": "Text"},
-    "prompt_set": {"id": "release_prompt_id", "text": "prompt_text"},
+    "prompt_set": {"id": "release_prompt_id", "text": "prompt_text"},  # official prompt set files
+    "db": {"id": "prompt_uid", "text": "prompt_text"},  # database dumps
 }
 
 

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -1,16 +1,19 @@
 import csv
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
-from modelgauge.pipeline import Source, Pipe, Sink, CachingPipe
+from modelgauge.pipeline import CachingPipe, Pipe, Sink, Source
 from modelgauge.prompt import TextPrompt
 from modelgauge.single_turn_prompt_response import TestItem
 from modelgauge.sut import PromptResponseSUT, SUT, SUTOptions, SUTResponse
 
 
-PROMPT_CSV_INPUT_COLUMNS = ["UID", "Text"]
+PROMPT_CSV_INPUT_COLUMNS = {
+    "default": {"id": "UID", "text": "Text"},
+    "prompt_set": {"id": "release_prompt_id", "text": "prompt_text"},
+}
 
 
 @dataclass
@@ -44,27 +47,38 @@ class CsvPromptInput(PromptInput):
     def __init__(self, path):
         super().__init__()
         self.path = path
-        self._validate_file()
+        self.prompt_input_type = "default"
+        self._identify_input()
+
+    def _extract_field(self, row, field_name):
+        column_name = PROMPT_CSV_INPUT_COLUMNS[self.prompt_input_type][field_name]
+        return row[column_name]
 
     def __iter__(self) -> Iterable[TestItem]:
         with open(self.path, newline="") as f:
             csvreader = csv.DictReader(f)
             for row in csvreader:
                 yield TestItem(
-                    prompt=TextPrompt(text=row["Text"]),
+                    prompt=TextPrompt(text=self._extract_field(row, "text")),
                     # Forward the underlying id to help make data tracking easier.
-                    source_id=row["UID"],
+                    source_id=self._extract_field(row, "id"),
                     # Context can be any type you want.
                     context=row,
                 )
 
-    def _validate_file(self):
+    def _identify_input(self):
         with open(self.path, newline="") as f:
             csvreader = csv.reader(f)
             columns = next(csvreader)
-        assert all(
-            c in columns for c in PROMPT_CSV_INPUT_COLUMNS
-        ), f"Invalid input file. Must have columns: {', '.join(PROMPT_CSV_INPUT_COLUMNS)}."
+            is_valid = False
+            for prompt_input_type, column_names in PROMPT_CSV_INPUT_COLUMNS.items():
+                if all(c in columns for c in column_names.values()):
+                    self.prompt_input_type = prompt_input_type
+                    is_valid = True
+                    break
+        assert (
+            is_valid
+        ), f"Unsupported input file. Required columns are one of: f{PROMPT_CSV_INPUT_COLUMNS.values()}\nActual columns are: f{columns}"
 
 
 class PromptOutput(metaclass=ABCMeta):
@@ -92,7 +106,7 @@ class CsvPromptOutput(PromptOutput):
     def __enter__(self):
         self.file = open(self.path, "w", newline="")
         self.writer = csv.writer(self.file, quoting=csv.QUOTE_ALL)
-        self.writer.writerow(PROMPT_CSV_INPUT_COLUMNS + [s for s in self.suts.keys()])
+        self.writer.writerow(list(PROMPT_CSV_INPUT_COLUMNS["default"].values()) + [s for s in self.suts.keys()])
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/modelgauge_tests/test_prompt_pipeline.py
+++ b/tests/modelgauge_tests/test_prompt_pipeline.py
@@ -101,6 +101,26 @@ def test_csv_prompt_input_invalid_columns(tmp_path, header):
         CsvPromptInput(file_path)
 
 
+@pytest.mark.parametrize(
+    "header",
+    [
+        "UID,Text\n",
+        "release_prompt_id,prompt_text\n",
+        "prompt_uid,prompt_text\n",
+        "UID,Text,other,fields\n",
+        "release_prompt_id,prompt_text,other,fields\n",
+        "prompt_uid,prompt_text,other,fields\n",
+        "Text,spacer,UID\n",
+        "release_prompt_id,spacer,prompt_text\n",
+        "prompt_uid,spacer,prompt_text\n",
+    ],
+)
+def test_csv_prompt_input_accepts_multiple_formats(tmp_path, header):
+    file_path = tmp_path / "input.csv"
+    file_path.write_text(header)
+    _ = CsvPromptInput(file_path)
+
+
 def test_csv_prompt_output(tmp_path, suts):
     file_path = tmp_path / "output.csv"
 

--- a/tests/modelgauge_tests/test_prompt_pipeline.py
+++ b/tests/modelgauge_tests/test_prompt_pipeline.py
@@ -7,23 +7,22 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from modelgauge.pipeline import PipelineSegment, Pipeline
+from modelgauge.pipeline import Pipeline, PipelineSegment
 from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_pipeline import (
-    PromptOutput,
-    PromptInput,
     CsvPromptInput,
     CsvPromptOutput,
-)
-from modelgauge.prompt_pipeline import (
+    PromptInput,
+    PromptOutput,
+    PromptSink,
     PromptSource,
     PromptSutAssigner,
     PromptSutWorkers,
-    PromptSink,
     SutInteraction,
 )
-from modelgauge.sut import SUTOptions, SUTResponse
 from modelgauge.single_turn_prompt_response import TestItem
+from modelgauge.sut import SUTOptions, SUTResponse
+
 from modelgauge_tests.fake_sut import FakeSUT, FakeSUTRequest, FakeSUTResponse
 
 
@@ -98,7 +97,7 @@ def test_csv_prompt_input(tmp_path):
 def test_csv_prompt_input_invalid_columns(tmp_path, header):
     file_path = tmp_path / "input.csv"
     file_path.write_text(header)
-    with pytest.raises(AssertionError, match="Invalid input file. Must have columns: UID, Text."):
+    with pytest.raises(AssertionError, match="Unsupported input file. Required columns are"):
         CsvPromptInput(file_path)
 
 


### PR DESCRIPTION
If you run a modelgauge test using an official prompt set csv file as input, modelgauge rejects it because the column names don't match what it expects.

This adds support for:

* official prompt set files
* database dumps using the table column names

https://github.com/mlcommons/modelbench/issues/901