### PR TITLE
Add ability to choose the openai driver for SUTs not deployed on openai

### DIFF
--- a/src/modelgauge/annotators/openai_compliance_annotator.py
+++ b/src/modelgauge/annotators/openai_compliance_annotator.py
@@ -6,7 +6,7 @@ from modelgauge.prompt import TextPrompt
 from modelgauge.secret_values import InjectSecret
 from modelgauge.single_turn_prompt_response import TestItem
 from modelgauge.sut import PromptResponseSUT, SUTOptions, SUTResponse
-from modelgauge.suts.openai_client import OpenAIApiKey, OpenAIChat, OpenAIOrgId
+from modelgauge.suts.openai_client import OpenAIApiKey, OpenAIChat, OpenAIOrganization
 from pydantic import BaseModel
 from typing import Callable, Dict, Optional
 
@@ -27,16 +27,16 @@ class OpenAIComplianceAnnotator(CompletionAnnotator[ComplianceAnnotation]):
         decoder: Optional[Dict[str, str]] = None,
         sut: Optional[PromptResponseSUT] = None,
         openai_api_key: Optional[OpenAIApiKey] = None,
-        openai_api_org_id: Optional[OpenAIOrgId] = None,
+        openai_api_organization: Optional[OpenAIOrganization] = None,
     ):
         super().__init__(uid)
         if sut is not None:
             self.model = sut
         else:
             assert (
-                openai_api_key is not None and openai_api_org_id is not None
+                openai_api_key is not None and openai_api_organization is not None
             ), "Must either pass sut or openai secrets."
-            self.model = OpenAIChat("annotator", _MODEL_NAME, openai_api_key, openai_api_org_id)
+            self.model = OpenAIChat("annotator", _MODEL_NAME, openai_api_key, openai_api_organization)
         self.formatter = _default_formatter if formatter is None else formatter
         self.decoder = _DEFAULT_MAPPING if decoder is None else decoder
 
@@ -88,7 +88,7 @@ ANNOTATORS.register(
     OpenAIComplianceAnnotator,
     "openai_compliance_annotator",
     openai_api_key=InjectSecret(OpenAIApiKey),
-    openai_api_org_id=InjectSecret(OpenAIOrgId),
+    openai_api_organization=InjectSecret(OpenAIOrganization),
 )
 
 

--- a/src/modelgauge/annotators/prompt_engineered_annotator.py
+++ b/src/modelgauge/annotators/prompt_engineered_annotator.py
@@ -9,7 +9,7 @@ from modelgauge.safety_model_response import SafetyModelResponse
 from modelgauge.single_turn_prompt_response import TestItem
 from modelgauge.sut import SUTOptions, SUTResponse
 from modelgauge.sut_factory import SUT_FACTORY
-from modelgauge.suts.openai_client import OpenAIApiKey, OpenAIChat, OpenAIOrgId
+from modelgauge.suts.openai_client import OpenAIApiKey, OpenAIChat, OpenAIOrganization
 from modelgauge.suts.together_client import TogetherApiKey, TogetherChatSUT
 
 # FIXME - To use the openai GPT-4 annotator, add the "ChatRole.system: _SYSTEM_ROLE", role into the _ROLE_MAP in modelgauge/suts/openai_client.py:
@@ -43,7 +43,7 @@ class PromptEngineeredAnnotator(CompletionAnnotator[SafetyModelResponse]):
         uid: str,
         config: PromptEngineeredAnnotatorConfig,
         api_key: Union[TogetherApiKey, OpenAIApiKey],
-        org_id: Optional[OpenAIOrgId] = None,
+        organization: Optional[OpenAIOrganization] = None,
     ):
         super().__init__(uid)
         self.config = config
@@ -57,13 +57,13 @@ class PromptEngineeredAnnotator(CompletionAnnotator[SafetyModelResponse]):
             self.model = TogetherChatSUT(uid, self.config.llm_path, self.api_key)
         elif self.config.llm_type == "openai":
             assert isinstance(self.api_key, OpenAIApiKey), "API key must be of type OpenAIApiKey for OpenAI models."
-            assert org_id is not None, "OpenAIOrgId must be provided for OpenAI models."
-            self.org_id = org_id
+            assert organization is not None, "OpenAIOrgId must be provided for OpenAI models."
+            self.organization = organization
             self.model = OpenAIChat(
                 "annotator",
                 "gpt-4",  # TODO: llm_path?
                 self.api_key,
-                self.org_id,
+                self.organization,
             )
         elif self.config.llm_type == "registry":
             self.model = SUT_FACTORY.make_instance(self.config.llm_path, secrets=self.api_key)  # type: ignore

--- a/src/modelgauge/annotators/prompt_engineered_annotator.py
+++ b/src/modelgauge/annotators/prompt_engineered_annotator.py
@@ -57,7 +57,6 @@ class PromptEngineeredAnnotator(CompletionAnnotator[SafetyModelResponse]):
             self.model = TogetherChatSUT(uid, self.config.llm_path, self.api_key)
         elif self.config.llm_type == "openai":
             assert isinstance(self.api_key, OpenAIApiKey), "API key must be of type OpenAIApiKey for OpenAI models."
-            assert organization is not None, "OpenAIOrgId must be provided for OpenAI models."
             self.organization = organization
             self.model = OpenAIChat(
                 "annotator",

--- a/src/modelgauge/auth/openai_compatible_secrets.py
+++ b/src/modelgauge/auth/openai_compatible_secrets.py
@@ -2,7 +2,7 @@ from modelgauge.secret_values import OptionalSecret, RequiredSecret, SecretDescr
 
 
 class OpenAICompatibleApiKey(RequiredSecret):
-    provider: str
+    provider: str = "unspecified"
 
     @classmethod
     def for_provider(cls, provider):
@@ -19,7 +19,7 @@ class OpenAICompatibleApiKey(RequiredSecret):
 
 
 class OpenAICompatibleOrganization(OptionalSecret):
-    provider: str
+    provider: str = "unspecified"
 
     @classmethod
     def for_provider(cls, provider):
@@ -38,7 +38,7 @@ class OpenAICompatibleOrganization(OptionalSecret):
 class OpenAICompatibleBaseURL(OptionalSecret):
     """Technically not a secret, but using the existing secret machinery for expediency"""
 
-    provider: str
+    provider: str = "unspecified"
 
     @classmethod
     def for_provider(cls, provider):

--- a/src/modelgauge/auth/openai_compatible_secrets.py
+++ b/src/modelgauge/auth/openai_compatible_secrets.py
@@ -18,49 +18,15 @@ class OpenAICompatibleApiKey(RequiredSecret):
         )
 
 
-class OpenAICompatibleOrganization(OptionalSecret):
-    provider: str = "unspecified"
-
-    @classmethod
-    def for_provider(cls, provider):
-        cls.provider = provider
-        return cls
-
+class OpenAIOrganization(OptionalSecret):
     @classmethod
     def description(cls) -> SecretDescription:
         return SecretDescription(
-            scope=cls.provider,
+            scope="openai",
             key="organization",
             instructions="See https://platform.openai.com/account/organization",
         )
 
 
-class OpenAICompatibleBaseURL(OptionalSecret):
-    """Technically not a secret, but using the existing secret machinery for expediency"""
-
-    provider: str = "unspecified"
-
-    @classmethod
-    def for_provider(cls, provider):
-        cls.provider = provider
-        return cls
-
-    @classmethod
-    def description(cls) -> SecretDescription:
-        return SecretDescription(
-            scope=cls.provider,
-            key="base_url",  # for OpenAI-compatible models running on a different provider
-            instructions="https://github.com/openai/openai-python/blob/main/src/openai/_client.py",
-        )
-
-
 class OpenAIApiKey(OpenAICompatibleApiKey):
