### PR TITLE
Update source URLs in demo tests to point to the main branch

### DIFF
--- a/src/modelgauge/tests/demo_01_simple_qa_test.py
+++ b/src/modelgauge/tests/demo_01_simple_qa_test.py
@@ -23,8 +23,7 @@ class DemoSimpleQATest(PromptResponseTest):
             # The keys can be arbitrary, they are used to decide where to store
             # the dependency locally and when you look up the dependency in make_test_items.
             "jsonl_questions": WebData(
-                # TODO: change this back to main once merged in follow up PR
-                source_url="https://raw.githubusercontent.com/mlcommons/modelbench/refs/heads/lazy-loading-plugins/src/modelgauge/suts/demo/web_data/an_example.jsonl"
+                source_url="https://raw.githubusercontent.com/mlcommons/modelbench/refs/heads/main/src/modelgauge/suts/demo/web_data/an_example.jsonl"
             ),
             # If your test depends on multiple files, you can specify each here.
         }

--- a/src/modelgauge/tests/demo_02_unpacking_dependency_test.py
+++ b/src/modelgauge/tests/demo_02_unpacking_dependency_test.py
@@ -22,8 +22,7 @@ class DemoUnpackingDependencyTest(PromptResponseTest):
         """Specify all the external dependencies needed to run this Test."""
         return {
             "questions_tar": WebData(
-                # TODO: change this back to main once merged in follow up PR
-                source_url="https://raw.githubusercontent.com/mlcommons/modelbench/refs/heads/lazy-loading-plugins/src/modelgauge/suts/demo/web_data/question_answer.tar.gz",
+                source_url="https://raw.githubusercontent.com/mlcommons/modelbench/refs/heads/main/src/modelgauge/suts/demo/web_data/question_answer.tar.gz",
                 # Specify that after downloading, this file needs to be unpacked
                 # using the Tar command. Because this is specified, get_local_path
                 # will return the path to the directory.


### PR DESCRIPTION
It had to point to the last PR branch to allow the CI to pass. But now that it's on main, we can clean up.