### PR TITLE
Fix together dynamic factory

### DIFF
--- a/src/modelgauge/suts/together_sut_factory.py
+++ b/src/modelgauge/suts/together_sut_factory.py
@@ -28,18 +28,21 @@ class TogetherSUTFactory(DynamicSUTFactory):
         return [api_key]
 
     def _find(self, sut_metadata: DynamicSUTMetadata):
-        found = None
+        model = None
         try:
-            model_list = self.client.Models.list()
-            found = [
-                model["id"] for model in model_list if model["id"].lower() == sut_metadata.external_model_name().lower()
-            ][0]
+            model = sut_metadata.external_model_name().lower()
+            self.client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "user", "content": "Anybody home?"},
+                ],
+            )
         except Exception as e:
             raise ModelNotSupportedError(
                 f"Model {sut_metadata.external_model_name()} not found or not available on together: {e}"
             )
 
-        return found
+        return model
 
     def make_sut(self, sut_metadata: DynamicSUTMetadata) -> TogetherChatSUT:
         model_name = self._find(sut_metadata)


### PR DESCRIPTION
Together's `models` API is broken. Roger opened an [issue](https://github.com/togethercomputer/together-python/issues/343) 2 weeks ago that has still not been acknowledged.

This is one of the issues causing smoke test failures.

This PR fixes the issue by no longer relying on the `models` call.