### PR TITLE
Prompt node bug

### DIFF
--- a/src/modelgauge/annotators/composer/prompt_enricher.py
+++ b/src/modelgauge/annotators/composer/prompt_enricher.py
@@ -63,5 +63,4 @@ class PromptEngineeredNode(Enricher):
                 output_token_cost=self._count_tokens(sut_response.text),
             ),
             original_ctx=ctx,
-            updated_ctx=ctx.with_response(sut_response.text),
         )


### PR DESCRIPTION
AFAICT, it does not make sense to replace the original sut response context with the response from this node. This node's "sut" response is already stored in the output value.