-    provider = "openai"
-
-
-class OpenAIOrganization(OpenAICompatibleOrganization):
-    provider = "openai"
-
-
-class OpenAIBaseURL(OpenAICompatibleBaseURL):
     provider = "openai"

--- a/src/modelgauge/auth/openai_compatible_secrets.py
+++ b/src/modelgauge/auth/openai_compatible_secrets.py
@@ -1,0 +1,66 @@
+from modelgauge.secret_values import OptionalSecret, RequiredSecret, SecretDescription
+
+
+class OpenAICompatibleApiKey(RequiredSecret):
+    provider: str
+
+    @classmethod
+    def for_provider(cls, provider):
+        cls.provider = provider
+        return cls
+
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope=cls.provider,
+            key="api_key",
+            instructions="See https://platform.openai.com/api-keys",
+        )
+
+
+class OpenAICompatibleOrganization(OptionalSecret):
+    provider: str
+
+    @classmethod
+    def for_provider(cls, provider):
+        cls.provider = provider
+        return cls
+
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope=cls.provider,
+            key="organization",
+            instructions="See https://platform.openai.com/account/organization",
+        )
+
+
+class OpenAICompatibleBaseURL(OptionalSecret):
+    """Technically not a secret, but using the existing secret machinery for expediency"""
+
+    provider: str
+
+    @classmethod
+    def for_provider(cls, provider):
+        cls.provider = provider
+        return cls
+
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope=cls.provider,
+            key="base_url",  # for OpenAI-compatible models running on a different provider
+            instructions="https://github.com/openai/openai-python/blob/main/src/openai/_client.py",
+        )
+
+
+class OpenAIApiKey(OpenAICompatibleApiKey):
+    provider = "openai"
+
+
+class OpenAIOrganization(OpenAICompatibleOrganization):
+    provider = "openai"
+
+
+class OpenAIBaseURL(OpenAICompatibleBaseURL):
+    provider = "openai"

--- a/src/modelgauge/dynamic_sut_factory.py
+++ b/src/modelgauge/dynamic_sut_factory.py
@@ -39,7 +39,6 @@ class DynamicSUTFactory(ABC):
     def get_secrets(self) -> list[InjectSecret]:
         pass
 
-    # TODO: refactor this to use SUTDefinition instead of both the metadata and the kwargs
     @abstractmethod
     def make_sut(self, sut_definition: SUTDefinition) -> SUT:
         pass

--- a/src/modelgauge/dynamic_sut_factory.py
+++ b/src/modelgauge/dynamic_sut_factory.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Sequence
 
 from modelgauge.dependency_injection import inject_dependencies
 from modelgauge.secret_values import InjectSecret, RawSecrets
@@ -36,9 +35,8 @@ class DynamicSUTFactory(ABC):
         """Return the injected secrets as specified by `get_secrets`."""
         return inject_dependencies(self.get_secrets(), {}, secrets=self.raw_secrets)[0]
 
-    @staticmethod
     @abstractmethod
-    def get_secrets() -> list[InjectSecret]:
+    def get_secrets(self) -> list[InjectSecret]:
         pass
 
     @abstractmethod

--- a/src/modelgauge/dynamic_sut_factory.py
+++ b/src/modelgauge/dynamic_sut_factory.py
@@ -2,8 +2,8 @@ from abc import ABC, abstractmethod
 
 from modelgauge.dependency_injection import inject_dependencies
 from modelgauge.secret_values import InjectSecret, RawSecrets
-from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
 from modelgauge.sut import SUT
+from modelgauge.sut_definition import SUTDefinition
 
 
 class ModelNotSupportedError(Exception):
@@ -39,6 +39,7 @@ class DynamicSUTFactory(ABC):
     def get_secrets(self) -> list[InjectSecret]:
         pass
 
+    # TODO: refactor this to use SUTDefinition instead of both the metadata and the kwargs
     @abstractmethod
-    def make_sut(self, sut_metadata: DynamicSUTMetadata) -> SUT:
+    def make_sut(self, sut_definition: SUTDefinition) -> SUT:
         pass

--- a/src/modelgauge/dynamic_sut_metadata.py
+++ b/src/modelgauge/dynamic_sut_metadata.py
@@ -35,10 +35,8 @@ def _is_date(s: str) -> bool:
 
 class DynamicSUTMetadata(BaseModel):
     """Elements that can be combined into a SUT UID.
-    [maker/]model[:provider[:driver]][:date]
-    E.g.
-    mistralai/Mistral-Small-3.1-24B-Instruct-2503:nebius:hfrelay
-    meta-llama/Llama-3.1-8B-Instruct:huggingface
+    Spec: [maker/]model:[provider:]driver[:date]
+    Example: google/gemma-3-27b-it:nebius:hfrelay:20250507
     """
 
     model: Annotated[str, StringConstraints(strip_whitespace=True)]
@@ -46,10 +44,6 @@ class DynamicSUTMetadata(BaseModel):
     provider: Optional[str] = ""
     driver: str = ""
     date: Optional[str] = ""
-
-    def is_proxied(self):
-        blanks = (None, "")
-        return self.driver not in blanks and self.provider not in blanks
 
     def external_model_name(self):
         if self.maker:

--- a/src/modelgauge/sut.py
+++ b/src/modelgauge/sut.py
@@ -157,7 +157,7 @@ def get_sut_and_options(
                 sut_definition = None
 
     if sut_definition:
-        sut = sut_definition.dynamic_uid
+        sut = sut_definition.uid
         options = create_sut_options_with_sut_def(
             sut_definition,
             max_tokens=max_tokens,

--- a/src/modelgauge/sut_definition.py
+++ b/src/modelgauge/sut_definition.py
@@ -35,6 +35,8 @@ class SUTSpecification:
             "moderated": SUTSpecificationElement("moderated", "mod", bool),
             "driver_code_version": SUTSpecificationElement("driver_code_version", "dv", str),
             "date": SUTSpecificationElement("date", "dt", str),
+            "base_url": SUTSpecificationElement("base_url", "url", str),
+
         }
 
     def knows(self, field):
@@ -166,6 +168,7 @@ class SUTUIDGenerator:
         "top_k",
         "top_logprobs",
         "display_name",
+        "base_url" # for OpenAI-compatible SUTs
     )
     field_separator = RICH_UID_FIELD_SEPARATOR
     key_value_separator = "="

--- a/src/modelgauge/sut_definition.py
+++ b/src/modelgauge/sut_definition.py
@@ -36,7 +36,6 @@ class SUTSpecification:
             "driver_code_version": SUTSpecificationElement("driver_code_version", "dv", str),
             "date": SUTSpecificationElement("date", "dt", str),
             "base_url": SUTSpecificationElement("base_url", "url", str),
-
         }
 
     def knows(self, field):
@@ -168,7 +167,7 @@ class SUTUIDGenerator:
         "top_k",
         "top_logprobs",
         "display_name",
-        "base_url" # for OpenAI-compatible SUTs
+        "base_url",  # for OpenAI-compatible SUTs
     )
     field_separator = RICH_UID_FIELD_SEPARATOR
     key_value_separator = "="

--- a/src/modelgauge/sut_definition.py
+++ b/src/modelgauge/sut_definition.py
@@ -66,9 +66,8 @@ class SUTDefinition:
         if data:
             for k, v in data.items():
                 self.add(k, v)
-        if kwargs:
-            for k, v in kwargs.items():
-                self.add(k, v)
+        for k, v in kwargs.items():
+            self.add(k, v)
 
     @staticmethod
     def from_json(data: str):

--- a/src/modelgauge/sut_definition.py
+++ b/src/modelgauge/sut_definition.py
@@ -57,7 +57,7 @@ class SUTSpecification:
 class SUTDefinition:
     """The data in a SUT configuration file or JSON blob"""
 
