### PR TITLE
Misc. run-job improvements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+airr_data/
 run/
 __pycache__/
 web/

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -274,7 +274,7 @@ def run_test(
     type=click.Path(exists=True, path_type=pathlib.Path),
 )
 def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path, max_tokens, temp, top_p, top_k):
-    """Run rows in a CSV through some SUTs and/or annotators.
+    """Run rows in a CSV through a SUT and/or a set of annotators.
 
     If running a SUT, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.
     If running ONLY  annotators, the file must have 'UID', 'Prompt', 'SUT', and 'Response' columns. The output will be saved to a json lines file.

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -334,6 +334,8 @@ def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
             complete_count = data["completed"]
             bar.update(complete_count - last_complete_count)
             last_complete_count = complete_count
+            if last_complete_count == pipeline_runner.num_total_items:
+                print()  # Print new line after progress bar for better formatting.
 
         pipeline_runner.run(show_progress, debug)
 

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -35,6 +35,8 @@ from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.sut_registry import SUTS
 from modelgauge.test_registry import TESTS
 
+logger = logging.getLogger(__name__)
+
 
 @modelgauge_cli.command(name="list")
 @LOCAL_PLUGIN_DIR_OPTION
@@ -277,10 +279,7 @@ def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
     If running a SUT, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.
     If running ONLY  annotators, the file must have 'UID', 'Prompt', 'SUT', and 'Response' columns. The output will be saved to a json lines file.
     """
-    # Setup logger.
-    logging.basicConfig()
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
     # Check all objects for missing secrets.
     secrets = load_secrets_from_config()
     if sut_uid:
@@ -311,16 +310,13 @@ def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
             output_dir,
             sut_options=sut_options,
             tag=tag,
-            logger=logger,
         )
     elif sut_uid:
-        pipeline_runner = PromptRunner(
-            suts, workers, input_path, output_dir, sut_options=sut_options, tag=tag, logger=logger
-        )
+        pipeline_runner = PromptRunner(suts, workers, input_path, output_dir, sut_options=sut_options, tag=tag)
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             logger.warning(f"Received SUT options but only running annotators. Options will not be used.")
-        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, tag=tag, logger=logger)
+        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, tag=tag)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
 
@@ -395,10 +391,7 @@ def run_csv_items(
     If running SUTs, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.
     If running ONLY  annotators, the file must have 'UID', 'Prompt', 'SUT', and 'Response' columns. The output will be saved to a json lines file.
     """
-    # Setup logger.
-    logging.basicConfig()
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
     # Check all objects for missing secrets.
     secrets = load_secrets_from_config()
     check_secrets(secrets, sut_uids=sut_uids, annotator_uids=annotator_uids)
@@ -432,18 +425,15 @@ def run_csv_items(
             output_dir,
             cache_dir=cache_dir,
             sut_options=sut_options,
-            logger=logger,
         )
     elif suts:
         pipeline_runner = PromptRunner(
-            suts, workers, input_path, output_dir, cache_dir=cache_dir, sut_options=sut_options, logger=logger
+            suts, workers, input_path, output_dir, cache_dir=cache_dir, sut_options=sut_options
         )
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             warnings.warn(f"Received SUT options but only running annotators. Options will not be used.")
-        pipeline_runner = AnnotatorRunner(
-            annotators, workers, input_path, output_dir, cache_dir=cache_dir, logger=logger
-        )
+        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, cache_dir=cache_dir)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
 

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -35,8 +35,6 @@ from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.sut_registry import SUTS
 from modelgauge.test_registry import TESTS
 
-logger = logging.getLogger(__name__)
-
 
 @modelgauge_cli.command(name="list")
 @LOCAL_PLUGIN_DIR_OPTION
