### PR TITLE
Speed up tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,11 @@
 import copy
 import importlib
 import sys
+import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Dict
+from unittest import mock
 
 import pytest
 
@@ -71,3 +73,12 @@ def pytest_sessionstart(session):
     mg_config.load_secrets_from_config = new_func
     if "modelgauge.sut_factory" in sys.modules:
         importlib.reload(sys.modules["modelgauge.sut_factory"])
+
+
+actual_time_sleep = time.sleep
+
+
+@pytest.fixture(scope="session", autouse=True)
+def sleep_faster():
+    with mock.patch("time.sleep", lambda x: actual_time_sleep(x / 100000)) as _fixture:
+        yield _fixture

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -2,12 +2,13 @@ import json
 import math
 from datetime import datetime
 from typing import List, Mapping, Sequence
+from unittest import mock
 from unittest.mock import MagicMock, patch
-
-import modelbench
 
 import pytest
 from click.testing import CliRunner
+
+import modelbench
 from modelbench.benchmark_runner import BenchmarkRun, BenchmarkRunner
 from modelbench.benchmarks import (
     BenchmarkDefinition,
@@ -15,14 +16,14 @@ from modelbench.benchmarks import (
     GeneralPurposeAiChatBenchmarkV1,
     SecurityBenchmark,
 )
-from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1, Standards
 from modelbench.cli import cli
+from modelbench.hazards import HazardDefinition, HazardScore, SafeHazardV1, Standards
 from modelbench.scoring import ValueEstimate
 from modelbench.standards import NoStandardsFileError, OverwriteStandardsFileError
 from modelgauge.base_test import PromptResponseTest
-from modelgauge.preflight import make_sut
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError, ProviderNotFoundError, UnknownSUTMakerError
 from modelgauge.locales import DEFAULT_LOCALE, EN_US, FR_FR, ZH_CN
+from modelgauge.preflight import make_sut
 from modelgauge.prompt_sets import GENERAL_PROMPT_SETS
 from modelgauge.records import TestRecord
 from modelgauge.secret_values import RawSecrets
@@ -78,6 +79,15 @@ def standards_path_patch(monkeypatch, tmp_path):
         classmethod(lambda cls, uid: path),
     )
     return path
+
+
+@pytest.fixture(scope="module", autouse=True)
+def fast_metadata():
+    # Getting the benchmark metadata involves a lot of external processes, which slows our runs down quite a bit
+    with mock.patch(
+        "modelbench.record.benchmark_library_info", lambda: {"skipped by": "test_run.fast_metadata"}
+    ) as _fixture:
+        yield _fixture
 
 
 class TestCli:


### PR DESCRIPTION
Our tests had gotten up to 3 minutes of runtime. This brings them back down to around 10 seconds, albeit in dubious ways. Are they too dubious? Let me know.