### PR TITLE
Duplicate prompt/response pairs with unique prompt ids

### DIFF
--- a/src/modelgauge/annotation_pipeline.py
+++ b/src/modelgauge/annotation_pipeline.py
@@ -51,14 +51,7 @@ class AnnotatorWorkers(CachingPipe):
         request = annotator.translate_request(sut_interaction.prompt, sut_interaction.response)
         if isinstance(request, BaseModel):
             request = request.model_dump_json()
-        return (request, annotator_uid)
-
-    def handle_item(self, item):
-        result = super().handle_item(item)
-        sut_interaction, annotator_uid = item
-        return AnnotatedSUTInteraction(
-            annotator_uid=annotator_uid, annotation=result.annotation, sut_interaction=sut_interaction
-        )
+        return (sut_interaction.prompt.source_id, request, annotator_uid)
 
     def handle_uncached_item(self, item):
         sut_interaction, annotator_uid = item

--- a/tests/modelgauge_tests/test_annotation_pipeline.py
+++ b/tests/modelgauge_tests/test_annotation_pipeline.py
@@ -143,9 +143,9 @@ def test_annotator_worker_unique_responses(annotators, tmp_path):
     w.handle_item((make_sut_interaction("", "", "", "response 2"), "annotator_pydantic"))
     assert annotators["annotator_pydantic"].annotate_calls == 2
 
-    # Non-response SUT interaction attributes do not affect the cache key.
+    # New prompt id does affect the cache key.
     w.handle_item((make_sut_interaction("2", "2", "2", "response 2"), "annotator_pydantic"))
-    assert annotators["annotator_pydantic"].annotate_calls == 2
+    assert annotators["annotator_pydantic"].annotate_calls == 3
 
 
 def test_annotator_worker_cache_unique_prompts(tmp_path):

--- a/tests/modelgauge_tests/test_pipeline_runner.py
+++ b/tests/modelgauge_tests/test_pipeline_runner.py
@@ -76,7 +76,6 @@ def prompt_responses_file_with_duplicates(tmp_path_factory):
             text += f"p{i},Prompt {i},sut2,Response {i}\n"
         # add a duplicate with unique prompt ids
         text += f"q0,Prompt 0,sut1,Response 0\n"
-        print(text)
         f.write(text)
     return file
 


### PR DESCRIPTION
Ran into an issue where we had a prompt dataset with unique prompt ids, but a duplicate prompt (which produced a duplicate response).

The way our caching works was the key is based only on the request/response text, but the value is the "whole" row, including the prompt uid.

If we had a file like:
```csv
prompt_uid,prompt,response
ppp,prompt0,response0
qqq,prompt0,response0
...
```
We'd end up with output like:
```csv
prompt_uid,prompt,response,annotations...
ppp,prompt0,response0,...
ppp,prompt0,response0,...
```

We'll probably want to discuss a larger fix, but this fix minimally handles the issue above.

Output of the new test before the changes applied:
```
FAILED tests/modelgauge_tests/test_pipeline_runner.py::TestAnnotatorRunner::test_cache_responses - AssertionError: assert {'p0', 'p1', 'p2', 'q0'} == {'p0', 'p1', 'p2'}
```

Tests pass now.