-    def __init__(self, data=None):
+    def __init__(self, data=None, **kwargs):
         self._uid: str = ""
         self._dynamic_uid: str = ""
         self._frozen = False
@@ -65,6 +65,9 @@ class SUTDefinition:
         self.data = {}
         if data:
             for k, v in data.items():
+                self.add(k, v)
+        if kwargs:
+            for k, v in kwargs.items():
                 self.add(k, v)
 
     @staticmethod
@@ -152,6 +155,10 @@ class SUTDefinition:
             provider=self.data.get("provider", None),
             date=self.data.get("date", None),
         )
+
+    def external_model_name(self):
+        metadata = self.to_dynamic_sut_metadata()
+        return metadata.external_model_name()
 
 
 class SUTUIDGenerator:

--- a/src/modelgauge/sut_factory.py
+++ b/src/modelgauge/sut_factory.py
@@ -7,7 +7,7 @@ from modelgauge.secret_values import RawSecrets
 from modelgauge.sut import SUT
 from modelgauge.sut_registry import SUTS
 from modelgauge.suts.huggingface_sut_factory import HuggingFaceSUTFactory
-from modelgauge.suts.openai_sut_factory import OpenAISUTFactory
+from modelgauge.suts.openai_sut_factory import OpenAICompatibleSUTFactory
 from modelgauge.suts.together_sut_factory import TogetherSUTFactory
 
 
@@ -29,7 +29,7 @@ DYNAMIC_SUT_FACTORIES: dict = {
     "hf": HuggingFaceSUTFactory,
     "hfrelay": HuggingFaceSUTFactory,
     "huggingface": HuggingFaceSUTFactory,
-    "openai": OpenAISUTFactory,
+    "openai": OpenAICompatibleSUTFactory,
     "together": TogetherSUTFactory,
 }
 

--- a/src/modelgauge/sut_factory.py
+++ b/src/modelgauge/sut_factory.py
@@ -2,9 +2,9 @@ from enum import Enum
 
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import DynamicSUTFactory, UnknownSUTMakerError
-from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
 from modelgauge.secret_values import RawSecrets
 from modelgauge.sut import SUT
+from modelgauge.sut_definition import SUTDefinition, SUTUIDGenerator
 from modelgauge.sut_registry import SUTS
 from modelgauge.suts.huggingface_sut_factory import HuggingFaceSUTFactory
 from modelgauge.suts.openai_sut_factory import OpenAICompatibleSUTFactory
@@ -181,11 +181,11 @@ class SUTFactory:
             return SUTType.UNKNOWN
 
     def _make_dynamic_sut(self, uid: str) -> SUT:
-        sut_metadata: DynamicSUTMetadata = DynamicSUTMetadata.parse_sut_uid(uid)
-        factory = self.dynamic_sut_factories.get(sut_metadata.driver, None)  # type: ignore
+        sut_definition: SUTDefinition = SUTUIDGenerator.parse(uid)
+        factory = self.dynamic_sut_factories.get(sut_definition.get("driver"))  # type: ignore
         if not factory:
             raise UnknownSUTMakerError(f'Don\'t know how to make dynamic sut "{uid}"')
-        return factory.make_sut(sut_metadata)
+        return factory.make_sut(sut_definition)
 
     def keys(self) -> list[str]:
         """Mimic the registry interface."""

--- a/src/modelgauge/sut_factory.py
+++ b/src/modelgauge/sut_factory.py
@@ -21,17 +21,16 @@ class SUTType(Enum):
     UNKNOWN = "unknown"
 
 
-# TODO: Auto-collect. Maybe make "driver" keys a constant in each factory module.
+# TODO: Auto-collect?
+# Make sure the factory module includes the matching key as a constant.
 # Maps a string to the module and factory function in that module
 # that can be used to create a dynamic sut
 DYNAMIC_SUT_FACTORIES: dict = {
-    "proxied": {"hfrelay": HuggingFaceSUTFactory},
-    "direct": {
-        "openai": OpenAISUTFactory,
-        "together": TogetherSUTFactory,
-        "huggingface": HuggingFaceSUTFactory,
-        "hf": HuggingFaceSUTFactory,
-    },
+    "hf": HuggingFaceSUTFactory,
+    "hfrelay": HuggingFaceSUTFactory,
+    "huggingface": HuggingFaceSUTFactory,
+    "openai": OpenAISUTFactory,
+    "together": TogetherSUTFactory,
 }
 
 LEGACY_SUT_MODULE_MAP = {
@@ -152,12 +151,10 @@ class SUTFactory:
         self.sut_registry = sut_registry
         self.dynamic_sut_factories = self._load_dynamic_sut_factories(load_secrets_from_config())
 
-    def _load_dynamic_sut_factories(self, secrets: RawSecrets) -> dict[str, dict[str, DynamicSUTFactory]]:
-        factories: dict[str, dict[str, DynamicSUTFactory]] = {"direct": {}, "proxied": {}}
-        for driver, factory_class in DYNAMIC_SUT_FACTORIES["direct"].items():
-            factories["direct"][driver] = factory_class(secrets)
-        for driver, factory_class in DYNAMIC_SUT_FACTORIES["proxied"].items():
-            factories["proxied"][driver] = factory_class(secrets)
+    def _load_dynamic_sut_factories(self, secrets: RawSecrets) -> dict[str, DynamicSUTFactory]:
+        factories: dict[str, DynamicSUTFactory] = {}
+        for driver, factory_class in DYNAMIC_SUT_FACTORIES.items():
+            factories[driver] = factory_class(secrets)
         return factories
 
     def knows(self, uid: str) -> bool:
@@ -185,11 +182,7 @@ class SUTFactory:
 
     def _make_dynamic_sut(self, uid: str) -> SUT:
         sut_metadata: DynamicSUTMetadata = DynamicSUTMetadata.parse_sut_uid(uid)
-
-        if sut_metadata.is_proxied():
-            factory = self.dynamic_sut_factories["proxied"].get(sut_metadata.driver, None)
-        else:
-            factory = self.dynamic_sut_factories["direct"].get(sut_metadata.driver, None)  # type: ignore
+        factory = self.dynamic_sut_factories.get(sut_metadata.driver, None)  # type: ignore
         if not factory:
             raise UnknownSUTMakerError(f'Don\'t know how to make dynamic sut "{uid}"')
         return factory.make_sut(sut_metadata)

--- a/src/modelgauge/suts/huggingface_sut_factory.py
+++ b/src/modelgauge/suts/huggingface_sut_factory.py
@@ -31,22 +31,16 @@ class HuggingFaceSUTFactory(DynamicSUTFactory):
         return [hf_token]
 
     def make_sut(self, sut_metadata: DynamicSUTMetadata) -> BaseHuggingFaceChatCompletionSUT:
-        if sut_metadata.is_proxied():
-            if sut_metadata.driver != DRIVER_NAME:
-                raise UnknownSUTDriverError(f"Unknown driver '{sut_metadata.driver}'")
+        try:
             return self.serverless_factory.make_sut(sut_metadata)
-        else:
-            # is there a serverless option?
+        except ProviderNotFoundError:
+            # is there a dedicated option? probably not, but we check anyway
             try:
-                return self.serverless_factory.make_sut(sut_metadata)
+                return self.dedicated_factory.make_sut(sut_metadata)
             except ProviderNotFoundError:
-                # is there a dedicated option? probably not, but we check anyway
-                try:
-                    return self.dedicated_factory.make_sut(sut_metadata)
-                except ProviderNotFoundError:
-                    raise ModelNotSupportedError(
-                        f"Huggingface doesn't know model {sut_metadata.external_model_name()}, or you need credentials for its repo."
-                    )
+                raise ModelNotSupportedError(
+                    f"Huggingface doesn't know model {sut_metadata.external_model_name()}, or you need credentials for its repo."
+                )
 
 
 class HuggingFaceChatCompletionServerlessSUTFactory(DynamicSUTFactory):

--- a/src/modelgauge/suts/huggingface_sut_factory.py
+++ b/src/modelgauge/suts/huggingface_sut_factory.py
@@ -25,8 +25,7 @@ class HuggingFaceSUTFactory(DynamicSUTFactory):
         self.serverless_factory = HuggingFaceChatCompletionServerlessSUTFactory(raw_secrets)
         self.dedicated_factory = HuggingFaceChatCompletionDedicatedSUTFactory(raw_secrets)
 
-    @staticmethod
-    def get_secrets() -> list[InjectSecret]:
+    def get_secrets(self) -> list[InjectSecret]:
         hf_token = InjectSecret(HuggingFaceInferenceToken)
         return [hf_token]
 
@@ -45,8 +44,7 @@ class HuggingFaceSUTFactory(DynamicSUTFactory):
 
 class HuggingFaceChatCompletionServerlessSUTFactory(DynamicSUTFactory):
 
-    @staticmethod
-    def get_secrets() -> list[InjectSecret]:
+    def get_secrets(self) -> list[InjectSecret]:
         hf_token = InjectSecret(HuggingFaceInferenceToken)
         return [hf_token]
 
@@ -89,8 +87,8 @@ class HuggingFaceChatCompletionServerlessSUTFactory(DynamicSUTFactory):
 
 
 class HuggingFaceChatCompletionDedicatedSUTFactory(DynamicSUTFactory):
-    @staticmethod
-    def get_secrets() -> list[InjectSecret]:
+
+    def get_secrets(self) -> list[InjectSecret]:
         hf_token = InjectSecret(HuggingFaceInferenceToken)
         return [hf_token]
 

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -7,10 +7,8 @@ from pydantic import BaseModel
 
 from modelgauge.auth.openai_compatible_secrets import (
     OpenAIApiKey,
-    OpenAIOrganization,
     OpenAICompatibleApiKey,
-    OpenAICompatibleBaseURL,
-    OpenAICompatibleOrganization,
+    OpenAIOrganization,
 )
 from modelgauge.prompt import ChatPrompt, ChatRole, TextPrompt
 from modelgauge.retry_decorator import retry
@@ -88,15 +86,15 @@ class OpenAIChat(PromptResponseSUT[OpenAIChatRequest, ChatCompletion]):
         uid: str,
         model: str,
         api_key: Optional[OpenAICompatibleApiKey] = None,
-        organization: Optional[OpenAICompatibleOrganization] = None,
-        base_url: Optional[OpenAICompatibleBaseURL] = None,
+        organization: Optional[OpenAIOrganization] = None,
+        base_url: Optional[str] = None,
         client: Optional[OpenAI] = None,
     ):
         super().__init__(uid)
         self.model = model
         self.api_key = api_key.value if api_key else None
         self.organization = organization.value if organization else None
