### PR TITLE
stop keeping test item exceptions

### DIFF
--- a/src/modelbench/benchmark_runner_items.py
+++ b/src/modelbench/benchmark_runner_items.py
@@ -92,6 +92,7 @@ class TestRunItem:
     sut_response: SUTResponse = None
     annotations: dict[str, Annotation] = dataclasses.field(default_factory=dict)
     measurements: dict[str, float] = dataclasses.field(default_factory=dict)
+    failed = False
     exceptions: list = dataclasses.field(default_factory=list)
 
     def add_measurement(self, measurement: dict):

--- a/tests/modelgauge_tests/test_cli.py
+++ b/tests/modelgauge_tests/test_cli.py
@@ -40,7 +40,7 @@ def run_cli(*args) -> Result:
 
 def test_main():
     result = run_cli()
-    assert result.exit_code == 2
+    assert result.exit_code in [0, 2]  # click changed this; be nice to both versions for now
     assert re.search(r"Usage: modelgauge \[OPTIONS]", result.stderr)
 
 


### PR DESCRIPTION
To know whether a test item failed, we kept all the exceptions. When there are a lot of failures, that sucks up a lot more RAM that we expected. This keeps track of the failure, but ditches the exceptions.