### PR TITLE
Standardize columns + Data refactor

### DIFF
--- a/src/modelgauge/data_schema.py
+++ b/src/modelgauge/data_schema.py
@@ -1,10 +1,3 @@
-ANNOTATOR_CSV_INPUT_COLUMNS = ["UID", "Prompt", "SUT", "Response"]
-PROMPT_CSV_INPUT_COLUMNS = {
-    "default": {"id": "UID", "text": "Text"},
-    "prompt_set": {"id": "release_prompt_id", "text": "prompt_text"},  # official prompt set files
-    "db": {"id": "prompt_uid", "text": "prompt_text"},  # database dumps
-}
-
 # The first value is the preferred name.
 PROMPT_UID_COLS = ["prompt_uid", "release_prompt_id"]
 PROMPT_TEXT_COLS = ["prompt_text"]
@@ -92,3 +85,10 @@ class PromptResponseSchema(PromptSchema):
             missing.append(SUT_RESPONSE_COLS)
         if missing:
             raise SchemaValidationError(missing)
+
+
+# Schemas with preferred names.
+DEFAULT_PROMPT_SCHEMA = PromptSchema([PROMPT_UID_COLS[0], PROMPT_TEXT_COLS[0]])
+DEFAULT_PROMPT_RESPONSE_SCHEMA = PromptResponseSchema(
+    [PROMPT_UID_COLS[0], PROMPT_TEXT_COLS[0], SUT_UID_COLS[0], SUT_RESPONSE_COLS[0]]
+)

--- a/src/modelgauge/data_schema.py
+++ b/src/modelgauge/data_schema.py
@@ -3,6 +3,8 @@ PROMPT_UID_COLS = ["prompt_uid", "release_prompt_id"]
 PROMPT_TEXT_COLS = ["prompt_text"]
 SUT_UID_COLS = ["sut_uid", "sut"]
 SUT_RESPONSE_COLS = ["sut_response", "response_text", "response"]
+ANNOTATOR_UID_COLS = ["annotator_uid"]
+ANNOTATION_COLS = ["is_safe"]
 
 
 class SchemaValidationError(ValueError):
@@ -26,7 +28,7 @@ class SchemaValidationError(ValueError):
 
 
 class PromptSchema:
-    """A case-insensitive schema for a prompts file.
+    """A case-insensitive schema for a prompts file that is used as input to get SUT responses.
 
     Attributes:
         prompt_uid: The column name for the prompt uid.
