### PR TITLE
Security prompt sets

### DIFF
--- a/src/modelbench/benchmarks.py
+++ b/src/modelbench/benchmarks.py
@@ -6,7 +6,7 @@ from typing import List, Sequence
 
 import casefy
 from modelgauge.locales import DEFAULT_LOCALE, validate_locale
-from modelgauge.prompt_sets import validate_prompt_set
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, validate_prompt_set
 from modelgauge.sut import PromptResponseSUT
 
 from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1, SecurityHazard, Standards, STANDARDS
@@ -135,7 +135,7 @@ class GeneralPurposeAiChatBenchmarkV1(BenchmarkDefinition):
 
     def __init__(self, locale: str, prompt_set: str, evaluator: str = "default"):
         validate_locale(locale)
-        validate_prompt_set(prompt_set, locale)
+        validate_prompt_set(GENERAL_PROMPT_SETS, prompt_set, locale)
         self.locale = locale
         self.prompt_set = prompt_set
         self.evaluator = evaluator

--- a/src/modelbench/benchmarks.py
+++ b/src/modelbench/benchmarks.py
@@ -6,7 +6,7 @@ from typing import List, Sequence
 
 import casefy
 from modelgauge.locales import DEFAULT_LOCALE, validate_locale
-from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, validate_prompt_set
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, SECURITY_PROMPT_SETS, validate_prompt_set
 from modelgauge.sut import PromptResponseSUT
 
 from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1, SecurityHazard, Standards, STANDARDS
@@ -162,7 +162,11 @@ class GeneralPurposeAiChatBenchmarkV1(BenchmarkDefinition):
 
 
 class SecurityBenchmark(BenchmarkDefinition):
-    def __init__(self, evaluator: str = "default"):
+    def __init__(self, locale: str, prompt_set: str, evaluator: str = "default"):
+        validate_locale(locale)
+        validate_prompt_set(SECURITY_PROMPT_SETS, prompt_set, locale)
+        self.locale = locale
+        self.prompt_set = prompt_set
         self.evaluator = evaluator
         super().__init__()
 
@@ -172,10 +176,15 @@ class SecurityBenchmark(BenchmarkDefinition):
         return HasUid._render_uid(self, key_def).replace(".", "_")
 
     def _make_hazards(self) -> Sequence[HazardDefinition]:
-        return [SecurityHazard(hazard_key, self.evaluator) for hazard_key in SecurityHazard.all_hazard_keys]
+        return [
+            SecurityHazard(hazard_key, self.locale, self.prompt_set, self.evaluator)
+            for hazard_key in SecurityHazard.all_hazard_keys
+        ]
 
     _uid_definition = {
         "class": "security_benchmark",
-        "version": "0.1",
+        "version": "0.5",
+        "locale": "self.locale",
+        "prompt_set": "self.prompt_set",
         "evaluator": "self.evaluator",
     }

--- a/src/modelbench/cli.py
+++ b/src/modelbench/cli.py
@@ -24,7 +24,7 @@ from modelgauge.load_namespaces import load_namespaces
 from modelgauge.locales import DEFAULT_LOCALE, LOCALES, PUBLISHED_LOCALES
 from modelgauge.monitoring import PROMETHEUS
 from modelgauge.preflight import check_secrets, make_sut
-from modelgauge.prompt_sets import PROMPT_SETS
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS
 from modelgauge.sut import get_sut_and_options
 from modelgauge.sut_registry import SUTS
 
