### PR TITLE
Replace deprecated google model.

### DIFF
--- a/src/modelgauge/sut_factory.py
+++ b/src/modelgauge/sut_factory.py
@@ -107,7 +107,7 @@ LEGACY_SUT_MODULE_MAP = {
     # BaseTen
     "nvidia-llama-3.3-49b-nemotron-super": "baseten_api",
     # Google
-    "google-genai-gemini-2.5-flash-preview-05-20-no-reasoning": "google_genai",
+    "google-genai-gemini-2.5-flash-preview-09-2025-no-reasoning": "google_genai",
     "gemini-2.0-flash": "google_generativeai",
     "gemini-2.0-flash-lite": "google_generativeai",
     "gemini-2.0-flash-001": "google_generativeai",

--- a/src/modelgauge/suts/google_genai.py
+++ b/src/modelgauge/suts/google_genai.py
@@ -105,7 +105,7 @@ class GoogleGenAiSUT(PromptResponseSUT):
         return SUTResponse(text=response_text)
 
 
-models = ["gemini-2.5-flash-preview-05-20"]
+models = ["gemini-2.5-flash-preview-09-2025"]
 for model in models:
     SUTS.register(
         GoogleGenAiSUT,


### PR DESCRIPTION
Google deprecated `gemini-2.5-flash-preview-05-20` so doing a quick replacement with `gemini-2.5-flash-preview-09-2025`.