@@ -279,6 +277,10 @@ def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
     If running a SUT, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.
     If running ONLY  annotators, the file must have 'UID', 'Prompt', 'SUT', and 'Response' columns. The output will be saved to a json lines file.
     """
+    # Setup logger.
+    logging.basicConfig()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
     # Check all objects for missing secrets.
     secrets = load_secrets_from_config()
     if sut_uid:
@@ -309,13 +311,16 @@ def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
             output_dir,
             sut_options=sut_options,
             tag=tag,
+            logger=logger,
         )
     elif sut_uid:
-        pipeline_runner = PromptRunner(suts, workers, input_path, output_dir, sut_options=sut_options, tag=tag)
+        pipeline_runner = PromptRunner(
+            suts, workers, input_path, output_dir, sut_options=sut_options, tag=tag, logger=logger
+        )
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             logger.warning(f"Received SUT options but only running annotators. Options will not be used.")
-        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, tag=tag)
+        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, tag=tag, logger=logger)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
 
@@ -390,6 +395,10 @@ def run_csv_items(
     If running SUTs, the file must have 'UID' and 'Text' columns. The output will be saved to a CSV file.
     If running ONLY  annotators, the file must have 'UID', 'Prompt', 'SUT', and 'Response' columns. The output will be saved to a json lines file.
     """
+    # Setup logger.
+    logging.basicConfig()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
     # Check all objects for missing secrets.
     secrets = load_secrets_from_config()
     check_secrets(secrets, sut_uids=sut_uids, annotator_uids=annotator_uids)
@@ -423,15 +432,18 @@ def run_csv_items(
             output_dir,
             cache_dir=cache_dir,
             sut_options=sut_options,
+            logger=logger,
         )
     elif suts:
         pipeline_runner = PromptRunner(
-            suts, workers, input_path, output_dir, cache_dir=cache_dir, sut_options=sut_options
+            suts, workers, input_path, output_dir, cache_dir=cache_dir, sut_options=sut_options, logger=logger
         )
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             warnings.warn(f"Received SUT options but only running annotators. Options will not be used.")
-        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, cache_dir=cache_dir)
+        pipeline_runner = AnnotatorRunner(
+            annotators, workers, input_path, output_dir, cache_dir=cache_dir, logger=logger
+        )
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
 

--- a/src/modelgauge/main.py
+++ b/src/modelgauge/main.py
@@ -302,21 +302,20 @@ def run_job(sut_uid, annotator_uids, workers, output_dir, tag, debug, input_path
     # Create correct pipeline runner based on input.
     if sut_uid and annotators:
         pipeline_runner = PromptPlusAnnotatorRunner(
+            suts,
+            annotators,
             workers,
             input_path,
             output_dir,
-            None,
-            sut_options,
-            tag,
-            suts=suts,
-            annotators=annotators,
+            sut_options=sut_options,
+            tag=tag,
         )
     elif sut_uid:
-        pipeline_runner = PromptRunner(workers, input_path, output_dir, None, sut_options, tag, suts=suts)
+        pipeline_runner = PromptRunner(suts, workers, input_path, output_dir, sut_options=sut_options, tag=tag)
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             logger.warning(f"Received SUT options but only running annotators. Options will not be used.")
-        pipeline_runner = AnnotatorRunner(workers, input_path, output_dir, None, None, tag, annotators=annotators)
+        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, tag=tag)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
 
