### PR TITLE
prototype longer, richer SUT UIDs

### DIFF
--- a/src/modelgauge/sut_specification.py
+++ b/src/modelgauge/sut_specification.py
@@ -4,23 +4,23 @@ from pydantic import BaseModel
 
 
 class SUTSpecificationChunk(BaseModel):
-    name: str
-    label: str
-    type: type
+    name: str = ""
+    label: str = ""
+    value_type: type = str
     required: Optional[bool] = False
 
     @staticmethod  # sub for pydantic's verbose constructor
-    def make(name, label, type, required: bool = False):
-        return SUTSpecificationChunk(name=name, label=label, type=type, required=required)
+    def make(name="", label="", value_type=type, required: bool = False):
+        return SUTSpecificationChunk(name=name, label=label, value_type=value_type, required=required)
 
 
 class SUTSpecification:
     fields = {
         "model": SUTSpecificationChunk.make("model", "m", str, True),
+        "driver": SUTSpecificationChunk.make("driver", "d", str, True),
         "temperature": SUTSpecificationChunk.make("temperature", "t", float),
         "top_p": SUTSpecificationChunk.make("top_p", "p", int),
         "top_k": SUTSpecificationChunk.make("top_k", "k", int),
-        "driver": SUTSpecificationChunk.make("driver", "d", str, True),
         "maker": SUTSpecificationChunk.make("maker", "mk", str),
         "provider": SUTSpecificationChunk.make("provider", "pr", str),
         "display_name": SUTSpecificationChunk.make("display_name", "dn", str),
@@ -29,5 +29,10 @@ class SUTSpecification:
         "driver_code_version": SUTSpecificationChunk.make("driver_code_version", "dv", str),
         "date": SUTSpecificationChunk.make("date", "dt", str),
     }
+    values = {}
 
-    pass
+    def knows(self, field):
+        return field in self.fields
+
+    def requires(self, field):
+        return self.knows(field) and self.fields[field].required

--- a/src/modelgauge/sut_specification.py
+++ b/src/modelgauge/sut_specification.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class SUTSpecificationChunk(BaseModel):
+    name: str
+    label: str
+    type: type
+    required: Optional[bool] = False
+
+    @staticmethod  # sub for pydantic's verbose constructor
+    def make(name, label, type, required: bool = False):
+        return SUTSpecificationChunk(name=name, label=label, type=type, required=required)
+
+
+class SUTSpecification:
+    fields = {
+        "model": SUTSpecificationChunk.make("model", "m", str, True),
+        "temperature": SUTSpecificationChunk.make("temperature", "t", float),
+        "top_p": SUTSpecificationChunk.make("top_p", "p", int),
+        "top_k": SUTSpecificationChunk.make("top_k", "k", int),
+        "driver": SUTSpecificationChunk.make("driver", "d", str, True),
+        "maker": SUTSpecificationChunk.make("maker", "mk", str),
+        "provider": SUTSpecificationChunk.make("provider", "pr", str),
+        "display_name": SUTSpecificationChunk.make("display_name", "dn", str),
+        "reasoning": SUTSpecificationChunk.make("reasoning", "reas", bool),
+        "moderated": SUTSpecificationChunk.make("moderated", "mod", bool),
+        "driver_code_version": SUTSpecificationChunk.make("driver_code_version", "dv", str),
+        "date": SUTSpecificationChunk.make("date", "dt", str),
+    }
+
+    pass

--- a/src/modelgauge/uid_generator.py
+++ b/src/modelgauge/uid_generator.py
@@ -1,0 +1,134 @@
+from collections import defaultdict
+from pydantic import BaseModel
+from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
+
+
+class UID(str):
+    def __init__(self, value):
+        self = value
+
+    @staticmethod
+    def is_valid_uid(uid: str) -> bool:
+        return False  # todo
+
+
+class UIDChunk(BaseModel):
+    name: str
+    label: str
+    type: type
+
+    @staticmethod  # sub for pydantic's verbose constructor
+    def make(name, label, type):
+        return UIDChunk(name=name, label=label, type=type)
+
+
+class UIDGenerator:
+
+    def __init__(self, data=None):
+        self.data = defaultdict()
+        if data:
+            for k, v in data.items():
+                self.add(k, v)
+        self._uid: str = ""
+        self._fresh = False
+
+    @property
+    def uid(self) -> str:
+        if not self._fresh:
+            self.__generate()
+        return self._uid
+
+    def __generate(self):
+        pass
+
+    def add(self, key, value):
+        if self.data.get(key, None) == value:  # already added
+            return
+        if isinstance(value, str):
+            value = value.strip()
+        self.data[key] = value
+        self._fresh = False
+
+
+class SUTUIDGenerator(UIDGenerator):
+    fields = {
+        "model": UIDChunk.make("model", "m", str),
+        "temperature": UIDChunk.make("temperature", "t", float),
+        "top_p": UIDChunk.make("top_p", "p", int),
+        "top_k": UIDChunk.make("top_k", "k", int),
+        "driver": UIDChunk.make("driver", "d", str),
+        "maker": UIDChunk.make("maker", "mk", str),
+        "provider": UIDChunk.make("provider", "pr", str),
+        "display_name": UIDChunk.make("display_name", "dn", str),
+        "reasoning": UIDChunk.make("reasoning", "reas", bool),
+        "moderated": UIDChunk.make("moderated", "mod", bool),
+        "driver_code_version": UIDChunk.make("driver_code_version", "dv", str),
+        "date": UIDChunk.make("date", "dt", str),
+    }
+    order = (
+        "driver_code_version",
+        "moderated",
+        "reasoning",
+        "temperature",
+        "top_p",
+        "top_k",
+        "display_name",
+    )  # this is the order past the dynamic SUT UID fields, which are fixed and at the head of this UID
+    required = ("model", "driver", "temperature")  # TBD
+    field_separator = "_"
+    key_value_separator = ":"
+    blank_sub = "."
+    space_sub = "-"
+
+    @property
+    def uid(self) -> str:
+        if not self._fresh:
+            self.__generate()
+        return self._uid
+
+    @staticmethod
+    def kv_to_str(field, value) -> str:
+        if isinstance(value, str):
+            value = value.replace(" ", SUTUIDGenerator.space_sub)
+        return f"{field}{SUTUIDGenerator.key_value_separator}{value}"
+
+    @staticmethod
+    def bool_to_str(value):
+        return "y" if value else "n"
+
+    def validate(self):
+        for key, field in self.fields.items():
+            value = self.data.get(field.name, None)
+            if field.name in SUTUIDGenerator.required and value is None:
+                raise ValueError(f"Field {field.name} is required.")
+            if value is not None and not isinstance(value, field.type):
+                raise ValueError(f"Field {field.name} has wrong type.")
+
+    def __generate(self):
+        self.validate()
+        chunks = []
+
+        # the first chunks follow the dynamic SUT schema
+        metadata: DynamicSUTMetadata = self.to_dynamic_sut_metadata()
+        chunks.append(str(metadata))
+
+        for field in SUTUIDGenerator.order:
+            value = self.data.get(field, None)
+            label = SUTUIDGenerator.fields[field].label
+            if isinstance(value, bool):
+                value = SUTUIDGenerator.bool_to_str(value)
+            if value:
+                chunks.append(SUTUIDGenerator.kv_to_str(label, value))
+
+        self._uid = SUTUIDGenerator.field_separator.join(chunks).lower()
+        self._fresh = True
+        return self._uid
+
+    def to_dynamic_sut_metadata(self) -> DynamicSUTMetadata:
+        return DynamicSUTMetadata(
+            model=self.data["model"],
+            driver=self.data["driver"],
+            maker=self.data.get("maker", None),
+            provider=self.data.get("provider", None),
+            date=self.data.get("date", None),
+        )

