### PR TITLE
Allow SUTs to return empty strings

### DIFF
--- a/tests/modelgauge_tests/test_object_creation.py
+++ b/tests/modelgauge_tests/test_object_creation.py
@@ -132,7 +132,7 @@ def test_all_suts_can_evaluate(sut_name):
     native_response = sut.evaluate(native_request)
     response = sut.translate_response(native_request, native_response)
     assert isinstance(response, SUTResponse)
-    assert response.text.strip() != ""
+    assert response.text is not None
 
 
 @expensive_tests


### PR DESCRIPTION
This change was made primarily to handle reasoning SUTs, which will return empty strings if max_tokens is too small to generate non-thinking text.

Let me know if this is the right approach. I personally don't think we should be testing with max_tokens in the 1000s because a) slow and expensive and b) there's still no guarantee that a reasoning SUT will return non-thinking text.