### PR TITLE
Retry connection exceptions for baseten suts

### DIFF
--- a/plugins/baseten/modelgauge/suts/baseten_api.py
+++ b/plugins/baseten/modelgauge/suts/baseten_api.py
@@ -119,7 +119,7 @@ BASETEN_SECRET = InjectSecret(BasetenInferenceAPIKey)
 
 SUTS.register(
     BasetenMessagesSUT,
-    "llama-3.3-49b-nemotron-super",
+    "nvidia-llama-3.3-49b-nemotron-super",
     "nvidia/llama-3.3-nemotron-super-49b-v1",
     "https://model-v319m4rq.api.baseten.co/environments/production/predict",
     BASETEN_SECRET,

--- a/plugins/baseten/modelgauge/suts/baseten_api.py
+++ b/plugins/baseten/modelgauge/suts/baseten_api.py
@@ -64,7 +64,7 @@ class BasetenSUT(PromptResponseSUT[BasetenChatRequest, BasetenResponse]):
         self.model = model
         self.endpoint = endpoint
 
-    @retry()
+    @retry(transient_exceptions=[requests.exceptions.ConnectionError])
     def evaluate(self, request: BasetenChatRequest) -> BasetenResponse:
         headers = {
             "Accept": "application/json",


### PR DESCRIPTION
The baseten endpoint sometimes takes too long to spin up, resulting in a `ConnectionError` exception. This PR modifies the SUT to retry that specific exception for a whole day (instead of just 3 times).

I also modified the SUT UID to be consistent with the other nvidia sut.