### PR TITLE
Fix Pydantic issue with cached values.

### DIFF
--- a/src/modelgauge/suts/meta_llama_client.py
+++ b/src/modelgauge/suts/meta_llama_client.py
@@ -105,6 +105,9 @@ class MetaLlamaModeratedSUT(PromptResponseSUT[MetaLlamaChatRequest, MetaLlamaMod
         messages: list = kwargs.get("messages")  # type: ignore
         messages.append(chat_response.completion_message)
         moderation_response = self.client.moderations.create(messages=messages)
+        for r in moderation_response.results:
+            if r.flagged_categories is None:
+                r.flagged_categories = []  # make objects comply with Pydantic definitions
         return MetaLlamaModeratedResponse(sut_response=chat_response, moderation_response=moderation_response)
 
     def translate_response(self, request: MetaLlamaChatRequest, response: MetaLlamaModeratedResponse) -> SUTResponse:

--- a/src/modelgauge/suts/meta_llama_client.py
+++ b/src/modelgauge/suts/meta_llama_client.py
@@ -107,7 +107,9 @@ class MetaLlamaModeratedSUT(PromptResponseSUT[MetaLlamaChatRequest, MetaLlamaMod
         moderation_response = self.client.moderations.create(messages=messages)
         for r in moderation_response.results:
             if r.flagged_categories is None:
-                r.flagged_categories = []  # make objects comply with Pydantic definitions
+                # make objects comply with Pydantic definitions due to bug;
+                # see https://github.com/meta-llama/llama-api-python/issues/33 for more
+                r.flagged_categories = []
         return MetaLlamaModeratedResponse(sut_response=chat_response, moderation_response=moderation_response)
 
     def translate_response(self, request: MetaLlamaChatRequest, response: MetaLlamaModeratedResponse) -> SUTResponse:


### PR DESCRIPTION
The Llama API is returning things that are invalid according to their Pydantic definitions, but this somehow doesn't show up as a problem until cache retrieval. Here I'm just fixing the data to match its typing. Maybe there's a better option?