@@ -417,20 +416,22 @@ def run_csv_items(
     # Create correct pipeline runner based on input.
     if suts and annotators:
         pipeline_runner = PromptPlusAnnotatorRunner(
+            suts,
+            annotators,
             workers,
             input_path,
             output_dir,
-            cache_dir,
-            sut_options,
-            suts=suts,
-            annotators=annotators,
+            cache_dir=cache_dir,
+            sut_options=sut_options,
         )
     elif suts:
-        pipeline_runner = PromptRunner(workers, input_path, output_dir, cache_dir, sut_options, suts=suts)
+        pipeline_runner = PromptRunner(
+            suts, workers, input_path, output_dir, cache_dir=cache_dir, sut_options=sut_options
+        )
     elif annotators:
         if max_tokens is not None or temp is not None or top_p is not None or top_k is not None:
             warnings.warn(f"Received SUT options but only running annotators. Options will not be used.")
-        pipeline_runner = AnnotatorRunner(workers, input_path, output_dir, cache_dir, None, annotators=annotators)
+        pipeline_runner = AnnotatorRunner(annotators, workers, input_path, output_dir, cache_dir=cache_dir)
     else:
         raise ValueError("Must specify at least one SUT or annotator.")
 

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -20,6 +20,7 @@ from modelgauge.prompt_pipeline import (
     CsvPromptInput,
     CsvPromptOutput,
 )
+from modelgauge.sut import SUTOptions
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ logger.setLevel(logging.INFO)
 
 
 class PipelineRunner(ABC):
-    def __init__(self, num_workers, input_path, output_dir, cache_dir, sut_options, tag=None):
+    def __init__(self, num_workers, input_path, output_dir, cache_dir=None, sut_options=SUTOptions(), tag=None):
         self.num_workers = num_workers
         self.input_path = input_path
         self.root_dir = output_dir
@@ -163,9 +164,9 @@ class PipelineRunner(ABC):
 
 
 class PromptRunner(PipelineRunner):
-    def __init__(self, *args, suts):
+    def __init__(self, suts, *args, **kwargs):
         self.suts = suts
-        super().__init__(*args)
+        super().__init__(*args, **kwargs)
 
     @property
     def num_total_items(self):
@@ -189,10 +190,10 @@ class PromptRunner(PipelineRunner):
 
 
 class PromptPlusAnnotatorRunner(PipelineRunner):
-    def __init__(self, *args, suts, annotators):
+    def __init__(self, suts, annotators, *args, **kwargs):
         self.suts = suts
         self.annotators = annotators
-        super().__init__(*args)
+        super().__init__(*args, **kwargs)
 
     @property
     def num_total_items(self):
@@ -218,9 +219,9 @@ class PromptPlusAnnotatorRunner(PipelineRunner):
 
 
 class AnnotatorRunner(PipelineRunner):
-    def __init__(self, *args, annotators):
+    def __init__(self, annotators, *args, **kwargs):
         self.annotators = annotators
-        super().__init__(*args)
+        super().__init__(*args, **kwargs)
 
     @property
     def num_total_items(self):

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -22,18 +22,17 @@ from modelgauge.prompt_pipeline import (
 )
 from modelgauge.sut import SUTOptions
 
+logger = logging.getLogger(__name__)
+
 
 class PipelineRunner(ABC):
-    def __init__(
-        self, num_workers, input_path, output_dir, cache_dir=None, sut_options=SUTOptions(), tag=None, logger=None
-    ):
+    def __init__(self, num_workers, input_path, output_dir, cache_dir=None, sut_options=SUTOptions(), tag=None):
         self.num_workers = num_workers
         self.input_path = input_path
         self.root_dir = output_dir
         self.cache_dir = cache_dir
         self.sut_options = sut_options
         self.tag = tag
-        self.logger = logger
         self.pipeline_segments = []
         self.start_time = datetime.datetime.now()
         self.finish_time = None
@@ -76,7 +75,7 @@ class PipelineRunner(ABC):
     def output_dir(self):
         output_path = self.root_dir / self.run_id
         if not output_path.exists():
-            self._log(f"Creating output dir {output_path}")
+            logger.info(f"Creating output dir {output_path}")
             output_path.mkdir(parents=True)
         return output_path
 
@@ -88,7 +87,7 @@ class PipelineRunner(ABC):
         )
         pipeline.run()
         self.finish_time = datetime.datetime.now()
-        self._log(f"output saved to {self.output_dir() / self.output_file_name}")
+        logger.info(f"output saved to {self.output_dir() / self.output_file_name}")
         self._write_metadata()
 
     @staticmethod
@@ -160,12 +159,6 @@ class PipelineRunner(ABC):
     def _write_metadata(self):
         with open(self.output_dir() / "metadata.json", "w") as f:
             json.dump(self.metadata(), f, indent=4)
-
-    def _log(self, message):
-        if self.logger:
-            self.logger.info(message)
-        else:
-            print(message)
 
 
 class PromptRunner(PipelineRunner):

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -21,7 +21,9 @@ from modelgauge.prompt_pipeline import (
     CsvPromptOutput,
 )
 
+logging.basicConfig()
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class PipelineRunner(ABC):
@@ -86,7 +88,7 @@ class PipelineRunner(ABC):
         )
         pipeline.run()
         self.finish_time = datetime.datetime.now()
-        logger.info(f"\noutput saved to {self.output_dir() / self.output_file_name}")
+        logger.info(f"output saved to {self.output_dir() / self.output_file_name}")
         self._write_metadata()
 
     @staticmethod


### PR DESCRIPTION
- Update .gitignore to include default directory used by `run-job`
- The logger.info() statements weren't printing anything before. Now they print to stdout.
![Screenshot 2025-03-24 at 12 45 26 PM](https://github.com/user-attachments/assets/930ca6af-6cf7-41cd-82e7-0eaadd38d364)
