### PR TITLE
add poetry lock file check

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -74,8 +74,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        poetry cache clear --all .
-        rm -f poetry.lock
+        poetry cache clear --no-interaction --all .
+        poetry check || echo "poetry.lock is stale. Please update and commit it."
         poetry install --no-interaction --with dev --extras all_plugins
 
     - name: Lint formatting

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -74,8 +74,9 @@ jobs:
 
     - name: Install dependencies
       run: |
+        set -e
         poetry cache clear --no-interaction --all .
-        poetry check || echo "poetry.lock is stale. Please update and commit it."
+        poetry check
         poetry install --no-interaction --with dev --extras all_plugins
 
     - name: Lint formatting


### PR DESCRIPTION
Sometimes a poetry.lock file isn't refreshed by a developer. This adds a check so we get feedback about it early (at least earlier than the smoke test).

A pre-commit hook is also an option, but not everyone likes those. People who do are welcome to add them to their local repo.