### PR TITLE
Journal all requests

### DIFF
--- a/docs/run-journal.md
+++ b/docs/run-journal.md
@@ -103,15 +103,18 @@ Listed in run order. If a message isn't listed here, its fields are covered abov
     - request - raw request sent to the SUT
     - response - raw response as received from the SUT
 - using cached sut response
+    - request - raw request sent to the SUT
     - response - the raw response as previously received from the SUT
 - translated sut response
     - response_text - the text of the SUT response
 - fetched annotator response
     - annotator - the uid of the Annotator
     - run_time - seconds taken to get the response
+    - request - formatted request sent to the annotator
     - response - raw response as received from the Annotator
 - using cached annotator response
     - annotator - the uid of the Annotator
+    - request - formatted request sent to the annotator
     - response - raw response as previously received from the Annotator
 - translated annotation
     - annotator - the uid of the Annotator

--- a/src/modelbench/benchmark_runner.py
+++ b/src/modelbench/benchmark_runner.py
@@ -305,7 +305,9 @@ class TestRunSutWorker(IntermediateCachingPipe):
             if cache_key in self.cache:
                 self._debug(f"cache entry found")
                 raw_response = self.cache[cache_key]
-                self.test_run.journal.item_entry("using cached sut response", item, response=raw_response)
+                self.test_run.journal.item_entry(
+                    "using cached sut response", item, request=raw_request, response=raw_response
+                )
                 CACHED_SUT_RESPONSES.inc()
             else:
                 self._debug(f"cache entry not found; processing and saving")
@@ -402,6 +404,7 @@ class TestRunAnnotationWorker(IntermediateCachingPipe):
                         "using cached annotator response",
                         item,
                         annotator=annotator.uid,
+                        annotator_request=annotator_request,
                         response=annotator_response,
                     )
                     CACHED_ANNOTATOR_RESPONSES.inc()
@@ -415,6 +418,7 @@ class TestRunAnnotationWorker(IntermediateCachingPipe):
                         item,
                         annotator=annotator.uid,
                         run_time=timer,
+                        request=annotator_request,
                         response=annotator_response,
                     )
                     FETCHED_ANNOTATOR_RESPONSES.inc()


### PR DESCRIPTION
We should be able to see which prompt was sent to an annotator.