### PR TITLE
Pipeline retries

### DIFF
--- a/src/modelgauge/annotation_pipeline.py
+++ b/src/modelgauge/annotation_pipeline.py
@@ -1,8 +1,7 @@
 import csv
 import jsonlines
 import logging
-import sys
-import traceback
+import time
 from abc import abstractmethod, ABCMeta
 from collections import defaultdict
 from pydantic import BaseModel
@@ -141,6 +140,7 @@ class AnnotatorWorkers(CachingPipe):
                 logger.warning(
                     f"Exception calling annotator {annotator_uid} on attempt {tries}: {e}\nRetrying.....", exc_info=True
                 )
+                time.sleep(10)
         result = annotator.translate_response(request, response)
         self.annotation_counts[annotator_uid] += 1
         return sut_interaction, annotator_uid, result

--- a/src/modelgauge/annotation_pipeline.py
+++ b/src/modelgauge/annotation_pipeline.py
@@ -1,5 +1,6 @@
 import csv
 import jsonlines
+import logging
 import sys
 import traceback
 from abc import abstractmethod, ABCMeta
@@ -13,6 +14,8 @@ from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_pipeline import PromptOutput, SutInteraction
 from modelgauge.single_turn_prompt_response import TestItem
 from modelgauge.sut import PromptResponseSUT, SUTResponse
+
+logger = logging.getLogger(__name__)
 
 ANNOTATOR_CSV_INPUT_COLUMNS = ["UID", "Prompt", "SUT", "Response"]
 
@@ -126,19 +129,21 @@ class AnnotatorWorkers(CachingPipe):
 
     def handle_uncached_item(self, item):
         sut_interaction, annotator_uid = item
-        try:
-            annotator = self.annotators[annotator_uid]
-            request = annotator.translate_request(sut_interaction.prompt, sut_interaction.response)
-            response = annotator.annotate(request)
-            result = annotator.translate_response(request, response)
-            self.annotation_counts[annotator_uid] += 1
-            return sut_interaction, annotator_uid, result
-        except Exception as e:
-            print(
-                f"unexpected failure processing {item} for {annotator_uid}.\n{e}\n",
-                file=sys.stderr,
-            )
-            traceback.print_exc(file=sys.stderr)
+        annotator = self.annotators[annotator_uid]
+        request = annotator.translate_request(sut_interaction.prompt, sut_interaction.response)
+        tries = 0
+        while True:
+            tries += 1
+            try:
+                response = annotator.annotate(request)
+                break
+            except Exception as e:
+                logger.warning(
+                    f"Exception calling annotator {annotator_uid} on attempt {tries}: {e}\nRetrying.....", exc_info=True
+                )
+        result = annotator.translate_response(request, response)
+        self.annotation_counts[annotator_uid] += 1
+        return sut_interaction, annotator_uid, result
 
 
 class AnnotatorSink(Sink):

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -6,6 +6,7 @@ from typing import Iterable, Optional
 
 from modelgauge.pipeline import CachingPipe, Pipe, Sink, Source
 from modelgauge.prompt import TextPrompt
+from modelgauge.retry_decorator import retry
 from modelgauge.single_turn_prompt_response import TestItem
 from modelgauge.sut import PromptResponseSUT, SUT, SUTOptions, SUTResponse
 
@@ -165,6 +166,7 @@ class PromptSutWorkers(CachingPipe):
         response = self.call_sut(prompt_item.prompt, self.suts[sut_uid])
         return SutInteraction(prompt_item, sut_uid, response)
 
+    @retry(base_retry_count=10000, max_retry_duration=43200)
     def call_sut(self, prompt_text: TextPrompt, sut: PromptResponseSUT) -> SUTResponse:
         request = sut.translate_text_prompt(prompt_text, self.sut_options)
         response = sut.evaluate(request)

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import time
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
@@ -177,6 +178,7 @@ class PromptSutWorkers(CachingPipe):
                 break
             except Exception as e:
                 logger.warning(f"Exception calling SUT {sut.uid} on attempt {tries}: {e}\nRetrying.....", exc_info=True)
+                time.sleep(10)
         result = sut.translate_response(request, response)
         self.sut_response_counts[sut.uid] += 1
         return result

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -176,9 +176,7 @@ class PromptSutWorkers(CachingPipe):
                 response = sut.evaluate(request)
                 break
             except Exception as e:
-                logger.warning(
-                    f"Exception calling SUT {sut.uid} on attempt {tries}: {e}\nRetrying.....", exc_info=True
-                )
+                logger.warning(f"Exception calling SUT {sut.uid} on attempt {tries}: {e}\nRetrying.....", exc_info=True)
         result = sut.translate_response(request, response)
         self.sut_response_counts[sut.uid] += 1
         return result


### PR DESCRIPTION
The pipeline runner (which used by `run-job` and `run-csv-items`) now will keep retrying calls to SUTs and annotators until it gets a successful response. It logs exceptions and retry counts so that a user can manually stop the command if they see that it is retrying an impossible exception a million times.