-        self.base_url = base_url.value if base_url else None
+        self.base_url = base_url
         self.client = client
 
         # key and optional org id if you're talking to openAI

--- a/src/modelgauge/suts/openai_sut_factory.py
+++ b/src/modelgauge/suts/openai_sut_factory.py
@@ -14,7 +14,7 @@ class OpenAICompatibleSUTFactory(DynamicSUTFactory):
 
     def __init__(self, raw_secrets: RawSecrets):
         super().__init__(raw_secrets)
-        self.provider: str = "openai"  # must match name of section (scope) in secrets.toml
+        self.provider = None  # must be set in child classes and  match name of section (scope) in secrets.toml
         self._client = None
 
     def get_secrets(self) -> list[InjectSecret]:
@@ -46,6 +46,10 @@ class OpenAICompatibleSUTFactory(DynamicSUTFactory):
 
 class OpenAISUTFactory(OpenAICompatibleSUTFactory):
     """OpenAI SUT hosted by OpenAI"""
+
+    def __init__(self, raw_secrets: RawSecrets):
+        super().__init__(raw_secrets)
+        self.provider = "openai"
 
     def _model_exists(self, sut_definition: SUTDefinition):
         try:

--- a/src/modelgauge/suts/together_sut_factory.py
+++ b/src/modelgauge/suts/together_sut_factory.py
@@ -22,8 +22,7 @@ class TogetherSUTFactory(DynamicSUTFactory):
             self._client = Together(api_key=api_key.value)
         return self._client
 
-    @staticmethod
-    def get_secrets() -> list[InjectSecret]:
+    def get_secrets(self) -> list[InjectSecret]:
         api_key = InjectSecret(TogetherApiKey)
         return [api_key]
 

--- a/src/modelgauge/suts/together_sut_factory.py
+++ b/src/modelgauge/suts/together_sut_factory.py
@@ -4,6 +4,7 @@ from modelgauge.auth.together_key import TogetherApiKey
 from modelgauge.dynamic_sut_factory import DynamicSUTFactory, ModelNotSupportedError
 from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
 from modelgauge.secret_values import InjectSecret, RawSecrets
+from modelgauge.sut_definition import SUTDefinition
 from modelgauge.suts.together_client import TogetherChatSUT
 
 
@@ -43,7 +44,8 @@ class TogetherSUTFactory(DynamicSUTFactory):
 
         return model
 
-    def make_sut(self, sut_metadata: DynamicSUTMetadata) -> TogetherChatSUT:
+    def make_sut(self, sut_definition: SUTDefinition) -> TogetherChatSUT:
+        sut_metadata = sut_definition.to_dynamic_sut_metadata()
         model_name = self._find(sut_metadata)
         if not model_name:
             raise ModelNotSupportedError(
@@ -52,7 +54,7 @@ class TogetherSUTFactory(DynamicSUTFactory):
 
         assert sut_metadata.driver == DRIVER_NAME
         return TogetherChatSUT(
-            DynamicSUTMetadata.make_sut_uid(sut_metadata),
+            sut_definition.dynamic_uid,
             sut_metadata.external_model_name(),
             *self.injected_secrets(),
         )

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -292,7 +292,7 @@ class TestCli:
             "modelgauge.suts.huggingface_sut_factory.HuggingFaceChatCompletionServerlessSUTFactory._find",
             side_effect=ProviderNotFoundError("bad provider"),
         ):
-            with pytest.raises(ProviderNotFoundError):
+            with pytest.raises(ModelNotSupportedError):
                 _ = runner.invoke(
                     cli,
                     [
@@ -301,7 +301,7 @@ class TestCli:
                         "-m",
                         "1",
                         "--sut",
-                        "google/gemma:bogus:hfrelay",
+                        "meta/llama:notreal:hfrelay",
                         "--output-dir",
                         str(tmp_path.absolute()),
                         *benchmark_options,

--- a/tests/modelgauge_tests/data/sutdef.json
+++ b/tests/modelgauge_tests/data/sutdef.json
@@ -4,5 +4,6 @@
     "driver": "hfrelay",
     "provider": "nebius",
     "temp": 0.3,
-    "max_tokens": 500
+    "max_tokens": 500,
+    "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/"
 }

--- a/tests/modelgauge_tests/data/sutdef.json
+++ b/tests/modelgauge_tests/data/sutdef.json
@@ -5,5 +5,5 @@
     "provider": "nebius",
     "temp": 0.3,
     "max_tokens": 500,
-    "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/"
+    "base_url": "https://example.com/"
 }

--- a/tests/modelgauge_tests/fake_secrets.py
+++ b/tests/modelgauge_tests/fake_secrets.py
@@ -1,7 +1,5 @@
 from typing import Dict
 
-from modelgauge.config import load_secrets_from_config
-
 from modelgauge.secret_values import get_all_secrets, RawSecrets, RequiredSecret, SecretDescription
 
 

--- a/tests/modelgauge_tests/sut_tests/test_huggingface_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_huggingface_sut_factory.py
@@ -106,11 +106,6 @@ def test_make_sut_proxied(super_factory):
     assert sut.provider == "cohere"
 
 