@@ -34,6 +36,7 @@ class PromptSchema:
     """
 
     def __init__(self, header: list[str]):
+        self.header = header
         self.prompt_uid = self._find_column(header, PROMPT_UID_COLS)
         self.prompt_text = self._find_column(header, PROMPT_TEXT_COLS)
         self._validate()
@@ -58,7 +61,7 @@ class PromptSchema:
 
 
 class PromptResponseSchema(PromptSchema):
-    """A schema for a prompt + response file that is used as annotation input.
+    """A schema for a prompt + response file that is used as prompt-response output or annotation input.
     Attributes:
         prompt_uid: The column name for the prompt uid. (same as PromptSchema)
         prompt_text: The column name for the prompt text. (same as PromptSchema)
@@ -87,8 +90,50 @@ class PromptResponseSchema(PromptSchema):
             raise SchemaValidationError(missing)
 
 
+class AnnotationSchema(PromptResponseSchema):
+    """A schema for a prompt + response + annotation file that is used as annotation output.
+    Attributes:
+        prompt_uid: The column name for the prompt uid. (same as PromptSchema)
+        prompt_text: The column name for the prompt text. (same as PromptSchema)
+        sut_uid: The column name for the SUT uid. (same as PromptResponseSchema)
+        sut_response: The column name for the SUT response. (same as PromptResponseSchema)
+        annotator_uid: The column name for the annotator uid.
+        annotation: The column name for the text annotation.
+    """
+
+    def __init__(self, header: list[str]):
+        self.annotator_uid = self._find_column(header, ANNOTATOR_UID_COLS)
+        self.annotation = self._find_column(header, ANNOTATION_COLS)
+        super().__init__(header)  # Iniitalize the prompt schema columns and then validate.
+
+    def _validate(self):
+        missing = []
+        # Validate that the prompt schema is valid
+        try:
+            super()._validate()
+        except SchemaValidationError as e:
+            missing.extend(e.missing_columns)
+        # Validate that the SUT uid and response columns are present
+        if self.annotator_uid is None:
+            missing.append(ANNOTATOR_UID_COLS)
+        if self.annotation is None:
+            missing.append(ANNOTATION_COLS)
+        if missing:
+            raise SchemaValidationError(missing)
+
+
 # Schemas with preferred names.
 DEFAULT_PROMPT_SCHEMA = PromptSchema([PROMPT_UID_COLS[0], PROMPT_TEXT_COLS[0]])
 DEFAULT_PROMPT_RESPONSE_SCHEMA = PromptResponseSchema(
     [PROMPT_UID_COLS[0], PROMPT_TEXT_COLS[0], SUT_UID_COLS[0], SUT_RESPONSE_COLS[0]]
+)
+DEFAULT_ANNOTATION_SCHEMA = AnnotationSchema(
+    [
+        PROMPT_UID_COLS[0],
+        PROMPT_TEXT_COLS[0],
+        SUT_UID_COLS[0],
+        SUT_RESPONSE_COLS[0],
+        ANNOTATOR_UID_COLS[0],
+        ANNOTATION_COLS[0],
+    ]
 )

--- a/src/modelgauge/data_schema.py
+++ b/src/modelgauge/data_schema.py
@@ -4,7 +4,7 @@ PROMPT_TEXT_COLS = ["prompt_text"]
 SUT_UID_COLS = ["sut_uid", "sut"]
 SUT_RESPONSE_COLS = ["sut_response", "response_text", "response"]
 ANNOTATOR_UID_COLS = ["annotator_uid"]
-ANNOTATION_COLS = ["is_safe"]
+ANNOTATION_COLS = ["annotation_json"]
 
 
 class SchemaValidationError(ValueError):

--- a/src/modelgauge/data_schema.py
+++ b/src/modelgauge/data_schema.py
@@ -1,0 +1,94 @@
+ANNOTATOR_CSV_INPUT_COLUMNS = ["UID", "Prompt", "SUT", "Response"]
+PROMPT_CSV_INPUT_COLUMNS = {
+    "default": {"id": "UID", "text": "Text"},
+    "prompt_set": {"id": "release_prompt_id", "text": "prompt_text"},  # official prompt set files
+    "db": {"id": "prompt_uid", "text": "prompt_text"},  # database dumps
+}
+
+# The first value is the preferred name.
+PROMPT_UID_COLS = ["prompt_uid", "release_prompt_id"]
+PROMPT_TEXT_COLS = ["prompt_text"]
+SUT_UID_COLS = ["sut_uid", "sut"]
+SUT_RESPONSE_COLS = ["sut_response", "response_text", "response"]
+
+
+class SchemaValidationError(ValueError):
+    """Exception raised when schema validation fails."""
+
+    def __init__(self, missing_columns):
+        """missing_columns: a list where each element is a string or a list of strings. List elements are used to indicate that the column can be one of several options."""
+        self.missing_columns = missing_columns
+        super().__init__(str(self))
+
+    def __str__(self):
+        message = "Missing required columns:"
+        for column in self.missing_columns:
+            if isinstance(column, str):
+                message += f"\n\t{column}"
+            elif len(column) == 1:
+                message += f"\n\t{column[0]}"
+            else:
+                message += f"\n\tone of: {column}"
+        return message
+
+
+class PromptSchema:
+    """A case-insensitive schema for a prompts file.
+
+    Attributes:
+        prompt_uid: The column name for the prompt uid.
+        prompt_text: The column name for the prompt text.
+    """
+
+    def __init__(self, header: list[str]):
+        self.prompt_uid = self._find_column(header, PROMPT_UID_COLS)
+        self.prompt_text = self._find_column(header, PROMPT_TEXT_COLS)
+        self._validate()
+
+    def _find_column(self, header, columns):
+        return next((col for col in header if col.lower() in columns), None)
+
+    def _validate(self):
+        """Validates that all required columns were found in the header.
+
+        Raises:
+            SchemaValidationError: If any required columns are missing.
+        """
+        missing = []
+        if self.prompt_uid is None:
+            missing.append(PROMPT_UID_COLS)
+        if self.prompt_text is None:
+            missing.append(PROMPT_TEXT_COLS)
+
+        if missing:
+            raise SchemaValidationError(missing)
+
+
+class PromptResponseSchema(PromptSchema):
+    """A schema for a prompt + response file that is used as annotation input.
+    Attributes:
+        prompt_uid: The column name for the prompt uid. (same as PromptSchema)
+        prompt_text: The column name for the prompt text. (same as PromptSchema)
+        sut_uid: The column name for the SUT uid.
+        sut_response: The column name for the SUT response.
+    """
+
+    def __init__(self, header: list[str]):
+        self.sut_uid = self._find_column(header, SUT_UID_COLS)
+        self.sut_response = self._find_column(header, SUT_RESPONSE_COLS)
+        super().__init__(header)  # Iniitalize the prompt schema columns and then validate.
+
+    def _validate(self):
+        missing = []
+        # Validate that the prompt schema is valid
+        try:
+            super()._validate()
+        except SchemaValidationError as e:
+            missing.extend(e.missing_columns)
+        # Validate that the SUT uid and response columns are present
+        if self.sut_uid is None:
+            missing.append(SUT_UID_COLS)
+        if self.sut_response is None:
+            missing.append(SUT_RESPONSE_COLS)
+        if missing:
+            raise SchemaValidationError(missing)

--- a/src/modelgauge/dataset.py
+++ b/src/modelgauge/dataset.py
@@ -203,8 +203,6 @@ class AnnotationDataset(BaseDataset):
         )
         response = SUTResponse(text=row[self.schema.sut_response])
         interaction = SUTInteraction(prompt, row[self.schema.sut_uid], response)
-        print(row[self.schema.annotation])
-        print(type(row[self.schema.annotation]))
         annotation = json.loads(row[self.schema.annotation])
         return AnnotatedSUTInteraction(
             sut_interaction=interaction, annotator_uid=row[self.schema.annotator_uid], annotation=annotation

--- a/src/modelgauge/dataset.py
+++ b/src/modelgauge/dataset.py
@@ -1,0 +1,212 @@
+import csv
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Union, Any, Sequence
+
+from modelgauge.data_schema import (
+    DEFAULT_ANNOTATION_SCHEMA,
+    DEFAULT_PROMPT_RESPONSE_SCHEMA,
+    DEFAULT_PROMPT_SCHEMA,
+    AnnotationSchema,
+    PromptResponseSchema,
+    PromptSchema,
+)
+from modelgauge.prompt import TextPrompt
+from modelgauge.single_turn_prompt_response import SutInteraction, TestItem
+from modelgauge.sut import SUTResponse
+
+
+class BaseDataset(ABC):
+    """This class provides common functionality for CSV file handling and context management."""
+
+    def __init__(self, path: Union[str, Path], mode: str):
+        """Args:
+            path: Path to the dataset file
+            mode: Mode to open the file in ('r' for read, 'w' for write)
+        """
+        self.path = Path(path)
+        self.mode = mode
+        assert mode in ["r", "w"], f"Invalid dataset mode {mode}. Must be 'r' or 'w'."
+        if self.mode == "r" and not self.path.exists():
+            raise FileNotFoundError(f"File {self.path} does not exist.")
+        if self.mode == "w" and self.path.exists():
+            raise FileExistsError(f"File {self.path} already exists.")
+
+        self.file = None
+        self.writer = None
+        self.reader = None
+        self.schema = None
+        self._init_schema() # Initialized by subclass.
+
+    def __enter__(self):
+        """Context manager entry. Opens the file and sets the reader or writer."""
+        if self.file is not None:
+            raise RuntimeError("Cannot enter context manager twice before exiting.")
+        if self.mode == "w" and not self.path.exists():
+            # New file, need to write header.
+            self.file = open(self.path, mode=self.mode, newline="")
+            self.writer = csv.writer(self.file, quoting=csv.QUOTE_MINIMAL)
+            self.writer.writerow(self.header_columns())
+        elif self.mode == "w":
+            # Append to existing file.
+            self.file = open(self.path, mode="a", newline="")
+            self.writer = csv.writer(self.file, quoting=csv.QUOTE_MINIMAL)
+        elif self.mode == "r":
+            self.file = open(self.path, mode=self.mode, newline="")
+            self.reader = csv.DictReader(self.file)
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit. Closes the file and unsets the reader and writer."""
+        if self.file:
+            self.file.close()
+            self.file = None
+        self.reader = None
+        self.writer = None
+
+    def __iter__(self):
+        """Base iterator implementation that ensures proper context management.
+        Will enter the context if not already open.
+        """
+        if self.mode != "r":
+            raise RuntimeError("Can only iterate over dataset in read mode.")
+
+        # If we're not already in a context, create one for this iteration
+        if self.file is None:
+            with self:
+                for row in self.reader:
+                    yield self.row_to_item(row)
+        else:
+            # We're already in a context, just yield
+            for row in self.reader:
+                yield self.row_to_item(row)
+
+    def __len__(self) -> int:
+        if self.mode != "r":
+            raise NotImplementedError("Length not supported in write mode")
+        count = 0
+        with open(self.path, newline="") as f:
+            csvreader = csv.reader(f)
+            next(csvreader)  # Skip header row
+            for row in csvreader:
+                count += 1
+        return count
+
+    @abstractmethod
+    def _init_schema(self):
+        """Initialize dataset schema `self.schema`. To be implemented by subclasses."""
+        pass
+
+    def _read_header(self) -> list[str]:
+        """Read the header row from a CSV file."""
+        if self.mode != "r":
+            raise RuntimeError("Can only read header in read mode.")
+        if self.file is None:
+            with self:
+                header = self.reader.fieldnames
+        else:
+            header = self.reader.fieldnames
+        return header
+
+    def header_columns(self) -> Sequence[str]:
+        return self.schema.header
+
+    def write(self, item: Any):
+        """Write an item to the csv file."""
+        if self.mode != "w":
+            raise RuntimeError("Cannot write to dataset in read mode")
+        if not self.writer:
+            raise RuntimeError("Must be in a context to write.")
+        self.writer.writerow(self.item_to_row(item))
+
+    def row_to_item(self, row: dict):
+        """Transform a single  dict-row from the csv file into a dataset object."""
+        raise NotImplementedError("Subclasses that enable reading must implement this method.")
+
+    def item_to_row(self, item: Any) -> list[str]:
+        """Transform a dataset object into a list of strings that can be written to a csv file."""
+        raise NotImplementedError("Subclasses that enable writing must implement this method.")
+
+
+class PromptDataset(BaseDataset):
+    """Dataset for reading prompts as TestItems from a CSV file. Read only."""
+
+    def __init__(self, path: Union[str, Path]):
+        super().__init__(path, "r")
+
+    def _init_schema(self):
+        self.schema = PromptSchema(self._read_header())
+
+    def row_to_item(self, row: dict) -> TestItem:
+        """Convert a single prompt row to a TestItem."""
+        return TestItem(
+            prompt=TextPrompt(text=row[self.schema.prompt_text]),
+            source_id=row[self.schema.prompt_uid],
+            context=row,
+        )
+
+
+class PromptResponseDataset(BaseDataset):
+    """Dataset for prompt-response CSV data. Read or write."""
+
+    def _init_schema(self):
+        if self.mode == "r":
+            self.schema = PromptResponseSchema(self._read_header())
+        else:
+            self.schema = DEFAULT_PROMPT_RESPONSE_SCHEMA
+
+    def row_to_item(self, row: dict) -> SutInteraction:
+        prompt = TestItem(
+            prompt=TextPrompt(text=row[self.schema.prompt_text]),
+            source_id=row[self.schema.prompt_uid],
+            context=row,
+        )
+        response = SUTResponse(text=row[self.schema.sut_response])
+        return SutInteraction(prompt, row[self.schema.sut_uid], response)
+
+    def item_to_row(self, item: SutInteraction) -> list[str]:
+        if not isinstance(item.prompt.prompt, TextPrompt):
+            raise ValueError(f"Error handling {item}. Can only handle TextPrompts.")
+
+        return [
+            item.prompt.source_id,
+            item.prompt.prompt.text,
+            item.sut_uid,
+            item.response.text,
+        ]
+
+
+class AnnotationDataset(BaseDataset):
+    """Dataset for annotated prompt-response CSV data. Read or write."""
+
+    def _init_schema(self):
+        if self.mode == "r":
+            self.schema = AnnotationSchema(self._read_header())
+        else:
+            self.schema = DEFAULT_ANNOTATION_SCHEMA
+
+    # TODO: New annotation object
+    def row_to_item(self, row: dict) -> tuple[SutInteraction, Optional[Dict[str, Any]]]:
+        prompt = TestItem(
+            prompt=TextPrompt(text=row[self.schema.prompt_text]),
+            source_id=row[self.schema.prompt_uid],
+            context=row,
+        )
+        response = SUTResponse(text=row[self.schema.sut_response])
+        interaction = SutInteraction(prompt, row[self.schema.sut_uid], response)
+
+        # Extract annotations if present
+        annotations = row.get(self.schema.annotation)
+        return interaction, annotations
+
+    def item_to_row(self, item: SutInteraction, annotations: Optional[Dict[str, Any]] = None) -> list[str]:
+        if not isinstance(item.prompt.prompt, TextPrompt):
+            raise ValueError(f"Error handling {item}. Can only handle TextPrompts.")
+        return [
+            item.prompt.source_id,
+            item.prompt.prompt.text,
+            item.sut_uid,
+            item.response.text,
+            annotations.is_safe,
+        ]

--- a/src/modelgauge/dataset.py
+++ b/src/modelgauge/dataset.py
@@ -12,7 +12,7 @@ from modelgauge.data_schema import (
     PromptSchema,
 )
 from modelgauge.prompt import TextPrompt
-from modelgauge.single_turn_prompt_response import SutInteraction, TestItem
+from modelgauge.single_turn_prompt_response import SUTInteraction, TestItem
 from modelgauge.sut import SUTResponse
 
 
@@ -21,8 +21,8 @@ class BaseDataset(ABC):
 
     def __init__(self, path: Union[str, Path], mode: str):
         """Args:
-            path: Path to the dataset file
-            mode: Mode to open the file in ('r' for read, 'w' for write)
+        path: Path to the dataset file
+        mode: Mode to open the file in ('r' for read, 'w' for write)
         """
         self.path = Path(path)
         self.mode = mode
@@ -36,7 +36,7 @@ class BaseDataset(ABC):
         self.writer = None
         self.reader = None
         self.schema = None
-        self._init_schema() # Initialized by subclass.
+        self._init_schema()  # Initialized by subclass.
 
     def __enter__(self):
         """Context manager entry. Opens the file and sets the reader or writer."""
@@ -156,16 +156,16 @@ class PromptResponseDataset(BaseDataset):
         else:
             self.schema = DEFAULT_PROMPT_RESPONSE_SCHEMA
 
-    def row_to_item(self, row: dict) -> SutInteraction:
+    def row_to_item(self, row: dict) -> SUTInteraction:
         prompt = TestItem(
             prompt=TextPrompt(text=row[self.schema.prompt_text]),
             source_id=row[self.schema.prompt_uid],
             context=row,
         )
         response = SUTResponse(text=row[self.schema.sut_response])
-        return SutInteraction(prompt, row[self.schema.sut_uid], response)
+        return SUTInteraction(prompt, row[self.schema.sut_uid], response)
 
