### PR TITLE
Fix smoketests 

### DIFF
--- a/src/modelgauge/suts/meta_llama_client.py
+++ b/src/modelgauge/suts/meta_llama_client.py
@@ -115,7 +115,8 @@ class MetaLlamaModeratedSUT(PromptResponseSUT[MetaLlamaChatRequest, MetaLlamaMod
         return SUTResponse(text=text)
 
 
-CHAT_MODELS = ["Llama-4-Scout-17B-16E-Instruct-FP8", "Llama-4-Maverick-17B-128E-Instruct-FP8", "Llama-3.3-8B-Instruct"]
+# Unauthorized models: ["Llama-4-Scout-17B-16E-Instruct-FP8"]
+CHAT_MODELS = ["Llama-4-Maverick-17B-128E-Instruct-FP8", "Llama-3.3-8B-Instruct"]
 
 for model_name in CHAT_MODELS:
     SUTS.register(MetaLlamaSUT, "meta-" + model_name.lower() + "-llama", model_name, InjectSecret(MetaLlamaApiKey))

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -1,6 +1,4 @@
-import functools
 import math
-import os
 import pathlib
 from datetime import datetime
 from typing import List, Mapping, Sequence
@@ -18,7 +16,6 @@ from modelbench.cli import benchmark, cli, get_benchmark
 from modelbench.scoring import ValueEstimate
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.preflight import make_sut
-from modelgauge.config import SECRETS_PATH
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError, ProviderNotFoundError, UnknownSUTMakerError
 from modelgauge.locales import DEFAULT_LOCALE, EN_US, FR_FR, LOCALES
 from modelgauge.prompt_sets import PROMPT_SETS
@@ -26,8 +23,6 @@ from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.sut import PromptResponseSUT
 from modelgauge_tests.fake_sut import FakeSUT
-
-TEST_SECRETS_PATH = os.path.join("tests", "config", "secrets.toml")
 
 
 class AHazard(HazardDefinition):
@@ -106,33 +101,6 @@ class TestCli:
             datetime.now(),
         )
 
-    def manage_test_secrets(func):
-        """Decorator that manages test secrets during test execution.
-
-        1. If a secrets file exists, it's backed up
-        2. The test secrets file is copied to the expected location
-        3. After the test completes, the original state is restored
-        """
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            secrets_src = pathlib.Path(TEST_SECRETS_PATH)
-            secrets_dst = pathlib.Path(SECRETS_PATH)
-            backup_dst = secrets_dst.with_suffix(".bak")
-
-            if secrets_dst.exists():
-                secrets_dst.replace(backup_dst)
-            secrets_src.replace(secrets_dst)
-
-            try:
-                return func(*args, **kwargs)
-            finally:
-                secrets_dst.replace(secrets_src)
-                if backup_dst.exists():
-                    backup_dst.replace(secrets_dst)
-
-        return wrapper
-
     @pytest.fixture(autouse=False)
     def mock_run_benchmarks(self, sut, monkeypatch, tmp_path):
         mock = MagicMock(return_value=fake_benchmark_run(AHazard(), sut, tmp_path))
@@ -163,7 +131,6 @@ class TestCli:
         ],
         # TODO add more locales as we add support for them
     )
-    @manage_test_secrets
     def test_benchmark_basic_run_produces_json(
         self, runner, mock_run_benchmarks, mock_score_benchmarks, sut_uid, version, locale, prompt_set, tmp_path
     ):
@@ -207,7 +174,6 @@ class TestCli:
         ],
         # TODO add more locales as we add support for them
     )
-    @manage_test_secrets
     def test_benchmark_multiple_suts_produces_json(
         self, mock_run_benchmarks, runner, version, locale, prompt_set, sut_uid, tmp_path, monkeypatch
     ):
@@ -246,7 +212,6 @@ class TestCli:
         assert result.exit_code == 0
         assert (tmp_path / f"benchmark_record-{benchmark.uid}.json").exists
 
-    @manage_test_secrets
     def test_benchmark_anonymous_run_produces_json(
         self, runner, sut_uid, tmp_path, mock_run_benchmarks, mock_score_benchmarks
     ):
@@ -380,7 +345,6 @@ class TestCli:
     #     benchmark_arg = mock_score_benchmarks.call_args.args[0][0]
     #     assert isinstance(benchmark_arg, GeneralPurposeAiChatBenchmark)
 
-    @manage_test_secrets
     def test_v1_en_us_demo_is_default(self, runner, mock_run_benchmarks, sut_uid):
         result = runner.invoke(cli, ["benchmark", "--sut", sut_uid])
 
@@ -395,7 +359,6 @@ class TestCli:
         assert "Invalid value for '--prompt-set'" in result.output
 
     @pytest.mark.parametrize("prompt_set", PROMPT_SETS.keys())
-    @manage_test_secrets
     def test_calls_score_benchmark_with_correct_prompt_set(self, runner, mock_run_benchmarks, prompt_set, sut_uid):
         result = runner.invoke(cli, ["benchmark", "--prompt-set", prompt_set, "--sut", sut_uid])
 


### PR DESCRIPTION
This should fix most of the smoketest failures.
- Don't sub public demo files in "private" tests. The code was specific to `SafeTest` and was causing issues with the new `SecurityTest`. We should be testing private-data download anyway, so I completely axed that subbing mechanism.
- Remove modelbench test secret management that to be honest I don't fully understand but was causing failures in modelbench private.