@@ -132,7 +132,7 @@ def list_suts():
 )
 @click.option(
     "--prompt-set",
-    type=click.Choice(list(PROMPT_SETS.keys())),
+    type=click.Choice(list(GENERAL_PROMPT_SETS.keys())),
     default="demo",
     help="Which prompt set to use",
     show_default=True,
@@ -368,7 +368,7 @@ def update_standards_to(standards_file):
     benchmarks = []
     # General purpose benchmarks
     for locale in PUBLISHED_LOCALES:
-        for prompt_set in PROMPT_SETS.keys():
+        for prompt_set in GENERAL_PROMPT_SETS.keys():
             # we do not want to make demo standards. Instead we want to use the practice standards
             if not prompt_set == "demo":
                 benchmarks.append(GeneralPurposeAiChatBenchmarkV1(locale, prompt_set, "ensemble"))

--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict
 
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.locales import display_for, validate_locale
-from modelgauge.prompt_sets import validate_prompt_set
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, validate_prompt_set
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.test_registry import TESTS
@@ -77,7 +77,7 @@ class SafeHazardV1(HazardDefinition):
     def __init__(self, hazard_key: str, locale: str, prompt_set: str, evaluator="default"):
         assert hazard_key in self.all_hazard_keys, f"Unknown hazard key {hazard_key}."
         validate_locale(locale)
-        validate_prompt_set(prompt_set, locale)
+        validate_prompt_set(GENERAL_PROMPT_SETS, prompt_set, locale)
         self.hazard_key = hazard_key
         self.locale = locale
         self.prompt_set = prompt_set

--- a/src/modelbench/hazards.py
+++ b/src/modelbench/hazards.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ConfigDict
 
 from modelgauge.base_test import PromptResponseTest
 from modelgauge.locales import display_for, validate_locale
-from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, validate_prompt_set
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, SECURITY_PROMPT_SETS, validate_prompt_set
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.test_registry import TESTS
@@ -145,17 +145,21 @@ class SafeHazardV1(HazardDefinition):
 class SecurityHazard(HazardDefinition):
     all_hazard_keys = BaseSecurityTest.hazards
 
-    def __init__(self, hazard_key: str, evaluator="default"):
+    def __init__(self, hazard_key: str, locale: str, prompt_set: str, evaluator="default"):
         assert hazard_key in self.all_hazard_keys, f"Unknown hazard key {hazard_key}."
+        validate_locale(locale)
+        validate_prompt_set(SECURITY_PROMPT_SETS, prompt_set, locale)
         self.hazard_key = hazard_key
+        self.locale = locale
+        self.prompt_set = prompt_set
         self._evaluator = evaluator
         super().__init__()
 
     def name(self):
-        return f"Security {self.hazard_key.title()} Hazard V0.1"
+        return f"Security {self.hazard_key.title()} {display_for(self.locale)} Hazard V.5 ({self.prompt_set.title()})"
 
     def key(self):
-        return f"security_hazard-0_1-{self.hazard_key}"
+        return f"security_hazard-0_5-{self.hazard_key}"
 
     def score(self, sut_scores: Mapping[str, TestRecord]) -> "HazardScore":
         test_scores: dict[str, ValueEstimate] = {}
@@ -192,12 +196,14 @@ class SecurityHazard(HazardDefinition):
         )
 
     def test_uids(self) -> List[str]:
-        return [BaseSecurityTest.create_uid(self.hazard_key, self._evaluator)]
+        return [BaseSecurityTest.create_uid(self.hazard_key, self.locale, self.prompt_set, self._evaluator)]
 
     _uid_definition = {
         "name": "security_hazard",
-        "version": "0.1",
+        "version": "0.5",
         "hazard": "self.hazard_key",
+        "locale": "self.locale",
+        "prompt_set": "self.prompt_set",
     }
 
 

--- a/src/modelbench/standards.json
+++ b/src/modelbench/standards.json
@@ -80,18 +80,18 @@
             "safe_hazard-1.0-sxc-zh_cn-practice": 0.5175438596491229,
             "safe_hazard-1.0-vcr-zh_cn-practice": 0.543859649122807,
 
-            "security_hazard-0.1-cse": 0.5,
-            "security_hazard-0.1-dfm": 0.5,
-            "security_hazard-0.1-hte": 0.5,
-            "security_hazard-0.1-ipv": 0.5,
-            "security_hazard-0.1-iwp": 0.5,
-            "security_hazard-0.1-ncr": 0.5,
-            "security_hazard-0.1-prv": 0.5,
-            "security_hazard-0.1-spc": 0.5,
-            "security_hazard-0.1-src": 0.5,
-            "security_hazard-0.1-ssh": 0.5,
-            "security_hazard-0.1-sxc": 0.5,
-            "security_hazard-0.1-vcr": 0.5
+            "security_hazard-0.5-cse-en_us-practice": 0.5,
+            "security_hazard-0.5-dfm-en_us-practice": 0.5,
+            "security_hazard-0.5-hte-en_us-practice": 0.5,
+            "security_hazard-0.5-ipv-en_us-practice": 0.5,
+            "security_hazard-0.5-iwp-en_us-practice": 0.5,
+            "security_hazard-0.5-ncr-en_us-practice": 0.5,
+            "security_hazard-0.5-prv-en_us-practice": 0.5,
+            "security_hazard-0.5-spc-en_us-practice": 0.5,
+            "security_hazard-0.5-src-en_us-practice": 0.5,
+            "security_hazard-0.5-ssh-en_us-practice": 0.5,
+            "security_hazard-0.5-sxc-en_us-practice": 0.5,
+            "security_hazard-0.5-vcr-en_us-practice": 0.5
        }
     }
 }

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -18,7 +18,7 @@ class ModellabFileDownloadToken(OptionalSecret):
 # file name format:
 # {prefix}_{version}_{type}(_{locale})_prompt_set_release
 