-    def item_to_row(self, item: SutInteraction) -> list[str]:
+    def item_to_row(self, item: SUTInteraction) -> list[str]:
         if not isinstance(item.prompt.prompt, TextPrompt):
             raise ValueError(f"Error handling {item}. Can only handle TextPrompts.")
 
@@ -187,7 +187,7 @@ class AnnotationDataset(BaseDataset):
             self.schema = DEFAULT_ANNOTATION_SCHEMA
 
     # TODO: New annotation object
-    def row_to_item(self, row: dict) -> tuple[SutInteraction, Optional[Dict[str, Any]]]:
+    def row_to_item(self, row: dict) -> tuple[SUTInteraction, Optional[Dict[str, Any]]]:
         prompt = TestItem(
             prompt=TextPrompt(text=row[self.schema.prompt_text]),
             source_id=row[self.schema.prompt_uid],
@@ -200,7 +200,7 @@ class AnnotationDataset(BaseDataset):
         annotations = row.get(self.schema.annotation)
         return interaction, annotations
 
-    def item_to_row(self, item: SutInteraction, annotations: Optional[Dict[str, Any]] = None) -> list[str]:
+    def item_to_row(self, item: SUTInteraction, annotations: Optional[Dict[str, Any]] = None) -> list[str]:
         if not isinstance(item.prompt.prompt, TextPrompt):
             raise ValueError(f"Error handling {item}. Can only handle TextPrompts.")
         return [

--- a/src/modelgauge/dataset.py
+++ b/src/modelgauge/dataset.py
@@ -19,12 +19,17 @@ from modelgauge.sut import SUTResponse
 class BaseDataset(ABC):
     """This class provides common functionality for CSV file handling and context management."""
 
+    quoting = csv.QUOTE_ALL
+
     def __init__(self, path: Union[str, Path], mode: str):
         """Args:
         path: Path to the dataset file
         mode: Mode to open the file in ('r' for read, 'w' for write)
         """
         self.path = Path(path)
+        if self.path.suffix.lower() != ".csv":
+            raise ValueError(f"Invalid dataset file {path}. Must be a CSV file.")
+
         self.mode = mode
         assert mode in ["r", "w"], f"Invalid dataset mode {mode}. Must be 'r' or 'w'."
         if self.mode == "r" and not self.path.exists():
@@ -45,12 +50,12 @@ class BaseDataset(ABC):
         if self.mode == "w" and not self.path.exists():
             # New file, need to write header.
             self.file = open(self.path, mode=self.mode, newline="")
-            self.writer = csv.writer(self.file, quoting=csv.QUOTE_MINIMAL)
+            self.writer = csv.writer(self.file, quoting=self.quoting)
             self.writer.writerow(self.header_columns())
         elif self.mode == "w":
             # Append to existing file.
             self.file = open(self.path, mode="a", newline="")
-            self.writer = csv.writer(self.file, quoting=csv.QUOTE_MINIMAL)
+            self.writer = csv.writer(self.file, quoting=self.quoting)
         elif self.mode == "r":
             self.file = open(self.path, mode=self.mode, newline="")
             self.reader = csv.DictReader(self.file)

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -12,14 +12,13 @@ from modelgauge.annotation_pipeline import (
     EnsembleVoter,
     JsonlAnnotatorOutput,
 )
-from modelgauge.dataset import PromptDataset
+from modelgauge.dataset import PromptDataset, PromptResponseDataset
 from modelgauge.pipeline import Pipeline
 from modelgauge.prompt_pipeline import (
     PromptSource,
     PromptSutAssigner,
     PromptSutWorkers,
     PromptSink,
-    CsvPromptOutput,
 )
 from modelgauge.sut import SUTOptions
 
@@ -144,8 +143,8 @@ class PromptRunner(PipelineRunner):
         )
         self.pipeline_segments.append(self.sut_worker)
         if include_sink:
-            output = CsvPromptOutput(self.output_dir() / self.output_file_name, self.suts)
-            self.pipeline_segments.append(PromptSink(self.suts, output))
+            output = PromptResponseDataset(self.output_dir() / self.output_file_name, "w")
+            self.pipeline_segments.append(PromptSink(output))
 
     def _sut_metadata(self):
         counts = self.sut_worker.sut_response_counts

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -9,9 +9,8 @@ from modelgauge.annotation_pipeline import (
     AnnotatorSource,
     AnnotatorWorkers,
     EnsembleVoter,
-    JsonlAnnotatorOutput,
 )
-from modelgauge.dataset import PromptDataset, PromptResponseDataset
+from modelgauge.dataset import AnnotationDataset, PromptDataset, PromptResponseDataset
 from modelgauge.pipeline import Pipeline
 from modelgauge.prompt_pipeline import (
     PromptSource,
@@ -178,7 +177,7 @@ class AnnotatorRunner(PipelineRunner):
 
     @property
     def output_file_name(self):
-        return "annotations.jsonl"
+        return "annotations.csv"
 
     @property
     def run_id(self):
@@ -197,8 +196,8 @@ class AnnotatorRunner(PipelineRunner):
         self.annotator_workers = AnnotatorWorkers(self.annotators, self.num_workers)
         self.pipeline_segments.append(self.annotator_workers)
         if include_sink:
-            output = JsonlAnnotatorOutput(self.output_dir() / self.output_file_name)
-            self.pipeline_segments.append(AnnotatorSink(self.annotators, output, ensemble=False))
+            output = AnnotationDataset(self.output_dir() / self.output_file_name, "w")
+            self.pipeline_segments.append(AnnotatorSink(output))
 
     def _annotator_metadata(self):
         counts = self.annotator_workers.annotation_counts
@@ -255,8 +254,8 @@ class EnsembleRunner(AnnotatorRunner):
         """Adds ensemble worker plus annotator sink."""
         self.ensemble_voter = EnsembleVoter(self.ensemble)
         self.pipeline_segments.append(self.ensemble_voter)
-        output = JsonlAnnotatorOutput(self.output_dir() / self.output_file_name)
-        self.pipeline_segments.append(AnnotatorSink(self.annotators, output, ensemble=True))
+        output = AnnotationDataset(self.output_dir() / self.output_file_name, "w")
+        self.pipeline_segments.append(AnnotatorSink(output))
 
     def _initialize_segments(self):
         # Add regular annotator segments
@@ -274,7 +273,7 @@ class PromptPlusAnnotatorRunner(PromptRunner, AnnotatorRunner):
 
     @property
     def output_file_name(self):
-        return "prompt-responses-annotated.jsonl"
+        return "prompt-responses-annotated.csv"
 
     @property
     def run_id(self):
@@ -301,7 +300,7 @@ class PromptPlusEnsembleRunner(PromptRunner, EnsembleRunner):
 
     @property
     def output_file_name(self):
-        return "prompt-responses-annotated.jsonl"
+        return "prompt-responses-annotated.csv"
 
     @property
     def run_id(self):

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -8,7 +8,6 @@ from modelgauge.annotation_pipeline import (
     AnnotatorSink,
     AnnotatorSource,
     AnnotatorWorkers,
-    CsvAnnotatorInput,
     EnsembleVoter,
     JsonlAnnotatorOutput,
 )
@@ -192,7 +191,7 @@ class AnnotatorRunner(PipelineRunner):
 
     def _add_annotator_segments(self, include_source=True, include_sink=True):
         if include_source:
-            input = CsvAnnotatorInput(self.input_path)
+            input = PromptResponseDataset(self.input_path, mode="r")
             self.pipeline_segments.append(AnnotatorSource(input))
         self.pipeline_segments.append(AnnotatorAssigner(self.annotators))
         self.annotator_workers = AnnotatorWorkers(self.annotators, self.num_workers)

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -12,6 +12,7 @@ from modelgauge.annotation_pipeline import (
     EnsembleVoter,
     JsonlAnnotatorOutput,
 )
+from modelgauge.dataset import PromptDataset
 from modelgauge.pipeline import Pipeline
 from modelgauge.prompt_pipeline import (
     PromptSource,

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -19,7 +19,6 @@ from modelgauge.prompt_pipeline import (
     PromptSutAssigner,
     PromptSutWorkers,
     PromptSink,
-    CsvPromptInput,
     CsvPromptOutput,
 )
 from modelgauge.sut import SUTOptions
@@ -137,7 +136,7 @@ class PromptRunner(PipelineRunner):
         return {**super().metadata(), **self._sut_metadata()}
 
     def _add_prompt_segments(self, include_sink=True):
-        input = CsvPromptInput(self.input_path)
+        input = PromptDataset(self.input_path)
         self.pipeline_segments.append(PromptSource(input))
         self.pipeline_segments.append(PromptSutAssigner(self.suts))
         self.sut_worker = PromptSutWorkers(

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -1,7 +1,6 @@
 import csv
 import logging
 import time
-from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from typing import Iterable, Optional
 
@@ -13,19 +12,6 @@ from modelgauge.single_turn_prompt_response import SUTInteraction, TestItem
 from modelgauge.sut import PromptResponseSUT, SUT, SUTOptions, SUTResponse
 
 logger = logging.getLogger(__name__)
-
-
-# TODO: Delete.
-class PromptOutput(metaclass=ABCMeta):
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-    @abstractmethod
-    def write(self, item, results):
-        pass
 
 
 class PromptSource(Source):

--- a/src/modelgauge/prompt_pipeline.py
+++ b/src/modelgauge/prompt_pipeline.py
@@ -15,48 +15,6 @@ from modelgauge.sut import PromptResponseSUT, SUT, SUTOptions, SUTResponse
 logger = logging.getLogger(__name__)
 
 
-class PromptInput(metaclass=ABCMeta):
-    """
-    Your subclass should implement __iter__ such that it yields TestItem objects.
-    Note that the source_id field must be set.
-    """
-
-    @abstractmethod
-    def __iter__(self) -> Iterable[TestItem]:
-        pass
-
-    def __len__(self):
-        count = 0
-        for prompt in self:
-            count += 1
-        return count
-
-
-# TODO: Delete: replace with PromptDataset.
-class CsvPromptInput(PromptInput):
-    def __init__(self, path):
-        super().__init__()
-        self.path = path
-        self.schema = PromptSchema(self._header())  # Validate header and store the schema.
-
-    def _header(self) -> list[str]:
-        with open(self.path, newline="") as f:
-            csvreader = csv.reader(f)
-            return next(csvreader)
-
-    def __iter__(self) -> Iterable[TestItem]:
-        with open(self.path, newline="") as f:
-            csvreader = csv.DictReader(f)
-            for row in csvreader:
-                yield TestItem(
-                    prompt=TextPrompt(text=row[self.schema.prompt_text]),
-                    # Forward the underlying id to help make data tracking easier.
-                    source_id=row[self.schema.prompt_uid],
-                    # Context can be any type you want.
-                    context=row,
-                )
-
-
 class PromptOutput(metaclass=ABCMeta):
     def __enter__(self):
         return self

--- a/src/modelgauge/single_turn_prompt_response.py
+++ b/src/modelgauge/single_turn_prompt_response.py
@@ -83,3 +83,13 @@ class SUTInteraction:
 
     def __hash__(self):
         return hash(self.prompt.source_id + self.sut_uid)
+
+
+@dataclass
+class AnnotatedSUTInteraction:
+    annotator_uid: str
+    annotation: Annotation
+    sut_interaction: SUTInteraction
+
+    def __hash__(self):
+        return hash(self.prompt.source_id + self.sut_uid + self.annotator_uid)

--- a/src/modelgauge/single_turn_prompt_response.py
+++ b/src/modelgauge/single_turn_prompt_response.py
@@ -1,4 +1,5 @@
 from typing import Dict, Mapping, Optional, Type, TypeVar
+from dataclasses import dataclass
 
 from pydantic import BaseModel, Field
 
@@ -72,3 +73,13 @@ class MeasuredTestItem(BaseModel):
 
     test_item: TestItem
     measurements: Dict[str, float]
+
+
+@dataclass
+class SUTInteraction:
+    prompt: TestItem
+    sut_uid: str
+    response: SUTResponse
+
+    def __hash__(self):
+        return hash(self.prompt.source_id + self.sut_uid)

--- a/tests/modelgauge_tests/test_annotation_pipeline.py
+++ b/tests/modelgauge_tests/test_annotation_pipeline.py
@@ -5,7 +5,6 @@ import time
 from unittest.mock import MagicMock
 
 from modelgauge.annotation_pipeline import (
-    SutInteraction,
     AnnotatorInput,
     AnnotatorSource,
     AnnotatorAssigner,
@@ -25,7 +24,7 @@ from modelgauge.prompt_pipeline import (
     PromptSutAssigner,
     PromptSutWorkers,
 )
-from modelgauge.single_turn_prompt_response import TestItem
+from modelgauge.single_turn_prompt_response import SUTInteraction, TestItem
 from modelgauge.sut import SUTResponse
 from modelgauge_tests.fake_annotator import (
     FakeAnnotation,
@@ -51,7 +50,7 @@ class FakeAnnotatorInput(AnnotatorInput):
                 context=row,
             )
             response = SUTResponse(text=row[PROMPT_RESPONSE_SCHEMA.sut_response])
-            yield SutInteraction(prompt, row[PROMPT_RESPONSE_SCHEMA.sut_uid], response)
+            yield SUTInteraction(prompt, row[PROMPT_RESPONSE_SCHEMA.sut_uid], response)
 
 
 class FakeAnnotatorOutput(PromptOutput):
@@ -63,7 +62,7 @@ class FakeAnnotatorOutput(PromptOutput):
 
 
 def make_sut_interaction(source_id, prompt, sut_uid, response):
-    return SutInteraction(
+    return SUTInteraction(
         TestItem(source_id=source_id, prompt=TextPrompt(text=prompt)),
         sut_uid,
         SUTResponse(text=response),
@@ -88,7 +87,7 @@ def test_csv_annotator_input(tmp_path):
     input = CsvAnnotatorInput(file_path)
 
     assert len(input) == 1
-    item: SutInteraction = next(iter(input))
+    item: SUTInteraction = next(iter(input))
     assert sut_interactions_is_equal(item, make_sut_interaction("1", "a", "s", "b"))
 
 

--- a/tests/modelgauge_tests/test_annotation_pipeline.py
+++ b/tests/modelgauge_tests/test_annotation_pipeline.py
@@ -5,16 +5,15 @@ import time
 from unittest.mock import MagicMock
 
 from modelgauge.annotation_pipeline import (
-    AnnotatorInput,
     AnnotatorSource,
     AnnotatorAssigner,
     AnnotatorWorkers,
     AnnotatorSink,
-    CsvAnnotatorInput,
     EnsembleVoter,
     JsonlAnnotatorOutput,
 )
 from modelgauge.annotator_set import AnnotatorSet
+from modelgauge.dataset import PromptResponseDataset
 from modelgauge.data_schema import DEFAULT_PROMPT_RESPONSE_SCHEMA as PROMPT_RESPONSE_SCHEMA
 from modelgauge.pipeline import Pipeline
 from modelgauge.prompt import TextPrompt
@@ -35,7 +34,7 @@ from modelgauge_tests.fake_sut import FakeSUT
 from modelgauge_tests.test_prompt_pipeline import FakePromptInput
 
 
-class FakeAnnotatorInput(AnnotatorInput):
+class FakeAnnotatorInput:
     def __init__(self, items: list[dict], delay=None):
         super().__init__()
         self.items = items
@@ -84,7 +83,7 @@ def test_csv_annotator_input(tmp_path):
     file_path.write_text(
         f'{PROMPT_RESPONSE_SCHEMA.prompt_uid},{PROMPT_RESPONSE_SCHEMA.prompt_text},{PROMPT_RESPONSE_SCHEMA.sut_uid},{PROMPT_RESPONSE_SCHEMA.sut_response}\n"1","a","s","b"'
     )
-    input = CsvAnnotatorInput(file_path)
+    input = PromptResponseDataset(file_path, mode="r")
 
     assert len(input) == 1
     item: SUTInteraction = next(iter(input))

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -182,10 +182,20 @@ def test_run_prompts_normal(caplog, tmp_path, prompts_file):
         reader = csv.DictReader(f)
 
         rows = (next(reader), next(reader))
-        rows = sorted(rows, key=lambda row: row[PROMPT_SCHEMA.prompt_uid])
+        rows = sorted(rows, key=lambda row: row[PROMPT_RESPONSE_SCHEMA.prompt_uid])
         expected = (
-            {PROMPT_SCHEMA.prompt_uid: "p1", PROMPT_SCHEMA.prompt_text: "Say yes", "demo_yes_no": "Yes"},
-            {PROMPT_SCHEMA.prompt_uid: "p2", PROMPT_SCHEMA.prompt_text: "Refuse", "demo_yes_no": "No"},
+            {
+                PROMPT_RESPONSE_SCHEMA.prompt_uid: "p1",
+                PROMPT_RESPONSE_SCHEMA.prompt_text: "Say yes",
+                PROMPT_RESPONSE_SCHEMA.sut_uid: "demo_yes_no",
+                PROMPT_RESPONSE_SCHEMA.sut_response: "Yes",
+            },
+            {
+                PROMPT_RESPONSE_SCHEMA.prompt_uid: "p2",
+                PROMPT_RESPONSE_SCHEMA.prompt_text: "Refuse",
+                PROMPT_RESPONSE_SCHEMA.sut_uid: "demo_yes_no",
+                PROMPT_RESPONSE_SCHEMA.sut_response: "No",
+            },
         )
         assert rows[0] == expected[0]
         assert rows[1] == expected[1]

--- a/tests/modelgauge_tests/test_data_schema.py
+++ b/tests/modelgauge_tests/test_data_schema.py
@@ -1,0 +1,73 @@
+import pytest
+
+from modelgauge.data_schema import (
+    PROMPT_TEXT_COLS,
+    PROMPT_UID_COLS,
+    PromptResponseSchema,
+    PromptSchema,
+    SchemaValidationError,
+)
+
+
+def test_schema_validation_error():
+    error = SchemaValidationError(["one", "two"])
+    assert error.missing_columns == ["one", "two"]
+    assert str(error) == "Missing required columns:\n\tone\n\ttwo"
+
+
+def test_schema_validation_error_multiple_options():
+    error = SchemaValidationError([["one", "a"], "two"])
+    assert error.missing_columns == [["one", "a"], "two"]
+    assert str(error) == "Missing required columns:\n\tone of: ['one', 'a']\n\ttwo"
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        ["prompt_uid", "prompt_text"],  # Preferred names.
+        ["Prompt_UID", "Prompt_Text"],  # Case-insensitive
+        ["release_prompt_id", "prompt_text"],
+        ["release_prompt_id", "prompt_text", "random_column"],  # Extra columns are allowed.
+    ],
+)
+def test_valid_prompt_schema(header):
+    schema = PromptSchema(header)
+    assert schema.prompt_uid == header[0]
+    assert schema.prompt_text == header[1]
+
+
+def test_invalid_prompt_schema():
+    header = ["random_column", "random_column_2"]
+    with pytest.raises(SchemaValidationError) as e:
+        schema = PromptSchema(header)
+        assert set(e.missing_columns) == {PROMPT_UID_COLS, PROMPT_TEXT_COLS}
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        ["prompt_uid", "prompt_text", "sut_uid", "sut_response"],  # Preferred names.
+        ["prompt_UID", "Prompt_Text", "SUT_UID", "SUT_Response"],  # Case-insensitive
+        ["release_prompt_id", "prompt_text", "sut", "response"],
+    ],
+)
+def test_valid_prompt_response_schema(header):
+    schema = PromptResponseSchema(header)
+    assert schema.prompt_uid == header[0]
+    assert schema.prompt_text == header[1]
+    assert schema.sut_uid == header[2]
+    assert schema.sut_response == header[3]
+
+
+def test_valid_prompt_invalid_response_schema():
+    header = ["prompt_uid", "prompt_text", "random_column", "random_column_2"]
+    with pytest.raises(SchemaValidationError) as e:
+        schema = PromptResponseSchema(header)
+        assert set(e.missing_columns) == {SUT_UID_COLS, SUT_RESPONSE_COLS}
+
+
+def test_invalid_prompt_valid_response_schema():
+    header = ["random_column", "random_column_2", "prompt_uid", "prompt_text"]
+    with pytest.raises(SchemaValidationError) as e:
+        schema = PromptResponseSchema(header)
+        assert set(e.missing_columns) == {PROMPT_UID_COLS, PROMPT_TEXT_COLS}

--- a/tests/modelgauge_tests/test_data_schema.py
+++ b/tests/modelgauge_tests/test_data_schema.py
@@ -97,11 +97,11 @@ def test_default_prompt_response_schema():
     "header",
     [
         # Preferred names
-        ["prompt_uid", "prompt_text", "sut_uid", "sut_response", "annotator_uid", "is_safe"],
+        ["prompt_uid", "prompt_text", "sut_uid", "sut_response", "annotator_uid", "annotation_json"],
         # Case-insensitive
-        ["prompt_UID", "Prompt_Text", "SUT_UID", "SUT_Response", "Annotator_UID", "Is_Safe"],
+        ["prompt_UID", "Prompt_Text", "SUT_UID", "SUT_Response", "Annotator_UID", "annotation_JSON"],
         # Extra columns are allowed
-        ["prompt_uid", "prompt_text", "sut_uid", "sut_response", "annotator_uid", "is_safe", "extra_col"],
+        ["prompt_uid", "prompt_text", "sut_uid", "sut_response", "annotator_uid", "annotation_json", "extra_col"],
     ],
 )
 def test_valid_annotation_schema(header):
@@ -122,7 +122,7 @@ def test_valid_prompt_response_invalid_annotation_schema():
 
 
 def test_invalid_prompt_response_valid_annotation_schema():
-    header = ["random_1", "random_2", "random_3", "random_4", "annotator_uid", "is_safe"]
+    header = ["random_1", "random_2", "random_3", "random_4", "annotator_uid", "annotation_json"]
     with pytest.raises(SchemaValidationError) as e:
         schema = AnnotationSchema(header)
         assert set(e.missing_columns) == {
@@ -139,4 +139,4 @@ def test_default_annotation_schema():
     assert DEFAULT_ANNOTATION_SCHEMA.sut_uid == "sut_uid"
     assert DEFAULT_ANNOTATION_SCHEMA.sut_response == "sut_response"
     assert DEFAULT_ANNOTATION_SCHEMA.annotator_uid == "annotator_uid"
-    assert DEFAULT_ANNOTATION_SCHEMA.annotation == "is_safe"
+    assert DEFAULT_ANNOTATION_SCHEMA.annotation == "annotation_json"

--- a/tests/modelgauge_tests/test_data_schema.py
+++ b/tests/modelgauge_tests/test_data_schema.py
@@ -1,6 +1,8 @@
 import pytest
 
 from modelgauge.data_schema import (
+    DEFAULT_PROMPT_RESPONSE_SCHEMA,
+    DEFAULT_PROMPT_SCHEMA,
     PROMPT_TEXT_COLS,
     PROMPT_UID_COLS,
     PromptResponseSchema,
@@ -43,6 +45,11 @@ def test_invalid_prompt_schema():
         assert set(e.missing_columns) == {PROMPT_UID_COLS, PROMPT_TEXT_COLS}
 
 
+def test_default_prompt_schema():
+    assert DEFAULT_PROMPT_SCHEMA.prompt_uid == "prompt_uid"
+    assert DEFAULT_PROMPT_SCHEMA.prompt_text == "prompt_text"
+
+
 @pytest.mark.parametrize(
     "header",
     [
@@ -71,3 +78,10 @@ def test_invalid_prompt_valid_response_schema():
     with pytest.raises(SchemaValidationError) as e:
         schema = PromptResponseSchema(header)
         assert set(e.missing_columns) == {PROMPT_UID_COLS, PROMPT_TEXT_COLS}
+
+
+def test_default_prompt_response_schema():
+    assert DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_uid == "prompt_uid"
+    assert DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_text == "prompt_text"
+    assert DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid == "sut_uid"
+    assert DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response == "sut_response"

--- a/tests/modelgauge_tests/test_dataset.py
+++ b/tests/modelgauge_tests/test_dataset.py
@@ -51,7 +51,7 @@ class TestBaseDataset:
     def dummy_csv(self, tmp_path):
         """Create a dummy CSV file."""
         file_path = tmp_path / "dummy.csv"
-        file_path.write_text("col_a\ndata1")
+        file_path.write_text('"col_a"\n"data1"')
         return file_path
 
     @pytest.fixture
@@ -65,6 +65,10 @@ class TestBaseDataset:
     def test_invalid_mode(self, tmp_path):
         with pytest.raises(AssertionError, match="Invalid dataset mode"):
             self.DummyDataset(tmp_path / "data.csv", mode="x")
+
+    def test_invalid_file_extension(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid dataset file"):
+            self.DummyDataset(tmp_path / "data.txt", mode="r")
 
     def test_file_not_found(self):
         with pytest.raises(FileNotFoundError):
@@ -142,7 +146,7 @@ class TestBaseDataset:
         """Test that header is written to a new file."""
         with dummy_write_dataset:
             pass
-        assert dummy_write_dataset.path.read_text() == "col_a\n"
+        assert dummy_write_dataset.path.read_text() == '"col_a"\n'
 
     def test_append_to_existing_file(self, dummy_write_dataset):
         """Test that header does not get re-written if context manager is entered twice."""
@@ -150,7 +154,7 @@ class TestBaseDataset:
             pass
         with dummy_write_dataset:
             pass
-        assert dummy_write_dataset.path.read_text() == "col_a\n"
+        assert dummy_write_dataset.path.read_text() == '"col_a"\n'
 
     def test_iteration_enters_exits_context(self, dummy_read_dataset):
         """Test that iteration enters and exits the context."""
@@ -205,7 +209,7 @@ class TestPromptDataset:
     def test_invalid_schema(self, tmp_path):
         """Test that reading a CSV file with invalid schema raises an error."""
         file_path = tmp_path / "invalid.csv"
-        file_path.write_text("column1,column2\na,b\n")
+        file_path.write_text('"column1","column2"\n"a","b"\n')
 
         with pytest.raises(SchemaValidationError):
             PromptDataset(file_path)
@@ -273,7 +277,7 @@ class TestPromptResponseDataset:
             f"{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid},{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response}\n"
         )
         expected_data = "test1,Test prompt,sut1,Test response\n"
-        assert content == expected_header + expected_data
+        assert content.replace('"', "") == expected_header + expected_data
 
 
 # class TestAnnotationDataset:

--- a/tests/modelgauge_tests/test_dataset.py
+++ b/tests/modelgauge_tests/test_dataset.py
@@ -37,8 +37,8 @@ class TestBaseDataset:
             self.write_called = False
             self.write_item = None
 
-        def _init_schema(self):
-            self.schema = TestBaseDataset.DummySchema()
+        def _get_schema(self):
+            return TestBaseDataset.DummySchema()
 
         def row_to_item(self, row: dict) -> str:
             """Convert a row to a dummy item."""

--- a/tests/modelgauge_tests/test_dataset.py
+++ b/tests/modelgauge_tests/test_dataset.py
@@ -12,10 +12,9 @@ from modelgauge.dataset import (
     BaseDataset,
     PromptDataset,
     PromptResponseDataset,
-    SutInteraction,
 )
 from modelgauge.prompt import TextPrompt
-from modelgauge.single_turn_prompt_response import TestItem
+from modelgauge.single_turn_prompt_response import SUTInteraction, TestItem
 from modelgauge.sut import SUTResponse
 
 
@@ -238,7 +237,7 @@ class TestPromptResponseDataset:
         with PromptResponseDataset(sample_responses_csv, mode="r") as dataset:
             interactions = list(dataset)
             assert len(interactions) == 2
-            assert all(isinstance(interaction, SutInteraction) for interaction in interactions)
+            assert all(isinstance(interaction, SUTInteraction) for interaction in interactions)
 
             # Check first interaction
             assert interactions[0].prompt.source_id == "p1"
@@ -256,7 +255,7 @@ class TestPromptResponseDataset:
         output_file = tmp_path / "output.csv"
 
         # Create test data
-        interaction = SutInteraction(
+        interaction = SUTInteraction(
             prompt=TestItem(prompt=TextPrompt(text="Test prompt"), source_id="test1", context={}),
             sut_uid="sut1",
             response=SUTResponse(text="Test response"),

--- a/tests/modelgauge_tests/test_dataset.py
+++ b/tests/modelgauge_tests/test_dataset.py
@@ -77,7 +77,7 @@ class TestBaseDataset:
 
     def test_len(self, dummy_read_dataset):
         assert len(dummy_read_dataset) == 1
-    
+
     def test_len_in_write_mode(self, dummy_write_dataset):
         with pytest.raises(NotImplementedError, match="Length not supported in write mode"):
             len(dummy_write_dataset)

--- a/tests/modelgauge_tests/test_dataset.py
+++ b/tests/modelgauge_tests/test_dataset.py
@@ -1,0 +1,392 @@
+import pytest
+from pathlib import Path
+from typing import Iterable
+
+from modelgauge.data_schema import (
+    DEFAULT_PROMPT_RESPONSE_SCHEMA,
+    DEFAULT_PROMPT_SCHEMA,
+    SchemaValidationError,
+)
+from modelgauge.dataset import (
+    AnnotationDataset,
+    BaseDataset,
+    PromptDataset,
+    PromptResponseDataset,
+    SutInteraction,
+)
+from modelgauge.prompt import TextPrompt
+from modelgauge.single_turn_prompt_response import TestItem
+from modelgauge.sut import SUTResponse
+
+
+class TestBaseDataset:
+    """Tests for the base dataset functionality."""
+
+    class DummySchema:
+        def __init__(self):
+            self.header = ["col_a"]
+            self.col_a = "col_a"
+
+    class DummyDataset(BaseDataset):
+        def __init__(self, path: Path, mode: str):
+            super().__init__(path, mode)
+            self.row_to_item_called = False
+            self.write_called = False
+            self.write_item = None
+
+        def _init_schema(self):
+            self.schema = TestBaseDataset.DummySchema()
+
+        def row_to_item(self, row: dict) -> str:
+            """Convert a row to a dummy item."""
+            self.row_to_item_called = True
+            return row[self.schema.col_a]
+
+        def item_to_row(self, item: str) -> list[str]:
+            """Write a dummy item."""
+            self.write_called = True
+            self.write_item = item
+            return [item]
+
+    @pytest.fixture
+    def dummy_csv(self, tmp_path):
+        """Create a dummy CSV file."""
+        file_path = tmp_path / "dummy.csv"
+        file_path.write_text("col_a\ndata1")
+        return file_path
+
+    @pytest.fixture
+    def dummy_read_dataset(self, dummy_csv):
+        return self.DummyDataset(dummy_csv, mode="r")
+
+    @pytest.fixture
+    def dummy_write_dataset(self, tmp_path):
+        return self.DummyDataset(tmp_path / "dummy.csv", mode="w")
+
+    def test_invalid_mode(self, tmp_path):
+        with pytest.raises(AssertionError, match="Invalid dataset mode"):
+            self.DummyDataset(tmp_path / "data.csv", mode="x")
+
+    def test_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            self.DummyDataset("nonexistent.csv", mode="r")
+
+    def test_cannot_use_existing_file_for_write(self, dummy_csv):
+        with pytest.raises(FileExistsError):
+            self.DummyDataset(dummy_csv, mode="w")
+
+    def test_len(self, dummy_read_dataset):
+        assert len(dummy_read_dataset) == 1
+    
+    def test_len_in_write_mode(self, dummy_write_dataset):
+        with pytest.raises(NotImplementedError, match="Length not supported in write mode"):
+            len(dummy_write_dataset)
+
+    def test_schema_is_set_in_initialization(self, dummy_read_dataset):
+        assert isinstance(dummy_read_dataset.schema, self.DummySchema)
+
+    def test_header_columns(self, dummy_read_dataset):
+        assert dummy_read_dataset.header_columns() == ["col_a"]
+
+    def test_context_manager_read(self, dummy_read_dataset):
+        """Test that context manager properly opens and closes files in read mode."""
+        assert dummy_read_dataset.file is None
+
+        with dummy_read_dataset:
+            assert dummy_read_dataset.file is not None
+            assert not dummy_read_dataset.file.closed
+            assert dummy_read_dataset.reader is not None
+
+        assert dummy_read_dataset.file is None
+        assert dummy_read_dataset.reader is None
+
+    def test_context_manager_write(self, dummy_write_dataset):
+        """Test that context manager properly opens and closes files in write mode."""
+        assert dummy_write_dataset.file is None
+
+        with dummy_write_dataset:
+            assert dummy_write_dataset.file is not None
+            assert not dummy_write_dataset.file.closed
+            assert dummy_write_dataset.writer is not None
+
+        assert dummy_write_dataset.file is None
+        assert dummy_write_dataset.writer is None
+
+    def test_read_in_write_mode(self, dummy_write_dataset):
+        """Test that reading in write mode raises an error."""
+        with pytest.raises(RuntimeError, match="Can only iterate over dataset in read mode."):
+            for _ in dummy_write_dataset:
+                break  # Iteration forces read.
+
+    def test_write_in_read_mode(self, dummy_read_dataset):
+        """Test that writing in read mode raises an error."""
+        with pytest.raises(RuntimeError, match="Cannot write to dataset in read mode"):
+            with dummy_read_dataset:
+                dummy_read_dataset.write("test")
+
+    def test_row_to_item_called(self, dummy_read_dataset):
+        """Test that row_to_item is called when iterating."""
+        assert dummy_read_dataset.row_to_item_called is False
+        with dummy_read_dataset:
+            for obj in dummy_read_dataset:
+                assert dummy_read_dataset.row_to_item_called is True
+                assert obj == "data1"
+
+    def test_write_operation(self, dummy_write_dataset):
+        """Test that write operation works in write mode."""
+        with dummy_write_dataset:
+            dummy_write_dataset.write("test_data")
+            assert dummy_write_dataset.write_called is True
+            assert dummy_write_dataset.write_item == "test_data"
+
+    def test_header_gets_written_to_new_file(self, dummy_write_dataset):
+        """Test that header is written to a new file."""
+        with dummy_write_dataset:
+            pass
+        assert dummy_write_dataset.path.read_text() == "col_a\n"
+
+    def test_append_to_existing_file(self, dummy_write_dataset):
+        """Test that header does not get re-written if context manager is entered twice."""
+        with dummy_write_dataset:
+            pass
+        with dummy_write_dataset:
+            pass
+        assert dummy_write_dataset.path.read_text() == "col_a\n"
+
+    def test_iteration_enters_exits_context(self, dummy_read_dataset):
+        """Test that iteration enters and exits the context."""
+        assert dummy_read_dataset.file is None
+        for obj in dummy_read_dataset:
+            assert dummy_read_dataset.file is not None
+            assert not dummy_read_dataset.file.closed
+            assert obj == "data1"
+            break
+        assert dummy_read_dataset.file is None
+
+
+class TestPromptDataset:
+    @pytest.fixture
+    def sample_prompts_csv(self, tmp_path):
+        """Create a sample CSV file with prompts only."""
+        file_path = tmp_path / "prompts.csv"
+        content = (
+            f"{DEFAULT_PROMPT_SCHEMA.prompt_uid},{DEFAULT_PROMPT_SCHEMA.prompt_text}\n"
+            "p1,Say hello\n"
+            "p2,Say goodbye"
+        )
+        file_path.write_text(content)
+        return file_path
+
+    @pytest.fixture
+    def prompts_dataset(self, sample_prompts_csv):
+        return PromptDataset(sample_prompts_csv)
+
+    def test_header_columns(self, prompts_dataset):
+        assert prompts_dataset.header_columns() == DEFAULT_PROMPT_SCHEMA.header
+
+    def test_iterate_explicit_context(self, prompts_dataset):
+        with prompts_dataset as dataset:
+            items = []
+            for item in dataset:
+                items.append(item)
+            assert len(items) == 2
+            assert all(isinstance(item, TestItem) for item in items)
+
+            assert items[0].source_id == "p1"
+            assert items[0].prompt.text == "Say hello"
+
+            assert items[1].source_id == "p2"
+            assert items[1].prompt.text == "Say goodbye"
+
+    def test_iterate_implicit_context(self, prompts_dataset):
+        items = list(prompts_dataset)
+        assert len(items) == 2
+        assert all(isinstance(item, TestItem) for item in items)
+
+    def test_invalid_schema(self, tmp_path):
+        """Test that reading a CSV file with invalid schema raises an error."""
+        file_path = tmp_path / "invalid.csv"
+        file_path.write_text("column1,column2\na,b\n")
+
+        with pytest.raises(SchemaValidationError):
+            PromptDataset(file_path)
+
+
+class TestPromptResponseDataset:
+    @pytest.fixture
+    def sample_responses_csv(self, tmp_path):
+        """Create a sample CSV file with prompt-response data."""
+        file_path = tmp_path / "responses.csv"
+        content = (
+            f"{DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_uid},{DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_text},"
+            f"{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid},{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response}\n"
+            "p1,Say hello,sut1,Hello world\n"
+            "p2,Say goodbye,sut1,Goodbye world"
+        )
+        file_path.write_text(content)
+        return file_path
+
+    def test_schema_read(self, sample_responses_csv):
+        dataset = PromptResponseDataset(sample_responses_csv, mode="r")
+        assert dataset.schema.header == DEFAULT_PROMPT_RESPONSE_SCHEMA.header
+
+    def test_schema_write(self, tmp_path):
+        dataset = PromptResponseDataset(tmp_path / "responses.csv", mode="w")
+        assert dataset.schema == DEFAULT_PROMPT_RESPONSE_SCHEMA
+
+    def test_read_csv(self, sample_responses_csv):
+        with PromptResponseDataset(sample_responses_csv, mode="r") as dataset:
+            interactions = list(dataset)
+            assert len(interactions) == 2
+            assert all(isinstance(interaction, SutInteraction) for interaction in interactions)
+
+            # Check first interaction
+            assert interactions[0].prompt.source_id == "p1"
+            assert interactions[0].prompt.prompt.text == "Say hello"
+            assert interactions[0].sut_uid == "sut1"
+            assert interactions[0].response.text == "Hello world"
+
+            # Check second interaction
+            assert interactions[1].prompt.source_id == "p2"
+            assert interactions[1].prompt.prompt.text == "Say goodbye"
+            assert interactions[1].sut_uid == "sut1"
+            assert interactions[1].response.text == "Goodbye world"
+
+    def test_write_csv(self, tmp_path):
+        output_file = tmp_path / "output.csv"
+
+        # Create test data
+        interaction = SutInteraction(
+            prompt=TestItem(prompt=TextPrompt(text="Test prompt"), source_id="test1", context={}),
+            sut_uid="sut1",
+            response=SUTResponse(text="Test response"),
+        )
+
+        # Write data
+        with PromptResponseDataset(output_file, mode="w") as dataset:
+            dataset.write(interaction)
+
+        # Verify written data
+        assert output_file.exists()
+        content = output_file.read_text()
+        expected_header = (
+            f"{DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_uid},{DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_text},"
+            f"{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid},{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response}\n"
+        )
+        expected_data = "test1,Test prompt,sut1,Test response\n"
+        assert content == expected_header + expected_data
+
+
+# class TestAnnotationDataset:
+# @pytest.fixture
+# def sample_annotations_jsonl(tmp_path):
+#     """Create a sample JSONL file with annotated prompt-response data."""
+#     file_path = tmp_path / "annotations.jsonl"
+#     content = [
+#         {
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_uid: "p1",
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_text: "Say hello",
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid: "sut1",
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response: "Hello world",
+#             "Annotations": {"toxicity": 0.1}
+#         },
+#         {
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_uid: "p2",
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_text: "Say goodbye",
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid: "sut1",
+#             DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response: "Goodbye world",
+#             "Annotations": {"toxicity": 0.0}
+#         }
+#     ]
+#     import jsonlines
+#     with jsonlines.open(file_path, mode='w') as writer:
+#         writer.write_all(content)
+#     return file_path
+#
+#     def test_read_jsonl(self, sample_annotations_jsonl):
+#         """Test reading annotated prompt-response pairs from a JSONL file."""
+#         with AnnotationDataset(sample_annotations_jsonl, mode='r') as dataset:
+#             interactions = list(dataset)
+#             assert len(interactions) == 2
+
+#             # Check first interaction
+#             interaction, annotations = interactions[0]
+#             assert interaction.prompt.source_id == "p1"
+#             assert interaction.prompt.prompt.text == "Say hello"
+#             assert interaction.sut_uid == "sut1"
+#             assert interaction.response.text == "Hello world"
+#             assert annotations == {"toxicity": 0.1}
+
+#             # Check second interaction
+#             interaction, annotations = interactions[1]
+#             assert interaction.prompt.source_id == "p2"
+#             assert annotations == {"toxicity": 0.0}
+
+#     def test_read_csv(self, sample_responses_csv):
+#         """Test reading from a CSV file (should have no annotations)."""
+#         with AnnotationDataset(sample_responses_csv, mode='r') as dataset:
+#             interactions = list(dataset)
+#             assert len(interactions) == 2
+
+#             # Check that annotations are None
+#             for interaction, annotations in interactions:
+#                 assert annotations is None
+
+#     def test_write_jsonl(self, tmp_path):
+#         """Test writing annotated prompt-response pairs to a JSONL file."""
+#         output_file = tmp_path / "output.jsonl"
+
+#         # Create test data
+#         interaction = SutInteraction(
+#             prompt=TestItem(
+#                 prompt=TextPrompt(text="Test prompt"),
+#                 source_id="test1",
+#                 context={}
+#             ),
+#             sut_uid="sut1",
+#             response=SUTResponse(text="Test response")
+#         )
+#         annotations = {"toxicity": 0.5}
+
+#         # Write data
+#         with AnnotationDataset(output_file, mode='w') as dataset:
+#             dataset.write(interaction, annotations)
+
+#         # Verify written data
+#         import jsonlines
+#         with jsonlines.open(output_file) as reader:
+#             data = list(reader)
+#             assert len(data) == 1
+#             assert data[0][DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_uid] == "test1"
+#             assert data[0][DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_text] == "Test prompt"
+#             assert data[0][DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid] == "sut1"
+#             assert data[0][DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response] == "Test response"
+#             assert data[0]["Annotations"] == {"toxicity": 0.5}
+
+#     def test_write_csv(self, tmp_path):
+#         """Test writing to a CSV file (should ignore annotations)."""
+#         output_file = tmp_path / "output.csv"
+
+#         # Create test data
+#         interaction = SutInteraction(
+#             prompt=TestItem(
+#                 prompt=TextPrompt(text="Test prompt"),
+#                 source_id="test1",
+#                 context={}
+#             ),
+#             sut_uid="sut1",
+#             response=SUTResponse(text="Test response")
+#         )
+#         annotations = {"toxicity": 0.5}
+
+#         # Write data
+#         with AnnotationDataset(output_file, mode='w') as dataset:
+#             dataset.write(interaction, annotations)
+
+#         # Verify written data - should not include annotations
+#         assert output_file.exists()
+#         content = output_file.read_text()
+#         expected_header = f"{DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_uid},{DEFAULT_PROMPT_RESPONSE_SCHEMA.prompt_text}," \
+#                          f"{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_uid},{DEFAULT_PROMPT_RESPONSE_SCHEMA.sut_response}\n"
+#         expected_data = '"test1","Test prompt","sut1","Test response"\n'
+#         assert content == expected_header + expected_data

--- a/tests/modelgauge_tests/test_pipeline_runner.py
+++ b/tests/modelgauge_tests/test_pipeline_runner.py
@@ -9,6 +9,7 @@ from modelgauge.annotation_pipeline import (
     CsvAnnotatorInput,
 )
 from modelgauge.annotator_set import AnnotatorSet
+from modelgauge.dataset import PromptDataset
 from modelgauge.data_schema import (
     DEFAULT_PROMPT_RESPONSE_SCHEMA as PROMPT_RESPONSE_SCHEMA,
     DEFAULT_PROMPT_SCHEMA as PROMPT_SCHEMA,
@@ -25,7 +26,6 @@ from modelgauge.prompt_pipeline import (
     PromptSutAssigner,
     PromptSutWorkers,
     PromptSink,
-    CsvPromptInput,
     CsvPromptOutput,
 )
 from modelgauge.sut import SUTOptions
@@ -142,7 +142,7 @@ class TestPromptRunner:
         source, sut_assigner, sut_workers, sink = runner.pipeline_segments
 
         assert isinstance(source, PromptSource)
-        assert isinstance(source.input, CsvPromptInput)
+        assert isinstance(source.input, PromptDataset)
         assert source.input.path == prompts_file
 
         assert isinstance(sut_assigner, PromptSutAssigner)
@@ -250,7 +250,7 @@ class TestPromptPlusAnnotatorRunner:
         source, sut_assigner, sut_workers, annotator_assigner, annotator_workers, sink = runner.pipeline_segments
 
         assert isinstance(source, PromptSource)
-        assert isinstance(source.input, CsvPromptInput)
+        assert isinstance(source.input, PromptDataset)
         assert source.input.path == prompts_file
 
         assert isinstance(sut_assigner, PromptSutAssigner)

--- a/tests/modelgauge_tests/test_pipeline_runner.py
+++ b/tests/modelgauge_tests/test_pipeline_runner.py
@@ -9,7 +9,7 @@ from modelgauge.annotation_pipeline import (
     CsvAnnotatorInput,
 )
 from modelgauge.annotator_set import AnnotatorSet
-from modelgauge.dataset import PromptDataset
+from modelgauge.dataset import PromptDataset, PromptResponseDataset
 from modelgauge.data_schema import (
     DEFAULT_PROMPT_RESPONSE_SCHEMA as PROMPT_RESPONSE_SCHEMA,
     DEFAULT_PROMPT_SCHEMA as PROMPT_SCHEMA,
@@ -26,7 +26,6 @@ from modelgauge.prompt_pipeline import (
     PromptSutAssigner,
     PromptSutWorkers,
     PromptSink,
-    CsvPromptOutput,
 )
 from modelgauge.sut import SUTOptions
 from modelgauge_tests.fake_annotator import FakeAnnotator
@@ -154,9 +153,7 @@ class TestPromptRunner:
         assert sut_workers.thread_count == 20
 
         assert isinstance(sink, PromptSink)
-        assert sink.suts == suts
-        assert isinstance(sink.writer, CsvPromptOutput)
-        assert sink.writer.suts == suts
+        assert isinstance(sink.writer, PromptResponseDataset)
 
     def test_prompt_runner_num_input_items(self, runner_basic):
         assert runner_basic.num_input_items == NUM_PROMPTS

--- a/tests/modelgauge_tests/test_pipeline_runner.py
+++ b/tests/modelgauge_tests/test_pipeline_runner.py
@@ -6,7 +6,6 @@ from modelgauge.annotation_pipeline import (
     AnnotatorSink,
     AnnotatorSource,
     AnnotatorWorkers,
-    CsvAnnotatorInput,
 )
 from modelgauge.annotator_set import AnnotatorSet
 from modelgauge.dataset import PromptDataset, PromptResponseDataset
@@ -409,7 +408,7 @@ class TestAnnotatorRunner:
         source, annotator_assigner, annotator_workers, sink = runner.pipeline_segments
 
         assert isinstance(source, AnnotatorSource)
-        assert isinstance(source.input, CsvAnnotatorInput)
+        assert isinstance(source.input, PromptResponseDataset)
         assert source.input.path == prompt_responses_file
 
         assert isinstance(annotator_assigner, AnnotatorAssigner)

--- a/tests/modelgauge_tests/test_pipeline_runner.py
+++ b/tests/modelgauge_tests/test_pipeline_runner.py
@@ -265,8 +265,6 @@ class TestPromptPlusAnnotatorRunner:
         assert annotator_workers.thread_count == 20
 
         assert isinstance(sink, AnnotatorSink)
-        assert sink.annotators == annotators
-        assert sink.ensemble == False
 
     def test_pipeline_segments_ensemble(self, runner_ensemble, annotators, ensemble):
         source, sut_assigner, sut_workers, annotator_assigner, annotator_workers, ensemble_worker, sink = (
@@ -279,8 +277,6 @@ class TestPromptPlusAnnotatorRunner:
         assert ensemble_worker.ensemble == ensemble
 
         assert isinstance(sink, AnnotatorSink)
-        assert sink.annotators == annotators
-        assert sink.ensemble == True
 
     def test_runner_num_input_items(self, runner_basic):
         assert runner_basic.num_input_items == NUM_PROMPTS
@@ -419,8 +415,6 @@ class TestAnnotatorRunner:
         assert annotator_workers.thread_count == 20
 
         assert isinstance(sink, AnnotatorSink)
-        assert sink.annotators == annotators
-        assert sink.ensemble == False
 
     def test_pipeline_segments_ensemble(self, runner_ensemble, annotators, ensemble):
         source, annotator_assigner, annotator_workers, ensemble_worker, sink = runner_ensemble.pipeline_segments
@@ -431,8 +425,6 @@ class TestAnnotatorRunner:
         assert ensemble_worker.ensemble == ensemble
 
         assert isinstance(sink, AnnotatorSink)
-        assert sink.annotators == annotators
-        assert sink.ensemble is True
 
     def test_missing_ensemble_annotators_raises_error(self, tmp_path, prompt_responses_file, ensemble):
         incomplete_annotators = {"annotator1": FakeAnnotator("annotator1"), "annotator2": FakeAnnotator("annotator2")}

--- a/tests/modelgauge_tests/test_pipeline_runner.py
+++ b/tests/modelgauge_tests/test_pipeline_runner.py
@@ -9,6 +9,10 @@ from modelgauge.annotation_pipeline import (
     CsvAnnotatorInput,
 )
 from modelgauge.annotator_set import AnnotatorSet
+from modelgauge.data_schema import (
+    DEFAULT_PROMPT_RESPONSE_SCHEMA as PROMPT_RESPONSE_SCHEMA,
+    DEFAULT_PROMPT_SCHEMA as PROMPT_SCHEMA,
+)
 from modelgauge.pipeline_runner import (
     AnnotatorRunner,
     EnsembleRunner,
@@ -37,7 +41,7 @@ def prompts_file(tmp_path_factory):
     """Sample file with 3 prompts for testing."""
     file = tmp_path_factory.mktemp("data") / "prompts.csv"
     with open(file, "w") as f:
-        text = "UID,Text\n"
+        text = f"{PROMPT_SCHEMA.prompt_uid},{PROMPT_SCHEMA.prompt_text}\n"
         for i in range(NUM_PROMPTS):
             text += f"p{i},Prompt {i}\n"
         f.write(text)
@@ -341,7 +345,7 @@ class TestAnnotatorRunner:
         """Sample file with 2 prompts + responses from 2 SUTs for testing."""
         file = tmp_path_factory.mktemp("data") / "prompt-responses.csv"
         with open(file, "w") as f:
-            text = "UID,Prompt,SUT,Response\n"
+            text = f"{PROMPT_RESPONSE_SCHEMA.prompt_uid},{PROMPT_RESPONSE_SCHEMA.prompt_text},{PROMPT_RESPONSE_SCHEMA.sut_uid},{PROMPT_RESPONSE_SCHEMA.sut_response}\n"
             for i in range(NUM_PROMPTS):
                 text += f"p{i},Prompt {i},sut1,Response {i}\n"
                 text += f"p{i},Prompt {i},sut2,Response {i}\n"

--- a/tests/modelgauge_tests/test_prompt_pipeline.py
+++ b/tests/modelgauge_tests/test_prompt_pipeline.py
@@ -23,9 +23,8 @@ from modelgauge.prompt_pipeline import (
     PromptSource,
     PromptSutAssigner,
     PromptSutWorkers,
-    SutInteraction,
 )
-from modelgauge.single_turn_prompt_response import TestItem
+from modelgauge.single_turn_prompt_response import SUTInteraction,TestItem
 from modelgauge.sut import SUTOptions, SUTResponse
 
 from modelgauge_tests.fake_sut import FakeSUT, FakeSUTRequest, FakeSUTResponse
@@ -145,7 +144,7 @@ def test_prompt_sut_worker_normal(suts):
     w = PromptSutWorkers(suts)
     result = w.handle_item((prompt_with_context, "fake1"))
 
-    assert result == SutInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
+    assert result == SUTInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
 
 
 def test_prompt_sut_worker_sends_prompt_options(suts):
@@ -170,11 +169,11 @@ def test_prompt_sut_worker_cache(suts, tmp_path):
 
     w = PromptSutWorkers(suts, cache_path=tmp_path)
     result = w.handle_item((prompt_with_context, "fake1"))
-    assert result == SutInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
+    assert result == SUTInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
     assert mock.call_count == 1
 
     result = w.handle_item((prompt_with_context, "fake1"))
-    assert result == SutInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
+    assert result == SUTInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
     assert mock.call_count == 1
 
 
@@ -189,7 +188,7 @@ def test_prompt_sut_worker_retries_until_success(suts):
     w = PromptSutWorkers(suts)
     w.sleep_time = 0.01
     result = w.handle_item((prompt_with_context, "fake1"))
-    assert result == SutInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
+    assert result == SUTInteraction(prompt_with_context, "fake1", SUTResponse(text="a response"))
     assert mock.call_count == num_exceptions + 1
 
 

--- a/tests/modelgauge_tests/test_prompt_pipeline.py
+++ b/tests/modelgauge_tests/test_prompt_pipeline.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from modelgauge.dataset import PromptDataset
 from modelgauge.data_schema import (
     DEFAULT_PROMPT_RESPONSE_SCHEMA as PROMPT_RESPONSE_SCHEMA,
     DEFAULT_PROMPT_SCHEMA as PROMPT_SCHEMA,
@@ -15,16 +16,14 @@ from modelgauge.data_schema import (
 from modelgauge.pipeline import Pipeline, PipelineSegment
 from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_pipeline import (
-    CsvPromptInput,
     CsvPromptOutput,
-    PromptInput,
     PromptOutput,
     PromptSink,
     PromptSource,
     PromptSutAssigner,
     PromptSutWorkers,
 )
-from modelgauge.single_turn_prompt_response import SUTInteraction,TestItem
+from modelgauge.single_turn_prompt_response import SUTInteraction, TestItem
 from modelgauge.sut import SUTOptions, SUTResponse
 
 from modelgauge_tests.fake_sut import FakeSUT, FakeSUTRequest, FakeSUTResponse
@@ -45,7 +44,7 @@ class timeout:
         signal.alarm(0)
 
 
-class FakePromptInput(PromptInput):
+class FakePromptInput:
     def __init__(self, items: list[dict], delay=None):
         super().__init__()
         self.items = items
@@ -88,7 +87,7 @@ def suts():
 def test_csv_prompt_input(tmp_path):
     file_path = tmp_path / "input.csv"
     file_path.write_text(f'{PROMPT_SCHEMA.prompt_uid},{PROMPT_SCHEMA.prompt_text}\n"1","a"')
-    input = CsvPromptInput(file_path)
+    input = PromptDataset(file_path)
 
     assert len(input) == 1
     items: List[TestItem] = [i for i in input]
@@ -102,7 +101,7 @@ def test_csv_prompt_input_invalid_columns(tmp_path, header):
     file_path = tmp_path / "input.csv"
     file_path.write_text(header)
     with pytest.raises(SchemaValidationError):
-        CsvPromptInput(file_path)
+        PromptDataset(file_path)
 
 
 def test_csv_prompt_output(tmp_path, suts):

--- a/tests/modelgauge_tests/test_prompt_pipeline.py
+++ b/tests/modelgauge_tests/test_prompt_pipeline.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from modelgauge.data_schema import DEFAULT_PROMPT_SCHEMA as PROMPT_SCHEMA, SchemaValidationError
+from modelgauge.data_schema import (
+    DEFAULT_PROMPT_RESPONSE_SCHEMA as PROMPT_RESPONSE_SCHEMA,
+    DEFAULT_PROMPT_SCHEMA as PROMPT_SCHEMA,
+    SchemaValidationError,
+)
 from modelgauge.pipeline import Pipeline, PipelineSegment
 from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_pipeline import (
@@ -114,11 +118,15 @@ def test_csv_prompt_output(tmp_path, suts):
     with open(file_path, "r", newline="") as f:
         # noinspection PyTypeChecker
         items: list[dict] = [i for i in (DictReader(f))]
-        assert len(items) == 1
-        assert items[0][PROMPT_SCHEMA.prompt_uid] == "1"
-        assert items[0][PROMPT_SCHEMA.prompt_text] == "a"
-        assert items[0]["fake1"] == "a1"
-        assert items[0]["fake2"] == "a2"
+        assert len(items) == 2
+        assert items[0][PROMPT_RESPONSE_SCHEMA.prompt_uid] == "1"
+        assert items[0][PROMPT_RESPONSE_SCHEMA.prompt_text] == "a"
+        assert items[0][PROMPT_RESPONSE_SCHEMA.sut_uid] == "fake1"
+        assert items[0][PROMPT_RESPONSE_SCHEMA.sut_response] == "a1"
+        assert items[1][PROMPT_RESPONSE_SCHEMA.prompt_uid] == "1"
+        assert items[1][PROMPT_RESPONSE_SCHEMA.prompt_text] == "a"
+        assert items[1][PROMPT_RESPONSE_SCHEMA.sut_uid] == "fake2"
+        assert items[1][PROMPT_RESPONSE_SCHEMA.sut_response] == "a2"
 
 
 @pytest.mark.parametrize("output_fname", ["output.jsonl", "output"])


### PR DESCRIPTION
The overall goal of this PR is to standardize data formatting so that the outputs of one stage can be used as the input of another. And to avoid head aches.
Two new objects are instrumental in accomplishing this:
1) The Data Schema objects, which define column names in one place.
2) Dataset objects which handle both reading from input and writing to output.
    - The different types of datasets will read CSV rows and output the relevant object for each row e.g. TestItem for prompts, SUTInteraction for prompts-responses, and AnnotatedSUTInteraction for annotations.
    - The Annotation dataset serializes/deserializes annotations as json-strings. It can serialize pydantic objects or dictionaries. Annotations will always be deserialized as dictionaries.

Also in service of this goal, every output file (aside from metadata.json) is a CSV file in which one row corresponds to one prompt and one sut response and/or one annotation. No more `annotations.jsonl.`