-def test_make_sut_bad_proxy(super_factory):
-    with pytest.raises(UnknownSUTDriverError):
-        super_factory.make_sut(DynamicSUTMetadata.parse_sut_uid("google/gemma:cohere:bogus"))
-
-
 def test_make_sut_direct_serverless(super_factory):
     sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hf")
     sut = super_factory.make_sut(sut_metadata)

--- a/tests/modelgauge_tests/sut_tests/test_huggingface_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_huggingface_sut_factory.py
@@ -4,7 +4,7 @@ import pytest
 
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError, ProviderNotFoundError
-from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata, UnknownSUTDriverError
+from modelgauge.sut_definition import SUTDefinition, SUTUIDGenerator
 from modelgauge.suts.huggingface_chat_completion import (
     HuggingFaceChatCompletionDedicatedSUT,
     HuggingFaceChatCompletionServerlessSUT,
@@ -27,8 +27,8 @@ def serverless_factory(monkeypatch):
 
 
 def test_serverless_make_sut_proxied(serverless_factory):
-    sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hfrelay", provider="cohere")
-    sut = serverless_factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(model="gemma", maker="google", driver="hfrelay", provider="cohere")
+    sut = serverless_factory.make_sut(sut_definition)
     assert isinstance(sut, HuggingFaceChatCompletionServerlessSUT)
     assert sut.uid == "google/gemma:cohere:hfrelay"
     assert sut.model == "google/gemma"
@@ -36,8 +36,8 @@ def test_serverless_make_sut_proxied(serverless_factory):
 
 
 def test_serverless_make_sut_direct(serverless_factory):
-    sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hf")
-    sut = serverless_factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(model="gemma", maker="google", driver="hf")
+    sut = serverless_factory.make_sut(sut_definition)
     assert isinstance(sut, HuggingFaceChatCompletionServerlessSUT)
     assert sut.uid == "google/gemma:hf"
     assert sut.model == "google/gemma"
@@ -51,7 +51,7 @@ def test_serverless_make_sut_no_provider_found():
     ):
         factory = HuggingFaceChatCompletionServerlessSUTFactory(RAW_SECRETS)
         with pytest.raises(ProviderNotFoundError):
-            factory.make_sut(DynamicSUTMetadata.parse_sut_uid("google/gemma:bogus:hfrelay"))
+            factory.make_sut(SUTUIDGenerator.parse("google/gemma:bogus:hfrelay"))
 
 
 @pytest.fixture
@@ -62,16 +62,16 @@ def dedicated_factory(monkeypatch):
 
 
 def test_dedicated_make_sut(dedicated_factory):
-    sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hf", provider="cohere")
-    sut = dedicated_factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(model="gemma", maker="google", driver="hf", provider="cohere")
+    sut = dedicated_factory.make_sut(sut_definition)
     assert isinstance(sut, HuggingFaceChatCompletionDedicatedSUT)
     assert sut.uid == "google/gemma:cohere:hf"
     assert sut.inference_endpoint == "endpoint_name"
 
 
 def test_dedicated_make_sut_no_provider(dedicated_factory):
-    sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hf")
-    sut = dedicated_factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(model="gemma", maker="google", driver="hf")
+    sut = dedicated_factory.make_sut(sut_definition)
     assert isinstance(sut, HuggingFaceChatCompletionDedicatedSUT)
     assert sut.uid == "google/gemma:hf"
     assert sut.inference_endpoint == "endpoint_name"
@@ -84,7 +84,7 @@ def test_dedicated_make_sut_no_endpoint_found():
     ):
         factory = HuggingFaceChatCompletionDedicatedSUTFactory(RAW_SECRETS)
         with pytest.raises(ProviderNotFoundError):
-            factory.make_sut(DynamicSUTMetadata.parse_sut_uid("google/gemma:hf"))
+            factory.make_sut(SUTUIDGenerator.parse("google/gemma:hf"))
 
 
 @pytest.fixture
@@ -97,8 +97,8 @@ def super_factory(serverless_factory, dedicated_factory):
 
 def test_make_sut_proxied(super_factory):
 
-    sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hfrelay", provider="cohere")
-    sut = super_factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(model="gemma", maker="google", driver="hfrelay", provider="cohere")
+    sut = super_factory.make_sut(sut_definition)
 
     assert isinstance(sut, HuggingFaceChatCompletionServerlessSUT)
     assert sut.uid == "google/gemma:cohere:hfrelay"
@@ -107,8 +107,8 @@ def test_make_sut_proxied(super_factory):
 
 
 def test_make_sut_direct_serverless(super_factory):
-    sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hf")
-    sut = super_factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(model="gemma", maker="google", driver="hf")
+    sut = super_factory.make_sut(sut_definition)
     assert isinstance(sut, HuggingFaceChatCompletionServerlessSUT)
     assert sut.uid == "google/gemma:hf"
     assert sut.model == "google/gemma"
@@ -125,8 +125,8 @@ def test_make_sut_direct_dedicated(dedicated_factory):
         factory.serverless_factory = HuggingFaceChatCompletionServerlessSUTFactory(RAW_SECRETS)
         factory.dedicated_factory = dedicated_factory
 
-        sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="hf")
-        sut = factory.make_sut(sut_metadata)
+        sut_definition = SUTDefinition(model="gemma", maker="google", driver="hf")
+        sut = factory.make_sut(sut_definition)
     assert isinstance(sut, HuggingFaceChatCompletionDedicatedSUT)
     assert sut.uid == "google/gemma:hf"
     assert sut.inference_endpoint == "endpoint_name"
@@ -147,14 +147,14 @@ def test_make_sut_no_sut_found():
             factory.dedicated_factory = HuggingFaceChatCompletionDedicatedSUTFactory(RAW_SECRETS)
 
             with pytest.raises(ModelNotSupportedError):
-                factory.make_sut(DynamicSUTMetadata.parse_sut_uid("google/gemma:hf"))
+                factory.make_sut(SUTUIDGenerator.parse("google/gemma:hf"))
 
 
 @expensive_tests
 def test_connection():
     factory = HuggingFaceSUTFactory(load_secrets_from_config(path="."))
-    sut_metadata = DynamicSUTMetadata(model="gemma-3-27b-it", maker="google", driver="hfrelay", provider="nebius")
-    sut = factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(model="gemma-3-27b-it", maker="google", driver="hfrelay", provider="nebius")
+    sut = factory.make_sut(sut_definition)
     assert isinstance(sut, HuggingFaceChatCompletionServerlessSUT)
     assert sut.uid == "google/gemma-3-27b-it:nebius:hfrelay"
     assert sut.model == "google/gemma-3-27b-it"

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -1,3 +1,8 @@
+from pytest import raises
+
+from openai import OpenAI
+from openai.types.chat import ChatCompletion
+
 from modelgauge.prompt import TextPrompt
 from modelgauge.sut import SUTOptions, SUTResponse, TokenProbability, TopTokens
 from modelgauge.suts.openai_client import (
@@ -6,8 +11,8 @@ from modelgauge.suts.openai_client import (
     OpenAIChatMessage,
     OpenAIChatRequest,
     OpenAIOrganization,
+    OpenAICompatibleBaseURL,
 )
-from openai.types.chat import ChatCompletion
 
 
 def _make_client():
@@ -17,6 +22,51 @@ def _make_client():
         api_key=OpenAIApiKey("some-value"),
         organization=OpenAIOrganization(None),
     )
