### PR TITLE
Ensuring path is defined for extras.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4600,4 +4600,4 @@ vertexai = ["modelgauge_vertexai"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,!=3.12.5,<3.13"
-content-hash = "108889f983513096c9104f95332572a17672fccd6557f0445c88a5ec8a911a93"
+content-hash = "0a0b186e363a9934097287744ba4a183fddf8b51201f028cf325fa4093acb698"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,21 +75,6 @@ diskcache = "^5.6.3"
 starlette = ">=0.41,<0.46"
 fastapi = "^0.115.0"
 together = "^1.2.3"
-modelgauge_anthropic = {version = "*", optional = true}
-modelgauge_azure = {version = "*", optional = true}
-modelgauge_baseten = {version = "*", optional = true}
-modelgauge_demo_plugin = {version = "*", optional = false}
-modelgauge_nvidia = {version = "*", optional = true}
-modelgauge_openai = {version = "*", optional = true}
-modelgauge_huggingface = {version = "*", optional = true}
-modelgauge_perspective_api = {version = "*", optional = true}
-modelgauge_google = {version = "*", optional = true}
-modelgauge_vertexai = {version = "*", optional = true}
-modelgauge_mistral = {version = "*", optional = true}
-modelgauge_amazon = {version = "*", optional = true}
-prometheus-client = "^0.21.1"
-
-[tool.poetry.group.dev.dependencies]
 modelgauge_anthropic = {path = "plugins/anthropic", develop = true, optional=true}
 modelgauge_azure = {path = "plugins/azure", develop = true, optional=true}
 modelgauge_baseten = {path = "plugins/baseten", develop = true, optional=true}
@@ -103,6 +88,9 @@ modelgauge_vertexai = {path = "plugins/vertexai", develop = true, optional = tru
 # named *mistral* rather than *mistralai* to prevent a conflict with the first-party mistralai package
 modelgauge_mistral = {path = "plugins/mistral", develop = true, optional = true}
 modelgauge_amazon = {path = "plugins/amazon", develop = true, optional=true}
+prometheus-client = "^0.21.1"
+
+[tool.poetry.group.dev.dependencies]
 pytest-datafiles = "^3.0.0"
 pytest = "^8.0.1"
 pytest-mock = "^3.12.0"


### PR DESCRIPTION
We had the plugins defined both in the main dependencies (as `{version = "*", optional = true}`) and the dev dependencies (with `{path=..., develop = true, optional = true}`.

When using modelbench as a dependency in another pyproject file as below, I wasn't able to generate a lock:
```
modelbench = {git = "https://github.com/mlcommons/modelbench.git", extras = ["all_plugins"], rev= "test-plugin-cleanup"}
```
The error message:
```
Because modelbench[all-plugins] (1.0.0) @ git+https://github.com/mlcommons/modelbench.git@HEAD depends on modelgauge_amazon (*) which doesn't match any versions, modelbench is forbidden.
```

The issue is that it's resolving `modelgauge_amazon` with the first definition, not the second. 

With this PR, there's only one definition. I left in the develop / optional tags, but not the version tag. The poetry lock file was not updated, despite this change.