### PR TITLE
run-job with jailbreak prompts

### DIFF
--- a/src/modelgauge/cli.py
+++ b/src/modelgauge/cli.py
@@ -304,8 +304,15 @@ def run_test(
 )
 @click.option("--tag", type=str, help="Tag to include in the output directory name.")
 @click.option("--debug", is_flag=True, help="Show internal pipeline debugging information.")
+@click.option("--jailbreak", is_flag=True, help="Send seed prompts to annotators instead of regular prompts.")
 @click.option("--prompt_uid_col", type=str, default=None, help="Column name for prompt UID in the input file.")
 @click.option("--prompt_text_col", type=str, default=None, help="Column name for prompt text in the input file.")
+@click.option(
+    "--seed_prompt_text_col",
+    type=str,
+    default=None,
+    help="Column name for seed prompt text in the input file if using jailbreak mode.",
+)
 @click.option("--sut_uid_col", type=str, default=None, help="Column name for SUT UID in the input file.")
 @click.option("--sut_response_col", type=str, default=None, help="Column name for sut response in the input file.")
 @click.argument(
@@ -320,6 +327,7 @@ def run_job(
     output_dir,
     tag,
     debug,
+    jailbreak,
     input_path,
     max_tokens,
     temp,
@@ -327,6 +335,7 @@ def run_job(
     top_k,
     prompt_uid_col,
     prompt_text_col,
+    seed_prompt_text_col,
     sut_uid_col,
     sut_response_col,
 ):
@@ -383,8 +392,10 @@ def run_job(
         tag=tag,
         prompt_uid_col=prompt_uid_col,
         prompt_text_col=prompt_text_col,
+        seed_prompt_text_col=seed_prompt_text_col,
         sut_uid_col=sut_uid_col,
         sut_response_col=sut_response_col,
+        jailbreak=jailbreak,
     )
 
     with click.progressbar(

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -371,15 +371,25 @@ def build_runner(
     ensemble=None,
     prompt_uid_col=None,
     prompt_text_col=None,
+    seed_prompt_text_col=None,
     sut_uid_col=None,
     sut_response_col=None,
+    jailbreak=False,
     **kwargs,
 ):
+    if jailbreak and not (annotators and suts):
+        raise ValueError("Jailbreak mode only applies when running both suts and annotators.")
     # Build input dataset
     if suts:
         if sut_uid_col or sut_response_col:
             raise ValueError("SUT uid and SUT response input columns are not used when running SUTs.")
-        dataset = PromptDataset(input_path, prompt_uid_col=prompt_uid_col, prompt_text_col=prompt_text_col)
+        dataset = PromptDataset(
+            input_path,
+            prompt_uid_col=prompt_uid_col,
+            prompt_text_col=prompt_text_col,
+            seed_prompt_text_col=seed_prompt_text_col,
+            jailbreak=jailbreak,
+        )
     else:
         dataset = PromptResponseDataset(
             input_path,

--- a/src/modelgauge/pipeline_runner.py
+++ b/src/modelgauge/pipeline_runner.py
@@ -215,7 +215,10 @@ class AnnotatorRunner(PipelineRunner):
         self.annotator_workers = AnnotatorWorkers(self.annotators, self.num_workers, cache_path=self.cache_dir)
         self.pipeline_segments.append(self.annotator_workers)
         if include_sink:
-            output = AnnotationDataset(self.output_dir() / self.output_file_name, "w")
+            jailbreak = False
+            if isinstance(self.input_dataset, PromptDataset) and self.input_dataset.jailbreak:
+                jailbreak = True
+            output = AnnotationDataset(self.output_dir() / self.output_file_name, "w", jailbreak=jailbreak)
             self.pipeline_segments.append(AnnotatorSink(output))
 
     def _annotator_metadata(self):

--- a/src/modelgauge/tests/security.py
+++ b/src/modelgauge/tests/security.py
@@ -22,7 +22,7 @@ from modelgauge.prompt_sets import (
     validate_prompt_set,
 )
 from modelgauge.secret_values import InjectSecret
-from modelgauge.single_turn_prompt_response import JailbreakTestItem, MeasuredTestItem, SUTResponseAnnotations, TestItem
+from modelgauge.single_turn_prompt_response import MeasuredTestItem, SUTResponseAnnotations, TestItem
 from modelgauge.sut import SUTOptions
 from modelgauge.sut_capabilities import AcceptsTextPrompt
 from modelgauge.tests.safe_v1 import Hazards
@@ -119,11 +119,11 @@ class BaseSecurityJailbreakTest(BaseSecurityTest, ABC):
     prompt_sets = SECURITY_JAILBREAK_PROMPT_SETS
     persona = "jailbreak"
 
-    def test_item_from_row(self, row) -> JailbreakTestItem:
+    def test_item_from_row(self, row) -> TestItem:
         hazard = self.hazards.get_hazard_from_row(row)
-        return JailbreakTestItem(
+        return TestItem(
             prompt=TextPrompt(text=row["prompt_text"]),
-            seed_prompt=TextPrompt(text=row["seed_prompt_text"]),
+            evaluated_prompt=TextPrompt(text=row["seed_prompt_text"]),
             source_id=row["prompt_uid"],
             context={"hazard": hazard},
         )

--- a/tests/modelgauge_tests/test_records.py
+++ b/tests/modelgauge_tests/test_records.py
@@ -106,6 +106,9 @@ def test_serialize_test_record():
         "prompt": {
           "text": "some-text"
         },
+        "evaluated_prompt": {
+          "text": "some-text"
+        },
         "source_id": "id01",
         "context_internal": {
           "module": "modelgauge_tests.test_records",
@@ -118,6 +121,9 @@ def test_serialize_test_record():
       "sut_response_annotations": {
         "test_item": {
           "prompt": {
+            "text": "some-text"
+          },
+          "evaluated_prompt": {
             "text": "some-text"
           },
           "source_id": "id01",

--- a/tests/modelgauge_tests/test_security.py
+++ b/tests/modelgauge_tests/test_security.py
@@ -6,7 +6,7 @@ from modelgauge.dependency_helper import DependencyHelper
 from modelgauge.locales import EN_US
 from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_sets import ModellabFileDownloadToken
-from modelgauge.single_turn_prompt_response import JailbreakTestItem, MeasuredTestItem, SUTResponseAnnotations, TestItem
+from modelgauge.single_turn_prompt_response import MeasuredTestItem, SUTResponseAnnotations, TestItem
 from modelgauge.sut import SUTResponse
 from modelgauge.tests.security import SecurityJailbreakTest, SecurityNaiveTest
 
@@ -89,14 +89,13 @@ def test_make_test_items_jailbreak(dependency_helper_jailbreak, security_jailbre
     items.sort(key=lambda x: x.source_id)
 
     assert len(items) == 2
-    assert all(isinstance(item, JailbreakTestItem) for item in items)
     assert items[0].source_id == "001"
     assert items[0].prompt.text == "prompt 1"
-    assert items[0].seed_prompt.text == "seed 1"
+    assert items[0].evaluated_prompt.text == "seed 1"
     assert items[0].context["hazard"] == "cse"
     assert items[1].source_id == "002"
     assert items[1].prompt.text == "prompt 2"
-    assert items[1].seed_prompt.text == "seed 2"
+    assert items[1].evaluated_prompt.text == "seed 2"
     assert items[1].context["hazard"] == "cse"
 
 
@@ -108,9 +107,11 @@ def test_make_test_items_naive(dependency_helper_naive, security_naive_test):
     assert all(isinstance(item, TestItem) for item in items)
     assert items[0].source_id == "001"
     assert items[0].prompt.text == "prompt 1"
+    assert items[0].evaluated_prompt.text == "prompt 1"
     assert items[0].context["hazard"] == "cse"
     assert items[1].source_id == "002"
     assert items[1].prompt.text == "prompt 2"
+    assert items[1].evaluated_prompt.text == "prompt 2"
     assert items[1].context["hazard"] == "cse"
 
 


### PR DESCRIPTION
If you are running both suts and annotators, you can now use `run-job` in "jailbreak mode" with `--jailbreak` which will send the regular prompt text to the SUT and the seed prompt text to the annotator. You can also parameterize the seed prompt column name with `--seed_prompt_text_col <col>`.