### PR TITLE
security annotator ready check

### DIFF
--- a/src/modelgauge/annotator.py
+++ b/src/modelgauge/annotator.py
@@ -1,10 +1,10 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
 from modelgauge.ready import Readyable, ReadyResponse
-from modelgauge.single_turn_prompt_response import TestItem
+from modelgauge.single_turn_prompt_response import SecurityContext, TestItem
 from modelgauge.sut import _READINESS_CHECK_TEXT_PROMPT, SUTResponse
 from modelgauge.tracked_object import TrackedObject
 
@@ -50,3 +50,18 @@ class CompletionAnnotator(Annotator, Generic[AnnotationType], Readyable):
     def translate_response(self, request, response) -> AnnotationType:
         """Convert the raw response into the form read by Tests."""
         pass
+
+
+class SecurityAnnotator(CompletionAnnotator[AnnotationType], ABC):
+    """Security annotators require a seed prompt in the context."""
+
+    def run_readiness_check(self) -> ReadyResponse:
+        test_item = TestItem(
+            prompt=_READINESS_CHECK_TEST_ITEM.prompt,
+            source_id=_READINESS_CHECK_TEST_ITEM.source_id,
+            context=SecurityContext(seed_prompt="This is sent to annotator"),
+        )
+        raw_request = self.translate_request(test_item, _READINESS_CHECK_SUT_RESPONSE)
+        raw_response = self.annotate(raw_request)
+        response = self.translate_response(raw_request, raw_response)
+        return ReadyResponse(is_ready=bool(response), response=response)

--- a/src/modelgauge/annotators/prompt_engineered_annotator.py
+++ b/src/modelgauge/annotators/prompt_engineered_annotator.py
@@ -3,7 +3,7 @@ from typing import Optional, Union
 
 from pydantic import BaseModel
 
-from modelgauge.annotator import CompletionAnnotator
+from modelgauge.annotator import CompletionAnnotator, SecurityAnnotator
 from modelgauge.prompt import ChatMessage, ChatPrompt, ChatRole, TextPrompt
 from modelgauge.safety_model_response import SafetyModelResponse
 from modelgauge.single_turn_prompt_response import TestItem
@@ -147,7 +147,7 @@ class PromptEngineeredAnnotator(CompletionAnnotator[SafetyModelResponse]):
             )
 
 
-class PromptEngineeredSecurityAnnotator(PromptEngineeredAnnotator):
+class PromptEngineeredSecurityAnnotator(SecurityAnnotator, PromptEngineeredAnnotator):
     """Pass the seed prompt to the annotator instead of the actual attack prompt that is passed to the SUT."""
 
     @staticmethod

--- a/src/modelgauge/single_turn_prompt_response.py
+++ b/src/modelgauge/single_turn_prompt_response.py
@@ -51,6 +51,11 @@ class TestItem(BaseModel):
         super().__init__(prompt=prompt, source_id=source_id, context_internal=internal)
 
 
+class SecurityContext(BaseModel):
+    # I think we should eventually make a new type of TestItem specific to security.
+    seed_prompt: str  # This is what should get passed to the evaluator.
+
+
 class SUTResponseAnnotations(BaseModel):
     """The annotations for a SUT Response to a single TestItem."""
 

--- a/src/modelgauge/tests/security.py
+++ b/src/modelgauge/tests/security.py
@@ -21,16 +21,12 @@ from modelgauge.prompt_sets import (
     validate_prompt_set,
 )
 from modelgauge.secret_values import InjectSecret
-from modelgauge.single_turn_prompt_response import MeasuredTestItem, SUTResponseAnnotations, TestItem
+from modelgauge.single_turn_prompt_response import MeasuredTestItem, SecurityContext, SUTResponseAnnotations, TestItem
 from modelgauge.sut import SUTOptions
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.tests.safe_v1 import Hazards
 from modelgauge.test_decorator import modelgauge_test
 from modelgauge.test_registry import TESTS
-
-
-class SecurityContext(BaseModel):
-    seed_prompt: str  # This is what should get passed to the evaluator.
 
 
 class SecurityTestResult(BaseModel):


### PR DESCRIPTION
Security annotators require a context item and therefore special checks.