### PR TITLE
Command A

### DIFF
--- a/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
@@ -25,7 +25,7 @@ class ChatMessage(BaseModel):
 class HuggingFaceChatCompletionRequest(BaseModel):
     model: Optional[str] = None
     messages: List[ChatMessage]
-    logprobs: bool
+    logprobs: Optional[bool] = None
     top_logprobs: Optional[int] = None
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
@@ -152,7 +152,7 @@ class HuggingFaceChatCompletionServerlessSUT(BaseHuggingFaceChatCompletionSUT):
         )
 
     def translate_text_prompt(self, prompt: TextPrompt, options: SUTOptions) -> HuggingFaceChatCompletionRequest:
-        logprobs = False
+        logprobs = None
         if options.top_logprobs is not None:
             logprobs = True
         return HuggingFaceChatCompletionRequest(
@@ -191,6 +191,13 @@ for sut, endpoint in DEDICATED_SUTS_AND_SERVERS.items():
         HF_SECRET,
     )
 
+SUTS.register(
+    HuggingFaceChatCompletionServerlessSUT,
+    "cohere-c4ai-command-a-03-2025-hf",
+    "CohereLabs/c4ai-command-a-03-2025",
+    "cohere",
+    HF_SECRET,
+)
 
 SUTS.register(
     HuggingFaceChatCompletionServerlessSUT,

--- a/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_chat_completion.py
@@ -126,7 +126,7 @@ class HuggingFaceChatCompletionDedicatedSUT(BaseHuggingFaceChatCompletionSUT):
         return InferenceClient(base_url=endpoint.url, token=self.token.value)
 
     def translate_text_prompt(self, prompt: TextPrompt, options: SUTOptions) -> HuggingFaceChatCompletionRequest:
-        logprobs = False
+        logprobs = None
         if options.top_logprobs is not None:
             logprobs = True
         return HuggingFaceChatCompletionRequest(

--- a/plugins/huggingface/tests/test_huggingface_chat_completion.py
+++ b/plugins/huggingface/tests/test_huggingface_chat_completion.py
@@ -52,9 +52,9 @@ def _make_sut_request(top_logprobs: Optional[int] = None):
     extra_options = {}
     if top_logprobs is not None:
         extra_options["top_logprobs"] = top_logprobs
+        extra_options["logprobs"] = True
     return HuggingFaceChatCompletionRequest(
         messages=[ChatMessage(role="user", content="some text prompt")],
-        logprobs=top_logprobs is not None,
         max_tokens=5,
         temperature=1.0,
         **extra_options,
@@ -156,7 +156,6 @@ def test_huggingface_chat_completion_evaluate_sends_correct_request_params(mock_
     mock_client.chat_completion.assert_called_with(
         **{
             "messages": [{"content": "some text prompt", "role": "user"}],
-            "logprobs": False,
             "max_tokens": 5,
             "temperature": 1.0,
         }


### PR DESCRIPTION
I had to change the default logprobs value to be None because False was causing an error with the Command-A model. I tested that the other models still work as expected with this change.