### PR TITLE
Allow annotator workers to cache.

### DIFF
--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -193,7 +193,7 @@ class AnnotatorRunner(PipelineRunner):
             input = PromptResponseDataset(self.input_path, mode="r")
             self.pipeline_segments.append(AnnotatorSource(input))
         self.pipeline_segments.append(AnnotatorAssigner(self.annotators))
-        self.annotator_workers = AnnotatorWorkers(self.annotators, self.num_workers)
+        self.annotator_workers = AnnotatorWorkers(self.annotators, self.num_workers, cache_path=self.cache_dir)
         self.pipeline_segments.append(self.annotator_workers)
         if include_sink:
             output = AnnotationDataset(self.output_dir() / self.output_file_name, "w")


### PR DESCRIPTION
I noticed that while we pass the `cache_dir` to the `PromptSUTWorkers`, we don't pass it to the `AnnotatorWorkers`. There doesn't seem to be a good reason for not doing this.