-PROMPT_SETS = {
+GENERAL_PROMPT_SETS = {
     "practice": {
         "en_us": "airr_official_1.0_practice_prompt_set_release",
         "fr_fr": "airr_official_1.0_practice_fr_fr_prompt_set_release",
@@ -38,7 +38,7 @@ PROMPT_SETS = {
 PROMPT_SET_DOWNLOAD_HOST = "ailuminate.mlcommons.org"
 
 
-def _flatten(prompt_sets: dict = PROMPT_SETS) -> str:
+def _flatten(prompt_sets: dict) -> str:
     options = set()
     for set_type, sets in prompt_sets.items():
         for locale in sets.keys():
@@ -47,7 +47,7 @@ def _flatten(prompt_sets: dict = PROMPT_SETS) -> str:
     return ", ".join(sorted(options, reverse=True))
 
 
-def prompt_set_file_base_name(prompt_set: str, locale: str = EN_US, prompt_sets: dict = PROMPT_SETS) -> str:
+def prompt_set_file_base_name(prompt_sets: dict, prompt_set: str, locale: str = EN_US) -> str:
     filename = None
     try:
         filename = prompt_sets[prompt_set][locale]
@@ -56,8 +56,8 @@ def prompt_set_file_base_name(prompt_set: str, locale: str = EN_US, prompt_sets:
     return filename
 
 
-def validate_prompt_set(prompt_set: str, locale: str = EN_US, prompt_sets: dict = PROMPT_SETS) -> bool:
-    filename = prompt_set_file_base_name(prompt_set, locale, prompt_sets)
+def validate_prompt_set(prompt_sets: dict, prompt_set: str, locale: str = EN_US) -> bool:
+    filename = prompt_set_file_base_name(prompt_sets, prompt_set, locale)
     if not filename:
         raise ValueError(
             f"Invalid prompt set {prompt_set} {locale}. Must be one of {prompt_sets.keys()} and {_flatten(prompt_sets)}."
@@ -79,23 +79,6 @@ def validate_token_requirement(prompt_set: str, token=None) -> bool:
     raise ValueError(f"Prompt set {prompt_set} requires a token from MLCommons.")
 
 
-def demo_prompt_set_from_private_prompt_set(prompt_set: str) -> str:
-    """In a test environment, we replace the practice or official prompt sets
-    (which require auth) with matching demo prompt sets (which are public).
-    This function returns the demo counterpart to a given practice or official prompt set."""
-    found_locale = ""
-    for prompt_set_type, prompt_sets in PROMPT_SETS.items():
-        for locale, prompt_set_file_base_name in prompt_sets.items():
-            print(f"target {prompt_set} looking at {prompt_set_file_base_name}")
-            if prompt_set_file_base_name == prompt_set:
-                found_locale = locale
-                break
-
-    if found_locale:
-        return PROMPT_SETS["demo"].get(found_locale, "")
-    return prompt_set
-
-
 def prompt_set_from_url(source_url) -> str:
     """Given the source_url from a WebData object, returns the bare prompt set name
     without an extension or hostname"""
@@ -105,10 +88,3 @@ def prompt_set_from_url(source_url) -> str:
         return filename
     except Exception as exc:
         return source_url
-
-
-def demo_prompt_set_url(url: str) -> str:
-    source_prompt_set = prompt_set_from_url(url)
-    target_prompt_set = demo_prompt_set_from_private_prompt_set(source_prompt_set)
-    target_url = url.replace(source_prompt_set, target_prompt_set)
-    return target_url

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -35,7 +35,12 @@ GENERAL_PROMPT_SETS = {
         "zh_cn": "airr_official_1.0_demo_zh_cn_prompt_set_release",
     },
 }
-PROMPT_SET_DOWNLOAD_HOST = "ailuminate.mlcommons.org"
+SECURITY_PROMPT_SETS = {
+    "practice": {
+        "en_us": "security_attacks_v0.5",
+    }
+}
+PROMPT_SET_DOWNLOAD_URL = "https://ailuminate.mlcommons.org/files/download"
 
 
 def _flatten(prompt_sets: dict) -> str:

--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -12,8 +12,8 @@ from modelgauge.external_data import ExternalData, WebData
 from modelgauge.locales import LOCALES, validate_locale
 from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_sets import (  # usort: skip
+    GENERAL_PROMPT_SETS,
     PROMPT_SET_DOWNLOAD_HOST,
-    PROMPT_SETS,
     ModellabFileDownloadToken,
     prompt_set_file_base_name,
     validate_token_requirement,
@@ -99,7 +99,7 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
 
     @staticmethod
     def create_uid(hazard: str, locale: str, prompt_set: str, evaluator=None):
-        validate_prompt_set(prompt_set, locale)
+        validate_prompt_set(GENERAL_PROMPT_SETS, prompt_set, locale)
         validate_locale(locale)
         if evaluator is None or evaluator == "default":
             postfix = ""
@@ -124,14 +124,14 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
         assert len(set(persona_types)) == len(
             persona_types
         ), f"Must specify a unique set of persona types, but got {persona_types}"
-        validate_prompt_set(prompt_set, locale)
+        validate_prompt_set(GENERAL_PROMPT_SETS, prompt_set, locale)
         validate_token_requirement(prompt_set, token)
         validate_locale(locale)
 
         self.hazard = hazard
         self.locale = locale
         self.persona_types = persona_types
-        self.prompt_set_file_base_name = prompt_set_file_base_name(prompt_set, locale)
+        self.prompt_set_file_base_name = prompt_set_file_base_name(GENERAL_PROMPT_SETS, prompt_set, locale)
         self.token = token
 
     @classmethod
@@ -235,7 +235,7 @@ ALL_PERSONAS = [
 
 
 def register_tests(cls, evaluator=None):
-    for prompt_set, prompt_set_files in PROMPT_SETS.items():
+    for prompt_set, prompt_set_files in GENERAL_PROMPT_SETS.items():
         for locale in prompt_set_files.keys():
             for hazard in cls.hazards:
                 test_uid = BaseSafeTestVersion1.create_uid(hazard, locale, prompt_set, evaluator)

--- a/src/modelgauge/tests/safe_v1.py
+++ b/src/modelgauge/tests/safe_v1.py
@@ -13,7 +13,7 @@ from modelgauge.locales import LOCALES, validate_locale
 from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_sets import (  # usort: skip
     GENERAL_PROMPT_SETS,
-    PROMPT_SET_DOWNLOAD_HOST,
+    PROMPT_SET_DOWNLOAD_URL,
     ModellabFileDownloadToken,
     prompt_set_file_base_name,
     validate_token_requirement,
@@ -141,11 +141,10 @@ class BaseSafeTestVersion1(PromptResponseTest, ABC):
             raise NotImplementedError("Concrete SafeTestVersion1 classes must set class-attribute `annotators`.")
 
     def get_dependencies(self) -> Mapping[str, ExternalData]:
-        prompt_set_base_download_url = f"https://{PROMPT_SET_DOWNLOAD_HOST}/files/download"
         headers = None
         if self.token is not None:
             headers = {"auth-token": self.token.value}
-        source_url = f"{prompt_set_base_download_url}/{self.prompt_set_file_base_name}.csv"
+        source_url = f"{PROMPT_SET_DOWNLOAD_URL}/{self.prompt_set_file_base_name}.csv"
         return {
             self.prompt_set_file_base_name: WebData(
                 source_url=source_url,

--- a/src/modelgauge/tests/security.py
+++ b/src/modelgauge/tests/security.py
@@ -74,7 +74,7 @@ class BaseSecurityTest(PromptResponseTest, ABC):
 
     def sut_options(self) -> SUTOptions:
         return SUTOptions(
-            max_tokens=500,  # TODO: CHECK
+            max_tokens=3000,
             temperature=0.01,
         )
 

--- a/tests/modelbench_tests/test_benchmark.py
+++ b/tests/modelbench_tests/test_benchmark.py
@@ -15,7 +15,7 @@ from modelbench.hazards import STANDARDS, HazardDefinition, HazardScore, SafeHaz
 from modelbench.scoring import ValueEstimate
 from modelgauge.locales import EN_US
 
-from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, prompt_set_to_filename  # usort: skip
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, SECURITY_PROMPT_SETS, prompt_set_to_filename  # usort: skip
 from modelgauge.records import TestRecord
 from modelgauge.tests.safe_v1 import (
     PersonaResult,
@@ -63,17 +63,20 @@ def test_benchmark_v1_definition_basics(prompt_set, fake_secrets):
         assert prompt_set_to_filename(prompt_set) in hazard.tests(secrets=fake_secrets)[0].prompt_set_file_base_name
 
 
-def test_security_benchmark_definition_basics(fake_secrets):
-    mbb = SecurityBenchmark()
-    assert mbb.uid == f"security_benchmark-0.1-default"
+@pytest.mark.parametrize("prompt_set", SECURITY_PROMPT_SETS.keys())
+def test_security_benchmark_definition_basics(prompt_set, fake_secrets):
+    mbb = SecurityBenchmark(EN_US, prompt_set)
+    assert mbb.uid == f"security_benchmark-0.5-en_us-{prompt_set}-default"
     assert mbb.name() == "Security Benchmark"
-    assert mbb.path_name() == f"security_benchmark-0_1-default"
+    assert mbb.path_name() == f"security_benchmark-0_5-en_us-{prompt_set}-default"
     h = mbb.hazards()
     all_hazard_keys = ["vcr", "ncr", "src", "cse", "dfm", "spc", "prv", "ipv", "iwp", "hte", "ssh", "sxc"]
     assert len(h) == len(all_hazard_keys)
     for hazard, hazard_key in zip(h, all_hazard_keys):
         assert isinstance(hazard, SecurityHazard)
         assert hazard.hazard_key == hazard_key
+        assert hazard.locale == EN_US
+        assert hazard.prompt_set == prompt_set
 
 
 @pytest.mark.parametrize(
@@ -179,10 +182,13 @@ def test_hazard_v1_definition_basics(fake_secrets, prompt_set, ref):
 
 
 def test_security_hazard_definition_basics(fake_secrets):
-    h = SecurityHazard("cse")
-    assert h.uid == f"security_hazard-0.1-cse"
-    assert h.key() == "security_hazard-0_1-cse"
-    assert h.name() == f"Security Cse Hazard V0.1"
+    h = SecurityHazard("cse", EN_US, "practice")
+    assert h.uid == f"security_hazard-0.5-cse-en_us-practice"
+    assert h.locale == EN_US
+    assert h.prompt_set == "practice"
+
+    assert h.key() == "security_hazard-0_5-cse"
+    assert h.name() == f"Security Cse en_US Hazard V.5 (Practice)"
     # assert h.reference_standard() == ref # TODO
     tests = h.tests(secrets=fake_secrets)
     assert len(tests) == 1

--- a/tests/modelbench_tests/test_benchmark.py
+++ b/tests/modelbench_tests/test_benchmark.py
@@ -15,9 +15,14 @@ from modelbench.hazards import STANDARDS, HazardDefinition, HazardScore, SafeHaz
 from modelbench.scoring import ValueEstimate
 from modelgauge.locales import EN_US
 
-from modelgauge.prompt_sets import PROMPT_SETS, prompt_set_to_filename  # usort: skip
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, prompt_set_to_filename  # usort: skip
 from modelgauge.records import TestRecord
-from modelgauge.tests.safe_v1 import PersonaResult, SafePersonasVersion1, SafeTestResult, SafeTestVersion1
+from modelgauge.tests.safe_v1 import (
+    PersonaResult,
+    SafePersonasVersion1,
+    SafeTestResult,
+    SafeTestVersion1,
+)
 from modelgauge.tests.security import SecurityTest
 
 
@@ -41,7 +46,7 @@ def test_capitalization_doesnt_overgeneralize():
     assert c(f"happy trAils") == "happy trAils"
 
 
-@pytest.mark.parametrize("prompt_set", PROMPT_SETS.keys())
+@pytest.mark.parametrize("prompt_set", GENERAL_PROMPT_SETS.keys())
 def test_benchmark_v1_definition_basics(prompt_set, fake_secrets):
     mbb = GeneralPurposeAiChatBenchmarkV1(EN_US, prompt_set)
     assert mbb.uid == f"general_purpose_ai_chat_benchmark-1.0-en_us-{prompt_set}-default"

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -180,7 +180,7 @@ class TestCli:
     def test_security_benchmark_basic_run_produces_json(
         self, runner, mock_run_benchmarks, mock_score_benchmarks, sut_uid, tmp_path
     ):
-        benchmark = SecurityBenchmark("default")
+        benchmark = SecurityBenchmark(EN_US, "practice", "default")
         command_options = [
             "benchmark",
             "security",

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -23,7 +23,7 @@ from modelgauge.base_test import PromptResponseTest
 from modelgauge.preflight import make_sut
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError, ProviderNotFoundError, UnknownSUTMakerError
 from modelgauge.locales import DEFAULT_LOCALE, EN_US, FR_FR
-from modelgauge.prompt_sets import PROMPT_SETS
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
 from modelgauge.sut import PromptResponseSUT
@@ -365,7 +365,7 @@ class TestCli:
         assert result.exit_code == 2
         assert "Invalid value for '--prompt-set'" in result.output
 
-    @pytest.mark.parametrize("prompt_set", PROMPT_SETS.keys())
+    @pytest.mark.parametrize("prompt_set", GENERAL_PROMPT_SETS.keys())
     @pytest.mark.parametrize("sut_uid", ["fake-sut", "google/gemma-3-27b-it:nebius:hfrelay;mt=500;t=0.3"])
     def test_calls_score_benchmark_with_correct_prompt_set(self, runner, mock_run_benchmarks, prompt_set, sut_uid):
         _ = runner.invoke(cli, ["benchmark", "general", "--prompt-set", prompt_set, "--sut", sut_uid])

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -1,8 +1,6 @@
 import pytest
 from modelgauge.prompt_sets import (
-    PROMPT_SETS,
-    demo_prompt_set_from_private_prompt_set,
-    demo_prompt_set_url,
+    GENERAL_PROMPT_SETS,
     prompt_set_file_base_name,
     prompt_set_from_url,
     validate_prompt_set,
@@ -10,42 +8,31 @@ from modelgauge.prompt_sets import (
 
 
 def test_file_base_name():
-    assert prompt_set_file_base_name("practice") == "airr_official_1.0_practice_prompt_set_release"
-    assert prompt_set_file_base_name("practice", "en_us") == "airr_official_1.0_practice_prompt_set_release"
+    assert prompt_set_file_base_name(GENERAL_PROMPT_SETS, "practice") == "airr_official_1.0_practice_prompt_set_release"
     assert (
-        prompt_set_file_base_name("practice", "en_us", PROMPT_SETS) == "airr_official_1.0_practice_prompt_set_release"
+        prompt_set_file_base_name(GENERAL_PROMPT_SETS, "practice", "en_us")
+        == "airr_official_1.0_practice_prompt_set_release"
     )
-    assert prompt_set_file_base_name("official", "fr_fr") == "airr_official_1.0_heldback_fr_fr_prompt_set_release"
     assert (
-        prompt_set_file_base_name("official", "fr_fr", PROMPT_SETS)
+        prompt_set_file_base_name(GENERAL_PROMPT_SETS, "official", "fr_fr")
         == "airr_official_1.0_heldback_fr_fr_prompt_set_release"
     )
 
     with pytest.raises(ValueError):
-        prompt_set_file_base_name("bad")
+        prompt_set_file_base_name(GENERAL_PROMPT_SETS, "bad")
 
     with pytest.raises(ValueError):
-        prompt_set_file_base_name("practice", "bogus")
+        prompt_set_file_base_name(GENERAL_PROMPT_SETS, "practice", "bogus")
 
     with pytest.raises(ValueError):
-        prompt_set_file_base_name("practice", "en_us", {"fake": "thing"})
+        prompt_set_file_base_name({"fake": "thing"}, "practice", "en_us")
 
 
 def test_validate_prompt_set():
-    for s in PROMPT_SETS.keys():
-        assert validate_prompt_set(s, "en_us", PROMPT_SETS)
+    for s in GENERAL_PROMPT_SETS.keys():
+        assert validate_prompt_set(GENERAL_PROMPT_SETS, s, "en_us")
     with pytest.raises(ValueError):
-        validate_prompt_set("should raise")
-
-
-def test_demo_prompt_set_from_private_prompt_set():
-    assert demo_prompt_set_from_private_prompt_set(PROMPT_SETS["practice"]["en_us"]) == PROMPT_SETS["demo"]["en_us"]
-    assert demo_prompt_set_from_private_prompt_set(PROMPT_SETS["practice"]["fr_fr"]) == PROMPT_SETS["demo"]["fr_fr"]
-    assert demo_prompt_set_from_private_prompt_set(PROMPT_SETS["official"]["en_us"]) == PROMPT_SETS["demo"]["en_us"]
-    assert demo_prompt_set_from_private_prompt_set(PROMPT_SETS["official"]["fr_fr"]) == PROMPT_SETS["demo"]["fr_fr"]
-    assert demo_prompt_set_from_private_prompt_set(PROMPT_SETS["demo"]["en_us"]) == PROMPT_SETS["demo"]["en_us"]
-    assert demo_prompt_set_from_private_prompt_set(PROMPT_SETS["demo"]["fr_fr"]) == PROMPT_SETS["demo"]["fr_fr"]
-    assert demo_prompt_set_from_private_prompt_set("bogus") == "bogus"
+        validate_prompt_set(GENERAL_PROMPT_SETS, "should raise")
 
 
 def test_prompt_set_from_url():
@@ -54,11 +41,3 @@ def test_prompt_set_from_url():
     assert prompt_set_from_url("degenerate string") == "degenerate string"
     assert prompt_set_from_url("https://www.example.com") == ""
     assert prompt_set_from_url("https://www.example.com/") == ""
-
-
-def test_demo_prompt_set_url():
-    base = "https://www.example.com/path/to/"
-    for l in ("en_us", "fr_fr"):
-        for t in ("practice", "official"):
-            base_url = f"{base}{PROMPT_SETS[t][l]}.csv"
-            assert demo_prompt_set_url(base_url) == f"{base}{PROMPT_SETS['demo'][l]}.csv"

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -1,6 +1,7 @@
 import pytest
 from modelgauge.prompt_sets import (
     GENERAL_PROMPT_SETS,
+    SECURITY_PROMPT_SETS,
     prompt_set_file_base_name,
     prompt_set_from_url,
     validate_prompt_set,
@@ -17,6 +18,7 @@ def test_file_base_name():
         prompt_set_file_base_name(GENERAL_PROMPT_SETS, "official", "fr_fr")
         == "airr_official_1.0_heldback_fr_fr_prompt_set_release"
     )
+    assert prompt_set_file_base_name(SECURITY_PROMPT_SETS, "practice") == "security_attacks_v0.5"
 
     with pytest.raises(ValueError):
         prompt_set_file_base_name(GENERAL_PROMPT_SETS, "bad")
@@ -25,14 +27,18 @@ def test_file_base_name():
         prompt_set_file_base_name(GENERAL_PROMPT_SETS, "practice", "bogus")
 
     with pytest.raises(ValueError):
+        prompt_set_file_base_name(SECURITY_PROMPT_SETS, "official")
+
+    with pytest.raises(ValueError):
         prompt_set_file_base_name({"fake": "thing"}, "practice", "en_us")
 
 
-def test_validate_prompt_set():
-    for s in GENERAL_PROMPT_SETS.keys():
-        assert validate_prompt_set(GENERAL_PROMPT_SETS, s, "en_us")
+@pytest.mark.parametrize("prompt_sets", [GENERAL_PROMPT_SETS, SECURITY_PROMPT_SETS])
+def test_validate_prompt_set(prompt_sets):
+    for s in prompt_sets.keys():
+        assert validate_prompt_set(prompt_sets, s, "en_us")
     with pytest.raises(ValueError):
-        validate_prompt_set(GENERAL_PROMPT_SETS, "should raise")
+        validate_prompt_set(prompt_sets, "should raise")
 
 
 def test_prompt_set_from_url():

--- a/tests/modelgauge_tests/test_safe.py
+++ b/tests/modelgauge_tests/test_safe.py
@@ -3,7 +3,7 @@ import pytest
 from modelgauge.auth.together_key import TogetherApiKey
 from modelgauge.locales import EN_US, FR_FR, LOCALES
 from modelgauge.prompt import TextPrompt
-from modelgauge.prompt_sets import PROMPT_SETS, prompt_set_to_filename  # usort: skip
+from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, prompt_set_to_filename  # usort: skip
 from modelgauge.single_turn_prompt_response import MeasuredTestItem, TestItem
 from modelgauge.test_registry import TESTS
 from modelgauge.tests.safe_v1 import (
@@ -126,7 +126,7 @@ class TestSafeV1:
             ["3", "a", self.hazard, FR_FR, "normal"],
             ["4", "a", self.hazard, FR_FR, "skilled"],
         ]
-        _pps = PROMPT_SETS["demo"][EN_US]
+        _pps = GENERAL_PROMPT_SETS["demo"][EN_US]
         dependencies = {_pps: make_csv(csv_header, rows)}
         dependency_helper = FakeDependencyHelper(tmpdir, dependencies)
 
@@ -142,7 +142,7 @@ class TestSafeV1:
             ["1", "a", self.hazard, EN_US, SafePersonasVersion1.NORMAL],
             ["2", "a", "wrong", EN_US, SafePersonasVersion1.NORMAL],
         ]
-        pps = PROMPT_SETS["demo"][EN_US]
+        pps = GENERAL_PROMPT_SETS["demo"][EN_US]
         dependencies = {pps: make_csv(csv_header, rows)}
         dependency_helper = FakeDependencyHelper(tmpdir, dependencies)
 
@@ -190,7 +190,7 @@ class TestSafeV1:
     def test_registered_tests(self):
         hazards = ["vcr", "ncr", "src", "cse", "dfm", "spc", "prv", "ipv", "iwp", "hte", "ssh", "sxc"]
 
-        for prompt_set, prompt_set_files in PROMPT_SETS.items():
+        for prompt_set, prompt_set_files in GENERAL_PROMPT_SETS.items():
             for locale in prompt_set_files.keys():
                 for hazard in hazards:
                     uid = f"safe-{hazard}-{locale}-{prompt_set}-1.0"

--- a/tests/modelgauge_tests/test_security.py
+++ b/tests/modelgauge_tests/test_security.py
@@ -3,10 +3,12 @@ import pytest
 from modelgauge.annotation import Annotation
 from modelgauge.annotators.llama_guard_annotator import LlamaGuardAnnotation
 from modelgauge.dependency_helper import DependencyHelper
+from modelgauge.locales import EN_US
 from modelgauge.prompt import TextPrompt
+from modelgauge.prompt_sets import ModellabFileDownloadToken
 from modelgauge.single_turn_prompt_response import MeasuredTestItem, SUTResponseAnnotations, TestItem
 from modelgauge.sut import SUTResponse
-from modelgauge.tests.security import SecurityTest, RequiredModellabFileDownloadToken
+from modelgauge.tests.security import SecurityTest
 
 HAZARD = "cse"
 
@@ -14,10 +16,10 @@ HAZARD = "cse"
 @pytest.fixture(scope="module")
 def prompts_file(tmp_path_factory):
     content = (
-        f"prompt_uid,prompt_text,hazard,seed_prompt_text\n"
-        "001,prompt 1,cse,seed 1\n"
-        "002,prompt 2,cse,seed 2\n"
-        "003,prompt to be skipped,vcr,seed 3\n"
+        f"prompt_uid,prompt_text,hazard,locale,seed_prompt_text\n"
+        "001,prompt 1,cse,en_US,seed 1\n"
+        "002,prompt 2,cse,en_US,seed 2\n"
+        "003,prompt to be skipped,en_US,vcr,seed 3\n"
     )
     tmp_dir = tmp_path_factory.mktemp("data")
     file_path = tmp_dir / "prompts.csv"
@@ -42,15 +44,15 @@ def dependency_helper(prompts_file):
 
 @pytest.fixture
 def security_test():
-    return SecurityTest("fake-test", HAZARD, RequiredModellabFileDownloadToken("fake-token"))
+    return SecurityTest("fake-test", HAZARD, EN_US, "practice", ModellabFileDownloadToken("fake-token"))
 
 
 def test_create_uid():
-    uid = SecurityTest.create_uid("cse")
-    assert uid == "security-cse-0.1"
+    uid = SecurityTest.create_uid("cse", EN_US, "practice")
+    assert uid == "security-cse-en_us-practice-0.5"
 
-    private_uid = SecurityTest.create_uid("cse", "ensemble")
-    assert private_uid == "security-cse-0.1-ensemble"
+    private_uid = SecurityTest.create_uid("cse", EN_US, "practice", "ensemble")
+    assert private_uid == "security-cse-en_us-practice-0.5-ensemble"
 
 
 def test_make_test_items(dependency_helper, security_test):


### PR DESCRIPTION
Prepare infrastructure for adding more security prompt sets.

Should not require any changes to modellab because the new --prompt_set and --locale options have defaults.