### PR TITLE
register intellect-3 thinking sut

### DIFF
--- a/src/modelgauge/suts/huggingface_chat_completion.py
+++ b/src/modelgauge/suts/huggingface_chat_completion.py
@@ -276,6 +276,13 @@ SUTS.register(
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     HF_SECRET,
 )
+SUTS.register(
+    HuggingFaceChatCompletionDedicatedThinkingSUT,
+    "PrimeIntellect-INTELLECT-3-thinking-excluded-hf",
+    "intellect-3-uqs",
+    "PrimeIntellect/INTELLECT-3",
+    HF_SECRET,
+)
 
 # Register serverless SUTs.
 SUTS.register(


### PR DESCRIPTION
intellect-3 has thinking turned on by default with no documented way to disable it. This PR register a sut that discards the reasoning output.