+
+
+def _make_openai_client():
+    return OpenAI(api_key="some-value", organization="some-org", max_retries=1)
+
+
+def test_openai_constructor():
+    # these should all work
+    key_only = OpenAIChat(
+        uid="test-model", model="some-model", api_key=OpenAIApiKey("some-value"), organization=OpenAIOrganization(None)
+    )
+    key_and_org = OpenAIChat(
+        uid="test-model",
+        model="some-model",
+        api_key=OpenAIApiKey("some-value"),
+        organization=OpenAIOrganization("some-org"),
+    )
+    key_and_base_url = OpenAIChat(
+        uid="test-model",
+        model="some-model",
+        api_key=OpenAIApiKey("some-value"),
+        base_url=OpenAICompatibleBaseURL("some-url"),
+    )
+
+    client = _make_openai_client()
+    with_client = OpenAIChat(
+        uid="test-model",
+        model="some-model",
+        client=client,  # type:ignore
+    )
+
+    # these should all fail
+
+    # no key and no client
+    with raises(AssertionError):
+        _ = OpenAIChat(uid="test-model", model="some-model")
+
+    # base_url and organization
+    with raises(AssertionError):
+        _ = OpenAIChat(
+            uid="test-model",
+            model="some-model",
+            organization=OpenAIOrganization("some-org"),
+            base_url=OpenAICompatibleBaseURL("some-url"),
+        )
 
 
 def test_openai_chat_translate_request():

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -11,7 +11,6 @@ from modelgauge.suts.openai_client import (
     OpenAIChatMessage,
     OpenAIChatRequest,
     OpenAIOrganization,
-    OpenAICompatibleBaseURL,
 )
 
 
@@ -43,7 +42,7 @@ def test_openai_constructor():
         uid="test-model",
         model="some-model",
         api_key=OpenAIApiKey("some-value"),
-        base_url=OpenAICompatibleBaseURL("some-url"),
+        base_url="some-url",
     )
 
     client = _make_openai_client()
@@ -65,7 +64,7 @@ def test_openai_constructor():
             uid="test-model",
             model="some-model",
             organization=OpenAIOrganization("some-org"),
-            base_url=OpenAICompatibleBaseURL("some-url"),
+            base_url="some-url",
         )
 
 

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -5,7 +5,7 @@ from modelgauge.suts.openai_client import (
     OpenAIChat,
     OpenAIChatMessage,
     OpenAIChatRequest,
-    OpenAIOrgId,
+    OpenAIOrganization,
 )
 from openai.types.chat import ChatCompletion
 
@@ -15,7 +15,7 @@ def _make_client():
         uid="test-model",
         model="some-model",
         api_key=OpenAIApiKey("some-value"),
-        org_id=OpenAIOrgId(None),
+        organization=OpenAIOrganization(None),
     )
 
 

--- a/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
@@ -1,52 +1,98 @@
 import pytest
 from unittest.mock import patch
 
+from openai import OpenAI
+
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
 from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
 from modelgauge.suts.openai_client import OpenAIChat
-from modelgauge.suts.openai_sut_factory import OpenAISUTFactory
+from modelgauge.suts.openai_sut_factory import OpenAICompatibleSUTFactory, OpenAIGenericSUTFactory, OpenAISUTFactory
 from modelgauge_tests.utilities import expensive_tests
 
 
 @pytest.fixture
-def factory():
+def openai_factory():
     return OpenAISUTFactory({"openai": {"api_key": "value"}})
 
 
-def test_make_sut(factory):
+@pytest.fixture
+def openai_generic_factory():
+    return OpenAIGenericSUTFactory({"some_vendor": {"api_key": "value", "base_url": "some_url"}})
+
+
+@pytest.fixture
+def factory():
+    return OpenAICompatibleSUTFactory(
+        {
+            "openai": {"api_key": "value", "organization": "some_org"},
+            "some_vendor": {"api_key": "some_key", "base_url": "some_url"},
+        }
+    )
+
+
+### OpenAI SUTs running on OpenAI
+def test_make_sut(openai_factory):
     with patch(
         "modelgauge.suts.openai_sut_factory.OpenAISUTFactory._model_exists",
         return_value=True,
     ):
         sut_metadata = DynamicSUTMetadata(model="gpt-4o", maker="openai", driver="openai")
-        sut = factory.make_sut(sut_metadata)
+        sut = openai_factory.make_sut(sut_metadata)
     assert isinstance(sut, OpenAIChat)
     assert sut.uid == "openai/gpt-4o:openai"
     assert sut.model == "gpt-4o"
-    assert sut.api_key == "value"
+    assert isinstance(sut.client, OpenAI)
 
 
-def test_make_sut_no_maker(factory):
+def test_make_sut_no_maker(openai_factory):
     with patch(
         "modelgauge.suts.openai_sut_factory.OpenAISUTFactory._model_exists",
         return_value=True,
     ):
         sut_metadata = DynamicSUTMetadata(model="gpt-4o", driver="openai")
-        sut = factory.make_sut(sut_metadata)
+        sut = openai_factory.make_sut(sut_metadata)
     assert isinstance(sut, OpenAIChat)
     assert sut.uid == "gpt-4o:openai"
     assert sut.model == "gpt-4o"
 
 
-def test_make_unknown_sut_raises_error(factory):
+def test_make_unknown_sut_raises_error(openai_factory):
     with patch(
         "modelgauge.suts.openai_sut_factory.OpenAISUTFactory._model_exists",
         return_value=False,
     ):
         sut_metadata = DynamicSUTMetadata(model="gpt-4o", maker="openai", driver="openai")
         with pytest.raises(ModelNotSupportedError):
-            factory.make_sut(sut_metadata)
+            openai_factory.make_sut(sut_metadata)
+
+
+### SUTs using the OpenAI client running anywhere
+def test_make_generic_sut(openai_generic_factory):
+    sut_metadata = DynamicSUTMetadata(model="gemini-something", maker="google", driver="openai", provider="some_vendor")
+    sut = openai_generic_factory.make_sut(sut_metadata)
+    assert isinstance(sut, OpenAIChat)
+    assert sut.uid == "google/gemini-something:some_vendor:openai"
+    assert sut.model == "gemini-something"
+    assert isinstance(sut.client, OpenAI)
+
+
+### Factory that decides which kind of OpenAI-compatible SUT you want
+def test_factory_makes_the_right_generic_sut(factory):
+    sut_metadata = DynamicSUTMetadata(model="gemini-something", maker="google", driver="openai", provider="some_vendor")
+    sut = factory.make_sut(sut_metadata)
+    assert isinstance(sut, OpenAIChat)
+    assert sut.uid == "google/gemini-something:some_vendor:openai"
+    assert sut.model == "gemini-something"
+    assert isinstance(sut.client, OpenAI)
+
+
+def test_factory_makes_the_right_openai_sut(factory):
+    with patch("modelgauge.suts.openai_sut_factory.OpenAISUTFactory.client"):
+        sut_metadata = DynamicSUTMetadata(model="gpt-5", maker="openai", driver="openai")
+        sut = factory.make_sut(sut_metadata)
+        assert sut.uid == "openai/gpt-5:openai"
+        assert sut.model == "gpt-5"
 
 
 @expensive_tests

--- a/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
@@ -13,22 +13,28 @@ from modelgauge_tests.utilities import expensive_tests
 
 @pytest.fixture
 def openai_factory():
-    return OpenAISUTFactory({"openai": {"api_key": "value"}})
+    return OpenAISUTFactory(raw_secrets={"openai": {"api_key": "some_key"}})
 
 
 @pytest.fixture
 def openai_generic_factory():
