### PR TITLE
try both serverless and dedicated until you find a place to run your model

### DIFF
--- a/plugins/huggingface/modelgauge/suts/huggingface_sut_factory.py
+++ b/plugins/huggingface/modelgauge/suts/huggingface_sut_factory.py
@@ -26,7 +26,15 @@ def make_sut(sut_name: str, *args, **kwargs) -> tuple | None:
             raise UnknownSUTProviderError(f"Unknown proxy '{sut_metadata.driver}'")
         return HuggingFaceChatCompletionServerlessSUTFactory.make_sut(sut_metadata)
     else:
-        return HuggingFaceChatCompletionDedicatedSUTFactory.make_sut(sut_metadata)
+        # is there a serverless option?
+        sut = HuggingFaceChatCompletionServerlessSUTFactory.make_sut(sut_metadata)
+        if not sut:
+            # is there a dedicated option?
+            sut = HuggingFaceChatCompletionDedicatedSUTFactory.make_sut(sut_metadata)
+        if not sut:
+            raise ModelNotSupportedError(
+                f"Huggingface doesn't know model {sut_name}, or you need credentials for its repo."
+            )
 
 
 def find_inference_provider_for(model_name) -> dict | None:


### PR DESCRIPTION
When trying to run dynamic SUTs directly on huggingface, the code only looked for a dedicated endpoint. Now it looks for a serverless option as well.