### PR TITLE
Fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,6 @@ ENV PATH="/root/.local/bin:${PATH}"
 
 WORKDIR /app
 
-COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.venv /app/venv
 
-ENTRYPOINT ["/app/.venv/bin/modelbench"]
+ENTRYPOINT ["/app/venv/bin/modelbench"]


### PR DESCRIPTION
Modelrunner expects modelbench to live in `venv` not `.venv`