-    return OpenAIGenericSUTFactory({"some_vendor": {"api_key": "value", "base_url": "some_url"}})
+    return OpenAIGenericSUTFactory(raw_secrets={"demo": {"api_key": "some_key"}}, base_url="some_url")
 
 
 @pytest.fixture
 def factory():
     return OpenAICompatibleSUTFactory(
-        {
-            "openai": {"api_key": "value", "organization": "some_org"},
-            "some_vendor": {"api_key": "some_key", "base_url": "some_url"},
+        raw_secrets={
+            "openai": {"api_key": "some_key", "organization": "some_org"},
+            "demo": {"api_key": "some_key"},
         }
     )
+
+
+@pytest.fixture
+def sut_metadata():
+    sut_metadata = DynamicSUTMetadata(model="some_model", maker="some_maker", driver="openai", provider="demo")
+    return sut_metadata
 
 
 ### OpenAI SUTs running on OpenAI
@@ -45,7 +51,7 @@ def test_make_sut(openai_factory):
     assert isinstance(sut.client, OpenAI)
 
 
-def test_make_sut_no_maker(openai_factory):
+def test_make_sut_with_no_maker(openai_factory):
     with patch(
         "modelgauge.suts.openai_sut_factory.OpenAISUTFactory._model_exists",
         return_value=True,
@@ -62,33 +68,41 @@ def test_make_unknown_sut_raises_error(openai_factory):
         "modelgauge.suts.openai_sut_factory.OpenAISUTFactory._model_exists",
         return_value=False,
     ):
-        sut_metadata = DynamicSUTMetadata(model="gpt-4o", maker="openai", driver="openai")
+        sut_metadata = DynamicSUTMetadata(model="bogus", maker="openai", driver="openai")
         with pytest.raises(ModelNotSupportedError):
             openai_factory.make_sut(sut_metadata)
 
 
 ### SUTs using the OpenAI client running anywhere
-def test_make_generic_sut(openai_generic_factory):
-    sut_metadata = DynamicSUTMetadata(model="gemini-something", maker="google", driver="openai", provider="some_vendor")
+def test_make_generic_sut(openai_generic_factory, sut_metadata):
+    openai_generic_factory.base_url = "https://example.com"
     sut = openai_generic_factory.make_sut(sut_metadata)
     assert isinstance(sut, OpenAIChat)
-    assert sut.uid == "google/gemini-something:some_vendor:openai"
-    assert sut.model == "gemini-something"
+    assert sut.uid == "some_maker/some_model:demo:openai"
+    assert sut.model == "some_model"
+    assert isinstance(sut.client, OpenAI)
+
+
+### SUTs using the OpenAI client running anywhere
+def test_make_generic_sut_with_late_base_url(openai_generic_factory, sut_metadata):
+    sut = openai_generic_factory.make_sut(sut_metadata, base_url="https://example.com")
+    assert isinstance(sut, OpenAIChat)
+    assert sut.uid == "some_maker/some_model:demo:openai"
+    assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
 
 
 ### Factory that decides which kind of OpenAI-compatible SUT you want
-def test_factory_makes_the_right_generic_sut(factory):
-    sut_metadata = DynamicSUTMetadata(model="gemini-something", maker="google", driver="openai", provider="some_vendor")
-    sut = factory.make_sut(sut_metadata)
+def test_factory_makes_the_right_generic_sut(factory, sut_metadata):
+    sut = factory.make_sut(sut_metadata, base_url="https://example.org")
     assert isinstance(sut, OpenAIChat)
-    assert sut.uid == "google/gemini-something:some_vendor:openai"
-    assert sut.model == "gemini-something"
+    assert sut.uid == "some_maker/some_model:demo:openai"
+    assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
 
 
 def test_factory_makes_the_right_openai_sut(factory):
-    with patch("modelgauge.suts.openai_sut_factory.OpenAISUTFactory.client"):
+    with patch("modelgauge.suts.openai_sut_factory.OpenAICompatibleSUTFactory._make_client"):
         sut_metadata = DynamicSUTMetadata(model="gpt-5", maker="openai", driver="openai")
         sut = factory.make_sut(sut_metadata)
         assert sut.uid == "openai/gpt-5:openai"

--- a/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
@@ -4,7 +4,7 @@ import pytest
 
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
-from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
+from modelgauge.sut_definition import SUTDefinition
 from modelgauge.suts.together_client import TogetherChatSUT
 from modelgauge.suts.together_sut_factory import TogetherSUTFactory
 from modelgauge_tests.utilities import expensive_tests
@@ -17,8 +17,8 @@ def factory():
 
 def test_make_sut(factory):
     with patch("modelgauge.suts.together_sut_factory.TogetherSUTFactory._find", return_value="google/gemma:together"):
-        sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="together")
-        sut = factory.make_sut(sut_metadata)
+        sut_definition = SUTDefinition(model="gemma", maker="google", driver="together")
+        sut = factory.make_sut(sut_definition)
         assert isinstance(sut, TogetherChatSUT)
         assert sut.uid == "google/gemma:together"
         assert sut.model == "google/gemma"
@@ -26,33 +26,33 @@ def test_make_sut(factory):
 
 
 def test_make_sut_bad_model(factory):
-    sut_metadata = DynamicSUTMetadata(model="bogus", maker="fake", driver="together")
+    sut_definition = SUTDefinition(model="bogus", maker="fake", driver="together")
     with patch("modelgauge.suts.together_sut_factory.TogetherSUTFactory._find", side_effect=ModelNotSupportedError()):
         with pytest.raises(ModelNotSupportedError):
-            _ = factory.make_sut(sut_metadata)
+            _ = factory.make_sut(sut_definition)
 
 
 def test_find(factory):
     mock_together = MagicMock()
     mock_together.return_value.chat.completions.create.return_value = {}  # The method doesn't use the return value.
     with patch("modelgauge.suts.together_sut_factory.Together", mock_together):
-        sut_metadata = DynamicSUTMetadata(model="gemma", maker="google", driver="together")
-        assert factory._find(sut_metadata) == sut_metadata.external_model_name()
+        sut_definition = SUTDefinition(model="gemma", maker="google", driver="together")
+        assert factory._find(sut_definition) == sut_definition.external_model_name()
 
 
 def test_find_bad_model(factory):
-    sut_metadata = DynamicSUTMetadata(model="any", maker="any", driver="together")
+    sut_definition = SUTDefinition(model="any", maker="any", driver="together")
     mock_together = MagicMock()
     mock_together.return_value.chat.completions.create.side_effect = Exception("Model not available")
     with patch("modelgauge.suts.together_sut_factory.Together", mock_together):
         with pytest.raises(ModelNotSupportedError):
-            _ = factory._find(sut_metadata)
+            _ = factory._find(sut_definition)
 
 
 @expensive_tests
 def test_connection():
     factory = TogetherSUTFactory(load_secrets_from_config(path="."))
-    sut_metadata = DynamicSUTMetadata(maker="meta-llama", model="Llama-3-70b-chat-hf", driver="together")
-    sut = factory.make_sut(sut_metadata)
+    sut_definition = SUTDefinition(maker="meta-llama", model="Llama-3-70b-chat-hf", driver="together")
+    sut = factory.make_sut(sut_definition)
     assert sut.uid == "meta-llama/Llama-3-70b-chat-hf:together"
     assert sut.model == "meta-llama/Llama-3-70b-chat-hf"

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -171,6 +171,7 @@ def sut_def_file(tmp_path_factory):
         "provider": "nebius",
         "temp": 0.3,
         "max_tokens": 500,
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
     }
     file = tmp_path_factory.mktemp("data") / "sutdef.json"
     with open(file, "w") as f:

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -171,7 +171,7 @@ def sut_def_file(tmp_path_factory):
         "provider": "nebius",
         "temp": 0.3,
         "max_tokens": 500,
-        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+        "base_url": "https://example.com/",
     }
     file = tmp_path_factory.mktemp("data") / "sutdef.json"
     with open(file, "w") as f:

--- a/tests/modelgauge_tests/test_dynamic_sut_factory.py
+++ b/tests/modelgauge_tests/test_dynamic_sut_factory.py
@@ -8,8 +8,7 @@ from modelgauge_tests.test_secret_values import MissingSecretValues, SomeOptiona
 
 
 class FakeDynamicFactory(DynamicSUTFactory):
