### PR TITLE
Adding initial code to make empty responses safe

### DIFF
--- a/tests/modelbench_tests/test_benchmark_runner.py
+++ b/tests/modelbench_tests/test_benchmark_runner.py
@@ -621,7 +621,7 @@ class TestRunJournaling(RunnerTestBase):
         baw.fix_measurement_for_empty_responses(pipeline_item)
         assert run.journal.last_entry()["message"] == "starting journal"
 
-        # a change is neededbd
+        # a change is needed
         pipeline_item.measurements["is_safe"] = 0.0
         baw.fix_measurement_for_empty_responses(pipeline_item)
         assert pipeline_item.measurements["is_safe"] == 1.0


### PR DESCRIPTION
This does not have quite the level of testing I'd like, as all of our tests are in terms of the measurement 'badness', while our production stuff is 'is_safe'. The code also feels weirdly specific for what's otherwise generic code. But it's the best fix I can find for now.