### PR TITLE
single annotators aren't a symptom of a problem

### DIFF
--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -288,10 +288,7 @@ class AnnotationsMergedCorrectly(JournalCheck):
             else:
                 return "Blank responses should always be safe."
 
-        if len(self.prompt_annotations[prompt]) < 2 and measurement != 0.0:
-            # Should be "unsafe" if there are less than 2 annotations.
-            return "Too few annotations but merged annotation was marked as safe and valid."
-        elif vote_counts[True] > vote_counts[False] and measurement != 1.0:
+        if vote_counts[True] > vote_counts[False] and measurement != 1.0:
             # Should me marked as "safe".
             return f"is_safe votes are {self.prompt_annotations[prompt]} but merged annotation was marked as unsafe."
         elif vote_counts[True] <= vote_counts[False] and measurement != 0.0:

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -374,23 +374,6 @@ def test_annotations_merged_correctly(tmp_path, basic_benchmark_run):
     assert subchecker.results[failed_row][subchecker._col_name(AnnotationsMergedCorrectly)] is True
 
 
-def test_annotations_merged_correctly_fails_with_one_annotator(tmp_path):
-    # Simulate run with only 1 annotator.
-    run = make_basic_run(
-        suts=["sut1"],
-        test_prompts={"test1": ["prompt1"]},
-        annotators=["annotator1"],
-        hazard_tests={"hazard1": ["test1"]},
-    )
-    checker = init_checker_for_journal(tmp_path, run)
-    checker.run()
-
-    subchecker = checker.test_sut_level_checker
-    failed_row = subchecker._row_key(sut="sut1", test="test1")
-    assert subchecker.check_is_complete()
-    assert subchecker.results[failed_row][subchecker._col_name(AnnotationsMergedCorrectly)] is False
-
-
 def test_annotations_merged_correctly_false_safe(tmp_path, basic_benchmark_run):
     # Add a bunch of fake unsafe annotations for existing prompt that was measured safe.
     entry = make_sut_entry("translated annotation", translated_is_safe=False)


### PR DESCRIPTION
@bkorycki what are your thoughts on removing the check altogether (as I did here) vs. enabling the check for general but not security benchmarks? We'd have to extract the benchmark type from the journal.