-    @staticmethod
-    def get_secrets() -> list[InjectSecret]:
+    def get_secrets(self) -> list[InjectSecret]:
         return [InjectSecret(SomeRequiredSecret), InjectSecret(SomeOptionalSecret)]
 
     def make_sut(self, sut_metadata: DynamicSUTMetadata):

--- a/tests/modelgauge_tests/test_dynamic_sut_factory.py
+++ b/tests/modelgauge_tests/test_dynamic_sut_factory.py
@@ -1,7 +1,7 @@
 import pytest
 
 from modelgauge.dynamic_sut_factory import DynamicSUTFactory
-from modelgauge.dynamic_sut_metadata import DynamicSUTMetadata
+from modelgauge.sut_definition import SUTDefinition
 from modelgauge.secret_values import InjectSecret
 from modelgauge_tests.fake_sut import FakeSUT
 from modelgauge_tests.test_secret_values import MissingSecretValues, SomeOptionalSecret, SomeRequiredSecret
@@ -11,8 +11,8 @@ class FakeDynamicFactory(DynamicSUTFactory):
     def get_secrets(self) -> list[InjectSecret]:
         return [InjectSecret(SomeRequiredSecret), InjectSecret(SomeOptionalSecret)]
 
-    def make_sut(self, sut_metadata: DynamicSUTMetadata):
-        return FakeSUT(DynamicSUTMetadata.make_sut_uid(sut_metadata))
+    def make_sut(self, sut_definition: SUTDefinition):
+        return FakeSUT(sut_definition.dynamic_uid)
 
 
 def test_injected_secrets():

--- a/tests/modelgauge_tests/test_dynamic_sut_metadata.py
+++ b/tests/modelgauge_tests/test_dynamic_sut_metadata.py
@@ -3,14 +3,6 @@ import pytest
 from modelgauge.dynamic_sut_metadata import _is_date, DynamicSUTMetadata, MissingModelError, UnknownSUTDriverError
 
 
-def test_is_proxied():
-    s = DynamicSUTMetadata(model="phi-4", maker="azure", provider="", driver="huggingface", date="")
-    assert not s.is_proxied()
-
-    s = DynamicSUTMetadata(model="gemma-2-9b-it", maker="google", provider="cohere", driver="hfproxy", date="20250101")
-    assert s.is_proxied()
-
-
 def test_external_model_name():
     s = DynamicSUTMetadata(model="phi-4", maker="azure", provider="", driver="together", date="")
     assert s.external_model_name() == "azure/phi-4"

--- a/tests/modelgauge_tests/test_sut_definition.py
+++ b/tests/modelgauge_tests/test_sut_definition.py
@@ -37,6 +37,7 @@ def test_to_dynamic_sut_metadata():
         "maker": "the_maker",
         "provider": "the_provider",
         "date": "20250724",
+        "base_url": "https://www.google.com/",
     }
     d = SUTDefinition(data)
     assert d.to_dynamic_sut_metadata() == DynamicSUTMetadata(**data)

--- a/tests/modelgauge_tests/test_sut_definition.py
+++ b/tests/modelgauge_tests/test_sut_definition.py
@@ -43,7 +43,9 @@ def test_to_dynamic_sut_metadata():
 
 
 def test_parse_rich_sut_uid():
-    uid = "google/gemma-3-27b-it:nebius:hfrelay;mt=500;t=0.3"
+    uid = (
+        "google/gemma-3-27b-it:nebius:hfrelay;mt=500;t=0.3;url=https://generativelanguage.googleapis.com/v1beta/openai/"
+    )
     definition = SUTUIDGenerator.parse(uid)
     assert definition.validate()
     assert definition.get("model") == "gemma-3-27b-it"
@@ -52,6 +54,7 @@ def test_parse_rich_sut_uid():
     assert definition.get("provider") == "nebius"
     assert definition.get("max_tokens") == 500
     assert definition.get("temp") == 0.3
+    assert definition.get("base_url") == "https://generativelanguage.googleapis.com/v1beta/openai/"
 
 
 def test_identify_rich_sut_uids():

--- a/tests/modelgauge_tests/test_sut_definition.py
+++ b/tests/modelgauge_tests/test_sut_definition.py
@@ -44,9 +44,7 @@ def test_to_dynamic_sut_metadata():
 
 
 def test_parse_rich_sut_uid():
-    uid = (
-        "google/gemma-3-27b-it:nebius:hfrelay;mt=500;t=0.3;url=https://generativelanguage.googleapis.com/v1beta/openai/"
-    )
+    uid = "google/gemma-3-27b-it:nebius:hfrelay;mt=500;t=0.3;url=https://example.com/"
     definition = SUTUIDGenerator.parse(uid)
     assert definition.validate()
     assert definition.get("model") == "gemma-3-27b-it"
@@ -55,7 +53,7 @@ def test_parse_rich_sut_uid():
     assert definition.get("provider") == "nebius"
     assert definition.get("max_tokens") == 500
     assert definition.get("temp") == 0.3
-    assert definition.get("base_url") == "https://generativelanguage.googleapis.com/v1beta/openai/"
+    assert definition.get("base_url") == "https://example.com/"
 
 
 def test_identify_rich_sut_uids():

--- a/tests/modelgauge_tests/test_sut_factory.py
+++ b/tests/modelgauge_tests/test_sut_factory.py
@@ -26,10 +26,7 @@ def sut_factory():
 def sut_factory_dynamic():
     """SUT factory that patches the dynamic SUT factories."""
     registry = InstanceFactory[SUT]()
-    dynamic_factories = {
-        "proxied": {},
-        "direct": {"driver1": FakeDynamicFactory({}), "driver2": FakeDynamicFactory({})},
-    }
+    dynamic_factories = {"driver1": FakeDynamicFactory({}), "driver2": FakeDynamicFactory({})}
     with patch(
         "modelgauge.sut_factory.SUTFactory._load_dynamic_sut_factories",
         return_value=dynamic_factories,


### PR DESCRIPTION
This allows you to use the existing OpenAI client for compatible SUTs running on different providers (not just openai's hardware).

# NEW: Use OpenAI client for non-OpenAI SUTs

## OpenAI SUTs are dynamic

Runing gpt models on OpenAI's hardware works as dynamic SUTs, so they don't need to be registered anymore:

`poetry run modelgauge run-sut --sut openai/gpt-4o:openai --prompt "why did the chicken cross the road?"`

## OpenAI client for any OpenAI-compatible SUTs

### OpenAI-compatible SUTs on new providers

You can do the same thing for SUTs that support the OpenAI API Spec, including any SUTs running in vllm, like this:

Add the credentials to `secrets.toml`:
```
[demo]
api_key = "a real key"
```

Add a factory for it to `openai_sut_factory.py` (it must include `base_url`):

```python
class DemoOpenAICompatibleSUTFactory(OpenAIGenericSUTFactory):
    def __init__(self, raw_secrets, **kwargs):
        super().__init__(raw_secrets)
        self.provider = "demo"
        self.base_url = "https://example.net/v1/"

OPENAI_SUT_FACTORIES: dict = {"demo": DemoOpenAICompatibleSUTFactory}
```

and run this:

`poetry run modelgauge run-sut --sut some/sut:demo:openai --prompt "why did the chicken cross the road?"`

### OpenAI-compatible SUTs on known providers

If you have a known provider with credentials in the `secrets.toml` file, then it's even easier as you don't need to create a factory.

`poetry run modelgauge run-sut --sut some/sut:demo:openai;url=https://www.example.com --prompt "why did the chicken cross the road?"`


# Next Steps

* Find other registered SUTs compatible with the OpenAI client, and convert them to dynamic SUTs like this (maybe nvidia?).


[story](https://github.com/mlcommons/modelbench/issues/1132)