### PR TITLE
Run current versions of requested benchmarks.

### DIFF
--- a/src/modelbench/cli.py
+++ b/src/modelbench/cli.py
@@ -16,13 +16,18 @@ from functools import wraps
 
 import click
 import termcolor
-from airrlogger.log_config import configure_logging
+from airrlogger.log_config import configure_logging, get_logger
 from click import echo
 from rich.console import Console
 from rich.table import Table
 
 import modelgauge.annotators.cheval.registration  # noqa: F401
-from modelbench.benchmark_runner import BenchmarkRun, BenchmarkRunner, JsonRunTracker, TqdmRunTracker
+from modelbench.benchmark_runner import (
+    BenchmarkRun,
+    BenchmarkRunner,
+    JsonRunTracker,
+    TqdmRunTracker,
+)
 from modelbench.benchmarks import GeneralPurposeAiChatBenchmarkV1, SecurityBenchmark
 from modelbench.consistency_checker import (
     ConsistencyChecker,
@@ -39,6 +44,8 @@ from modelgauge.preflight import check_secrets, make_sut
 from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, SECURITY_JAILBREAK_PROMPT_SETS
 from modelgauge.sut_registry import SUTS
 from modelgauge.versions import CURRENT_GENERAL_VERSION, CURRENT_SECURITY_VERSION
+
+logger = get_logger(__name__)
 
 
 def load_local_plugins(_, __, path: pathlib.Path):
@@ -168,7 +175,6 @@ def list_suts():
 @click.option(
     "--version",
     "-v",
-    type=click.Choice([CURRENT_GENERAL_VERSION]),
     default=CURRENT_GENERAL_VERSION,
     help=f"Benchmark version to run (Default: {CURRENT_GENERAL_VERSION})",
     multiple=False,
@@ -191,6 +197,8 @@ def general_benchmark(
 ) -> None:
     run_path: pathlib.Path = ctx.obj["run_path"]
     sut = make_sut(sut_uid)
+    if version != CURRENT_GENERAL_VERSION:
+        logger.warning(f"Ignoring the requested version {version} and running with {CURRENT_GENERAL_VERSION}.")
     benchmark = GeneralPurposeAiChatBenchmarkV1(locale, prompt_set, evaluator)
     check_benchmark(benchmark)
     try:
@@ -204,7 +212,6 @@ def general_benchmark(
 @click.option(
     "--version",
     "-v",
-    type=click.Choice([CURRENT_SECURITY_VERSION]),
     default=CURRENT_SECURITY_VERSION,
     help=f"Benchmark version to run (Default: {CURRENT_SECURITY_VERSION})",
     multiple=False,
@@ -227,6 +234,8 @@ def security_benchmark(
 ) -> None:
     run_path: pathlib.Path = ctx.obj["run_path"]
     sut = make_sut(sut_uid)
+    if version != CURRENT_SECURITY_VERSION:
+        logger.warning(f"Ignoring the requested version {version} and running with {CURRENT_SECURITY_VERSION}.")
     benchmark = SecurityBenchmark(locale, prompt_set, evaluator=evaluator)
     check_benchmark(benchmark)
     try:

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -333,6 +333,7 @@ class TestCli:
         locale,
         prompt_set,
         run_dir,
+        caplog,
     ):
         benchmark_options = ["--version", version]
         if locale is not None:
@@ -366,6 +367,7 @@ class TestCli:
         assert annotation_file_path.exists()
         # TODO find a better spot for this test. It's handy here because all the objects are available.
         assert annotations_are_correct(annotation_file_path, prompt_set)
+        assert f"Ignoring the requested version" not in caplog.text
 
     # TODO: Add test back after calibrating!!
     # def test_security_benchmark_basic_run_produces_json(
@@ -492,11 +494,19 @@ class TestCli:
                 catch_exceptions=False,
             )
 
-    @pytest.mark.parametrize("version", ["0.0", "0.5"])
-    def test_invalid_benchmark_versions_can_not_be_called(self, version, runner):
-        result = runner(cli, ["benchmark", "general", "--version", "0.0"])
-        assert result.exit_code == 2
-        assert "Invalid value for '--version'" in result.output
+    @pytest.mark.parametrize("benchmark_type", ["general", "security"])
+    @pytest.mark.parametrize("version", ["0.0", "banana"])
+    def test_invalid_benchmark_versions_can_be_called(self, version, benchmark_type, runner, sut, monkeypatch, caplog):
+        run_mock = MagicMock()
+        monkeypatch.setattr(modelbench.cli, "run_and_report_benchmark", run_mock)
+
+        result = runner(
+            cli, ["benchmark", benchmark_type, "--version", version, "--sut", sut.uid], catch_exceptions=False
+        )
+
+        assert result.exit_code == 0
+        run_mock.assert_called_once()
+        assert f"Ignoring the requested version {version}" in caplog.text
 
     @pytest.mark.skip(reason="we have temporarily removed other languages")
     def test_calls_score_benchmark_with_correct_v1_locale(self, runner, mock_run_benchmarks, sut_uid):


### PR DESCRIPTION
Follow up:

* If we want to support multiple versions in modelbench, we'd change the CLI to instantiate different benchmark definitions depending on the input version. This should be easy to add when we actually need to add it.
* Candela change -- note this change (with this PR) would ONLY be used for the naming of the benchmark job / run uid. modelbench would run the same thing regardless. https://github.com/mlcommons/sugar/pull/627 **NOTE:** it would be good to have a better strategy for sharing these versions so updating versions doesn't result in pain. Adding modelbench as a dependency is one option, but kind of painful.
* In modelrunner, BenchmarkJob.version defaults to 1.1 always. I think we should remove the default (or make the default configured per benchmark_type).