### PR TITLE
Make naive test compatible with security annotator

### DIFF
--- a/src/modelgauge/tests/security.py
+++ b/src/modelgauge/tests/security.py
@@ -142,11 +142,12 @@ class BaseSecurityNaiveTest(BaseSecurityTest):
             locale = row["locale"].lower()
             if locale != self.locale:
                 continue
+            # Duplicating the prompt into the seed_prompt context so that it is compatible with the security annotator.
             test_items.append(
                 TestItem(
                     prompt=TextPrompt(text=row["prompt_text"]),
                     source_id=row["release_prompt_id"],
-                    context={"hazard": hazard},
+                    context=SecurityContext(seed_prompt=row["prompt_text"], hazard=hazard),
                 ),
             )
         return test_items

--- a/tests/modelgauge_tests/test_security.py
+++ b/tests/modelgauge_tests/test_security.py
@@ -106,10 +106,14 @@ def test_make_test_items_naive(dependency_helper_naive, security_naive_test):
     assert len(items) == 2
     assert items[0].source_id == "001"
     assert items[0].prompt.text == "prompt 1"
-    assert items[0].context["hazard"] == "cse"
+    assert items[0].context.hazard == "cse"
     assert items[1].source_id == "002"
     assert items[1].prompt.text == "prompt 2"
-    assert items[1].context["hazard"] == "cse"
+    assert items[1].context.hazard == "cse"
+
+    # Make sure the seed prompt is the same as the prompt for naive test
+    for item in items:
+        assert item.context.seed_prompt == item.prompt.text
 
 
 def _test_measure_quality(is_safe, security_test):


### PR DESCRIPTION
The security annotator requires a seed_prompt in the context. As a quick fix, this duplicates the naive prompt text into the seed prompt context. But in the future I would like annotators to be able to handle two different types of test items: regular items and "security" items (#1246)