--- a/tests/modelgauge_tests/test_sut_specification.py
+++ b/tests/modelgauge_tests/test_sut_specification.py
@@ -1,0 +1,10 @@
+from modelgauge.sut_specification import SUTSpecification, SUTSpecificationChunk
+
+
+def test_convenience_methods():
+    s = SUTSpecification()
+    assert s.requires("model")
+    assert not s.requires("reasoning")
+
+    assert s.knows("moderated")
+    assert not s.knows("bogus")

--- a/tests/modelgauge_tests/test_uid_generator.py
+++ b/tests/modelgauge_tests/test_uid_generator.py
@@ -1,0 +1,22 @@
+from modelgauge.uid_generator import SUTUIDGenerator
+
+
+def test_uid():
+    g = SUTUIDGenerator()
+    g.add("model", "chatgpt-4o")
+    g.add("maker", "openai")
+    g.add("driver", "openai")
+    g.add("provider", "openai")
+    g.add("temperature", 0.8)
+    g.add("top_p", 6)
+    g.add("top_k", 5)
+    g.add("moderated", True)
+    g.add("reasoning", False)
+    assert g.uid == "openai/chatgpt-4o:openai:openai_mod:y_reas:n_t:0.8_p:6_k:5"
+
+    g.add("driver_code_version", "abcde")
+    g.add("date", "20250723")
+    assert g.uid == "openai/chatgpt-4o:openai:openai:20250723_dv:abcde_mod:y_reas:n_t:0.8_p:6_k:5"
+
+    g.add("display_name", "my favorite SUT")
+    assert g.uid == "openai/chatgpt-4o:openai:openai:20250723_dv:abcde_mod:y_reas:n_t:0.8_p:6_k:5_dn:my-favorite-sut"

--- a/tests/modelgauge_tests/test_uid_generator.py
+++ b/tests/modelgauge_tests/test_uid_generator.py
@@ -1,3 +1,4 @@
+from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
 from modelgauge.uid_generator import SUTUIDGenerator
 
 
@@ -20,3 +21,27 @@ def test_uid():
 
     g.add("display_name", "my favorite SUT")
     assert g.uid == "openai/chatgpt-4o:openai:openai:20250723_dv:abcde_mod:y_reas:n_t:0.8_p:6_k:5_dn:my-favorite-sut"
+
+
+def test_from_json():
+    data = {"model": "the_model", "driver": "the_driver"}
+    g = SUTUIDGenerator.from_json(data)
+    assert g.data["model"] == "the_model"
+    assert g.data["driver"] == "the_driver"
+
+    data_s = '{"model": "my_model", "driver": "my_driver"}'
+    gg = SUTUIDGenerator.from_json(data_s)
+    assert gg.data["model"] == "my_model"
+    assert gg.data["driver"] == "my_driver"
+
+
+def test_to_dynamic_sut_metadata():
+    data = {
+        "model": "the_model",
+        "driver": "the_driver",
+        "maker": "the_maker",
+        "provider": "the_provider",
+        "date": "20250724",
+    }
+    g = SUTUIDGenerator(data)
+    assert g.to_dynamic_sut_metadata() == DynamicSUTMetadata(**data)


### PR DESCRIPTION
As discussed in Chicago, we are looking for SUT UIDs that include more details about the SUT configuration while remaining human readable, and having a deterministic shape so we can unambiguously turn a SUT config into a SUT UID and vice versa.

This is a first pass.

https://github.com/mlcommons/modelbench/issues/1097