### PR TITLE
Update to Together 2.0 endpoints

### DIFF
--- a/src/modelgauge/auth/together_secrets.py
+++ b/src/modelgauge/auth/together_secrets.py
@@ -9,3 +9,13 @@ class TogetherApiKey(RequiredSecret):
             key="api_key",
             instructions="See https://api.together.xyz/settings/api-keys",
         )
+
+
+class TogetherProjectId(RequiredSecret):
+    @classmethod
+    def description(cls) -> SecretDescription:
+        return SecretDescription(
+            scope="together",
+            key="project_id",
+            instructions="Get your project ID from the together dashboard in 'Manage Projects'.",
+        )

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -1,5 +1,5 @@
 import time
-from dataclasses import dataclass
+from enum import StrEnum
 from typing import List, Optional
 
 import requests  # type: ignore
@@ -32,8 +32,7 @@ _ROLE_MAP = {
 }
 
 
-@dataclass
-class TogetherEndpointState:
+class TogetherEndpointState(StrEnum):
     STARTED: str = "DEPLOYMENT_STATE_READY"
     STOPPED: str = "DEPLOYMENT_STATE_STOPPED"
     ERROR: str = "DEPLOYMENT_STATE_FAILED"

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -416,12 +416,7 @@ CHAT_MODELS = {
 for uid, model_name in CHAT_MODELS.items():
     SUTS.register(TogetherChatSUT, uid, model_name, InjectSecret(TogetherApiKey))
 
-DEDICATED_CHAT_MODELS = {
-    "mistral-8x22b-instruct-dedicated-together": "mlc_ai_safety_2/mistralai/Mixtral-8x22B-Instruct-v0.1-e1c7d251",
-    "gpt-oss-20b-dedicated-together": "mlc_ai_safety_2/openai/gpt-oss-20b-0fbd26f0",
-    "llama-3.3-70b-instruct-turbo-dedicated-together": "mlc_ai_safety_2/meta-llama/Llama-3.3-70B-Instruct-Turbo-8f91de15",
-    "gemma-4-26b-a4b-it-dedicated-together": "mlc_ai_safety_2/google/gemma-4-26B-A4B-it-c33cb205",
-}
+DEDICATED_CHAT_MODELS = {}
 for uid, model_name in DEDICATED_CHAT_MODELS.items():
     SUTS.register(
         TogetherDedicatedChatSUT, uid, model_name, InjectSecret(TogetherApiKey), InjectSecret(TogetherProjectId)

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -305,29 +305,30 @@ class TogetherDedicatedChatSUT(TogetherChatSUT):
 
     def __init__(self, uid: str, model: str, api_key: TogetherApiKey, project_id: TogetherProjectId):
         super().__init__(uid, model, api_key)
-        # Lazy-initialization of endpoint info for validation tests.
         self.project_id = project_id.value
         self.endpoint_id: Optional[str] = None
         self.deployment_id: Optional[str] = None
         self.endpoint_status: Optional[str] = None
 
+        # Can't lazy init because we need to know the endpoint info (the model name, speicifically) to translate the request.
+        self._set_endpoint_info()
+
     def _endpoints_url(self) -> str:
         return f"https://api.together.ai/v2/projects/{self.project_id}/endpoints"
 
-    def _get_endpoint_and_deployment_ids(self) -> tuple[str, str]:
+    def _set_endpoint_info(self):
         headers = {"accept": "application/json", "authorization": f"Bearer {self.api_key}"}
         response = _retrying_request(self._endpoints_url(), headers, None, "GET")
         for endpoint in response.json()["data"]:
             for deployment in endpoint["deployments"]:
                 if self.model.lower() in deployment["name"].lower():
-                    return endpoint["id"], deployment["id"]
+                    self.endpoint_id = endpoint["id"]
+                    self.deployment_id = deployment["id"]
+                    self.model = endpoint["name"]
+                    return
         raise APIException(f"No endpoint found for model {self.model}")
 
     def _get_endpoint_status(self) -> str:
-        if not self.endpoint_id:
-            endpoint_id, deployment_id = self._get_endpoint_and_deployment_ids()
-            self.endpoint_id = endpoint_id
-            self.deployment_id = deployment_id
         headers = {"accept": "application/json", "authorization": f"Bearer {self.api_key}"}
         response = _retrying_request(
             f"{self._endpoints_url()}/{self.endpoint_id}/deployments/{self.deployment_id}", headers, {}, "GET"
@@ -335,6 +336,7 @@ class TogetherDedicatedChatSUT(TogetherChatSUT):
         return response.json()["status"]["state"]
 
     def _spin_up_endpoint(self):
+        # TODO: Add a warning about manually stopping endpoiint somewhere.
         # Get latest endpoint status
         self.endpoint_status = self._get_endpoint_status()
         if self.endpoint_status == TogetherEndpointState.STARTED:

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -336,7 +336,9 @@ class TogetherDedicatedChatSUT(TogetherChatSUT):
         return response.json()["status"]["state"]
 
     def _spin_up_endpoint(self):
-        # TODO: Add a warning about manually stopping endpoiint somewhere.
+        logger.warning(
+            f"IMPORTANT: YOU MUST MANUALLY STOP THE ENDPOINT IN THE TOGETHER DASHBOARD AFTER USE. Auto-scale down is not yet supported by Together endpoints v2.0."
+        )
         # Get latest endpoint status
         self.endpoint_status = self._get_endpoint_status()
         if self.endpoint_status == TogetherEndpointState.STARTED:

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -1,4 +1,5 @@
 import time
+from dataclasses import dataclass
 from typing import List, Optional
 
 import requests  # type: ignore
@@ -31,7 +32,18 @@ _ROLE_MAP = {
 }
 
 
-def _retrying_request(url, headers, json_payload, method):
+@dataclass
+class TogetherEndpointState:
+    STARTED: str = "DEPLOYMENT_STATE_READY"
+    STOPPED: str = "DEPLOYMENT_STATE_STOPPED"
+    ERROR: str = "DEPLOYMENT_STATE_FAILED"
+    DEGRADED: str = "DEPLOYMENT_STATE_DEGRADED"
+    PENDING: str = "DEPLOYMENT_STATE_PROVISIONING"
+    STARTING: str = "DEPLOYMENT_STATE_SCALING"
+    STOPPING: str = "DEPLOYMENT_STATE_STOPPING"
+
+
+def _retrying_request(url, headers, json_payload, method, params=None):
     """HTTP Post with retry behavior."""
     retries = Retry(
         total=15,
@@ -59,7 +71,12 @@ def _retrying_request(url, headers, json_payload, method):
             raise ValueError(f"Invalid HTTP method: {method}")
         response = None
         try:
-            response = call(url, headers=headers, json=json_payload, timeout=120)
+            kwargs = {"headers": headers, "timeout": 120}
+            if json_payload:
+                kwargs["json"] = json_payload
+            if params:
+                kwargs["params"] = params
+            response = call(url, **kwargs)
             return response
         except Exception as e:
             logger.error(f"failed on request {url} {headers} {json_payload}", exc_info=e)
@@ -286,55 +303,76 @@ class TogetherThinkingSUT(ThinkingMixin, TogetherChatSUT):
 class TogetherDedicatedChatSUT(TogetherChatSUT):
     """A SUT based on dedicated Together endpoint. Supports automatic endpoint spin-up."""
 
-    _ENDPOINTS_URL = "https://api.together.xyz/v1/endpoints"
-
     def __init__(self, uid: str, model: str, api_key: TogetherApiKey, project_id: TogetherProjectId):
         super().__init__(uid, model, api_key)
         # Lazy-initialization of endpoint info for validation tests.
         self.project_id = project_id.value
         self.endpoint_id: Optional[str] = None
+        self.deployment_id: Optional[str] = None
         self.endpoint_status: Optional[str] = None
 
-    def _get_endpoint_id(self) -> str:
+    def _endpoints_url(self) -> str:
+        return f"https://api.together.ai/v2/projects/{self.project_id}/endpoints"
+
+    def _get_endpoint_and_deployment_ids(self) -> tuple[str, str]:
         headers = {"accept": "application/json", "authorization": f"Bearer {self.api_key}"}
-        response = _retrying_request(self._ENDPOINTS_URL, headers, {}, "GET")
+        response = _retrying_request(self._endpoints_url(), headers, None, "GET")
         for endpoint in response.json()["data"]:
-            if endpoint["name"] == self.model:
-                return endpoint["id"]
+            for deployment in endpoint["deployments"]:
+                if self.model.lower() in deployment["name"].lower():
+                    return endpoint["id"], deployment["id"]
         raise APIException(f"No endpoint found for model {self.model}")
 
     def _get_endpoint_status(self) -> str:
         if not self.endpoint_id:
-            self.endpoint_id = self._get_endpoint_id()
+            endpoint_id, deployment_id = self._get_endpoint_and_deployment_ids()
+            self.endpoint_id = endpoint_id
+            self.deployment_id = deployment_id
         headers = {"accept": "application/json", "authorization": f"Bearer {self.api_key}"}
-        response = _retrying_request(f"{self._ENDPOINTS_URL}/{self.endpoint_id}", headers, {}, "GET")
-        return response.json()["state"]
+        response = _retrying_request(
+            f"{self._endpoints_url()}/{self.endpoint_id}/deployments/{self.deployment_id}", headers, {}, "GET"
+        )
+        return response.json()["status"]["state"]
 
     def _spin_up_endpoint(self):
         # Get latest endpoint status
         self.endpoint_status = self._get_endpoint_status()
-        if self.endpoint_status == "STARTED":
+        if self.endpoint_status == TogetherEndpointState.STARTED:
             return
-        elif self.endpoint_status in ["PENDING", "STOPPING", "STARTING"]:
+        if self.endpoint_status == TogetherEndpointState.DEGRADED:
+            raise APIException(f"Together endpoint for {self.model} is degraded. Status: {self.endpoint_status}.")
+        elif self.endpoint_status in [
+            TogetherEndpointState.PENDING,
+            TogetherEndpointState.STOPPING,
+            TogetherEndpointState.STARTING,
+        ]:
             # Wait and retry.
             time.sleep(2 * 60)  # 2 minutes
             self._spin_up_endpoint()
-        elif self.endpoint_status == "STOPPED" or self.endpoint_status == "ERROR":
+        elif self.endpoint_status in [TogetherEndpointState.STOPPED, TogetherEndpointState.ERROR]:
             # Start endpoint.
             logger.warning(
                 f"Together endpoint for {self.model} is not ready. Status: {self.endpoint_status}. Spinning up..."
             )
             headers = {"accept": "application/json", "authorization": f"Bearer {self.api_key}"}
-            payload = {"state": "STARTED"}
-            response = _retrying_request(f"{self._ENDPOINTS_URL}/{self.endpoint_id}", headers, payload, "PATCH")
-            if "state" in response.json():
-                self.endpoint_status = response.json()["state"]
-            if self.endpoint_status != "STARTED":
+            params = {"update_mask": "autoscaling.minReplicas,autoscaling.maxReplicas"}
+            payload = {"autoscaling": {"minReplicas": 1, "maxReplicas": 1}}
+            response = _retrying_request(
+                f"{self._endpoints_url()}/{self.endpoint_id}/deployments/{self.deployment_id}",
+                headers,
+                payload,
+                "PATCH",
+                params=params,
+            )
+            state = response.json().get("status", {}).get("state", None)
+            if state is not None:
+                self.endpoint_status = state
+            if self.endpoint_status != TogetherEndpointState.STARTED:
                 # Try again.
                 self._spin_up_endpoint()
 
     def evaluate(self, request: TogetherChatRequest) -> TogetherChatResponse:
-        if self.endpoint_status != "STARTED":
+        if self.endpoint_status != TogetherEndpointState.STARTED:
             self._spin_up_endpoint()
         try:
             return super().evaluate(request)

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -6,7 +6,7 @@ from airrlogger.log_config import get_logger
 from pydantic import BaseModel
 from requests.adapters import HTTPAdapter, Retry  # type: ignore
 
-from modelgauge.auth.together_key import TogetherApiKey
+from modelgauge.auth.together_secrets import TogetherApiKey, TogetherProjectId
 from modelgauge.general import APIException
 from modelgauge.model_options import ModelOptions, TokenProbability, TopTokens
 from modelgauge.prompt import ChatPrompt, ChatRole, TextPrompt
@@ -288,9 +288,10 @@ class TogetherDedicatedChatSUT(TogetherChatSUT):
 
     _ENDPOINTS_URL = "https://api.together.xyz/v1/endpoints"
 
-    def __init__(self, uid: str, model: str, api_key: TogetherApiKey):
+    def __init__(self, uid: str, model: str, api_key: TogetherApiKey, project_id: TogetherProjectId):
         super().__init__(uid, model, api_key)
         # Lazy-initialization of endpoint info for validation tests.
+        self.project_id = project_id.value
         self.endpoint_id: Optional[str] = None
         self.endpoint_status: Optional[str] = None
 
@@ -384,6 +385,8 @@ DEDICATED_CHAT_MODELS = {
     "gemma-4-26b-a4b-it-dedicated-together": "mlc_ai_safety_2/google/gemma-4-26B-A4B-it-c33cb205",
 }
 for uid, model_name in DEDICATED_CHAT_MODELS.items():
-    SUTS.register(TogetherDedicatedChatSUT, uid, model_name, InjectSecret(TogetherApiKey))
+    SUTS.register(
+        TogetherDedicatedChatSUT, uid, model_name, InjectSecret(TogetherApiKey), InjectSecret(TogetherProjectId)
+    )
 
 SUTS.register(TogetherThinkingSUT, "deepseek-R1-thinking", "deepseek-ai/DeepSeek-R1", InjectSecret(TogetherApiKey))

--- a/src/modelgauge/suts/together_client.py
+++ b/src/modelgauge/suts/together_client.py
@@ -337,7 +337,7 @@ class TogetherDedicatedChatSUT(TogetherChatSUT):
 
     def _spin_up_endpoint(self):
         logger.warning(
-            f"IMPORTANT: YOU MUST MANUALLY STOP THE ENDPOINT IN THE TOGETHER DASHBOARD AFTER USE. Auto-scale down is not yet supported by Together endpoints v2.0."
+            "IMPORTANT: YOU MUST MANUALLY STOP THE ENDPOINT IN THE TOGETHER DASHBOARD AFTER USE. Auto-scale down is not yet supported by Together endpoints v2.0."
         )
         # Get latest endpoint status
         self.endpoint_status = self._get_endpoint_status()

--- a/src/modelgauge/suts/together_sut_factory.py
+++ b/src/modelgauge/suts/together_sut_factory.py
@@ -6,6 +6,7 @@ from airrlogger.log_config import get_logger
 
 from modelgauge.auth.together_secrets import TogetherApiKey, TogetherProjectId
 from modelgauge.dynamic_sut_factory import DynamicDriverSUTFactory, ModelNotSupportedError
+from modelgauge.general import APIException
 from modelgauge.secret_values import InjectSecret, RawSecrets
 from modelgauge.sut import PromptResponseSUT
 from modelgauge.sut_definition import SUTDefinition
@@ -46,16 +47,6 @@ class TogetherSUTFactory(DynamicDriverSUTFactory):
             logger.info(f"Error looking up serverless model {model} on together: {e}")
         return None
 
-    def _find_dedicated(self, model: str) -> str | None:
-        try:
-            endpoints = self.client.endpoints.list(type="dedicated", mine=True)
-            for endpoint in endpoints.data:
-                if endpoint.model.lower() == model:
-                    return endpoint.name
-        except Exception as e:
-            logger.error(f"Error looking up dedicated endpoints for {model} on together: {e}")
-        return None
-
     def get_secrets(self) -> list[InjectSecret]:
         api_key = InjectSecret(TogetherApiKey)
         project_id = InjectSecret(TogetherProjectId)
@@ -74,10 +65,11 @@ class TogetherSUTFactory(DynamicDriverSUTFactory):
                 api_key,
             )
         # serverless failed; try dedicated.
-        endpoint_name = self._find_dedicated(model)
-        if endpoint_name is not None:
-            return TogetherDedicatedChatSUT(sut_definition.dynamic_uid, endpoint_name, api_key, project_id)
-
-        raise ModelNotSupportedError(
-            f"Model {sut_metadata.external_model_name()} not found or not available on together serverless nor dedicated endpoints."
-        )
+        try:
+            return TogetherDedicatedChatSUT(
+                sut_definition.dynamic_uid, sut_metadata.external_model_name(), api_key, project_id
+            )
+        except APIException as e:
+            raise ModelNotSupportedError(
+                f"Model {sut_metadata.external_model_name()} not found or not available on together serverless nor dedicated endpoints. Try removing the maker name e.g. `gpt-oss-20b` instead of `openai/gpt-oss-20b`."
+            )

--- a/src/modelgauge/suts/together_sut_factory.py
+++ b/src/modelgauge/suts/together_sut_factory.py
@@ -4,7 +4,7 @@ from together import Together  # type: ignore
 
 from airrlogger.log_config import get_logger
 
-from modelgauge.auth.together_key import TogetherApiKey
+from modelgauge.auth.together_secrets import TogetherApiKey, TogetherProjectId
 from modelgauge.dynamic_sut_factory import DynamicDriverSUTFactory, ModelNotSupportedError
 from modelgauge.secret_values import InjectSecret, RawSecrets
 from modelgauge.sut import PromptResponseSUT
@@ -58,27 +58,25 @@ class TogetherSUTFactory(DynamicDriverSUTFactory):
 
     def get_secrets(self) -> list[InjectSecret]:
         api_key = InjectSecret(TogetherApiKey)
-        return [api_key]
+        project_id = InjectSecret(TogetherProjectId)
+        return [api_key, project_id]
 
     def make_sut(self, sut_definition: SUTDefinition) -> PromptResponseSUT:
         sut_metadata = sut_definition.to_dynamic_sut_metadata()
         model = sut_metadata.external_model_name().lower()
         # first try serverless
         model_name = self._find_serverless(model)
+        api_key, project_id = self.injected_secrets()
         if model_name is not None:
             return TogetherChatSUT(
                 sut_definition.dynamic_uid,
                 sut_metadata.external_model_name(),
-                *self.injected_secrets(),
+                api_key,
             )
         # serverless failed; try dedicated.
         endpoint_name = self._find_dedicated(model)
         if endpoint_name is not None:
-            return TogetherDedicatedChatSUT(
-                sut_definition.dynamic_uid,
-                endpoint_name,
-                *self.injected_secrets(),
-            )
+            return TogetherDedicatedChatSUT(sut_definition.dynamic_uid, endpoint_name, api_key, project_id)
 
         raise ModelNotSupportedError(
             f"Model {sut_metadata.external_model_name()} not found or not available on together serverless nor dedicated endpoints."

--- a/tests/modelgauge_tests/sut_tests/test_together_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_client.py
@@ -4,13 +4,13 @@ import pytest
 from requests import HTTPError  # type: ignore
 import json
 
+from modelgauge.auth.together_secrets import TogetherApiKey, TogetherProjectId
 from modelgauge.general import APIException
 from modelgauge.prompt import ChatMessage, ChatPrompt, ChatRole, TextPrompt
 from modelgauge.prompt_formatting import format_chat
 from modelgauge.sut import SUTResponse
 from modelgauge.model_options import ModelOptions, TokenProbability, TopTokens
 from modelgauge.suts.together_client import (
-    TogetherApiKey,
     TogetherChatResponse,
     TogetherChatRequest,
     TogetherChatSUT,
@@ -18,7 +18,7 @@ from modelgauge.suts.together_client import (
     TogetherCompletionsRequest,
     TogetherCompletionsSUT,
     TogetherDedicatedChatSUT,
-    TogetherProjectId,
+    TogetherEndpointState,
 )
 
 
@@ -349,14 +349,22 @@ class TestTogetherDedicatedChatSUT:
             project_id=TogetherProjectId("some-value"),
         )
         sut.endpoint_id = "test-endpoint-id"
-        sut.endpoint_status = "STARTED"
+        sut.endpoint_status = TogetherEndpointState.STARTED
+        sut.deployment_id = "test-deployment-id"
         return sut
 
     @pytest.fixture
     def mock_endpoints_response(self):
         # Mock the endpoints list response
         mock_endpoints_response = MagicMock()
-        mock_endpoints_response.json.return_value = {"data": [{"name": "some-model", "id": "test-endpoint-id"}]}
+        mock_endpoints_response.json.return_value = {
+            "data": [
+                {
+                    "id": "test-endpoint-id",
+                    "deployments": [{"name": "some-model", "id": "test-deployment-id"}],
+                }
+            ]
+        }
         return mock_endpoints_response
 
     @pytest.fixture
@@ -370,13 +378,13 @@ class TestTogetherDedicatedChatSUT:
         with patch("modelgauge.suts.together_client._retrying_request") as mock_request:
             # Mock the endpoint status response
             mock_status_response = MagicMock()
-            mock_status_response.json.return_value = {"state": "STARTED"}
+            mock_status_response.json.return_value = {"status": {"state": TogetherEndpointState.STARTED}}
 
             # Configure the mock to return different responses based on the URL
             def side_effect(url, headers, json_payload, method):
                 if url.endswith("/endpoints"):
                     return mock_endpoints_response
-                elif url.endswith("/test-endpoint-id"):
+                elif url.endswith("/test-deployment-id"):
                     return mock_status_response
                 elif url == TogetherChatSUT._CHAT_COMPLETIONS_URL:
                     return mock_chat_response
@@ -391,13 +399,15 @@ class TestTogetherDedicatedChatSUT:
                 project_id=TogetherProjectId("some-value"),
             )
             assert sut.endpoint_id is None
+            assert sut.deployment_id is None
             assert sut.endpoint_status is None
 
             request = TogetherChatRequest(model="some-model", messages=[])
             sut.evaluate(request)
 
             assert sut.endpoint_id == "test-endpoint-id"
-            assert sut.endpoint_status == "STARTED"
+            assert sut.deployment_id == "test-deployment-id"
+            assert sut.endpoint_status == TogetherEndpointState.STARTED
 
     def test_together_dedicated_chat_sut_no_endpoint_found(self, mock_endpoints_response):
         with patch("modelgauge.suts.together_client._retrying_request") as mock_request:
@@ -430,16 +440,16 @@ class TestTogetherDedicatedChatSUT:
         with patch("modelgauge.suts.together_client._retrying_request") as mock_request:
             # First status check shows STOPPED
             mock_stopped_status = MagicMock()
-            mock_stopped_status.json.return_value = {"state": "STOPPED"}
+            mock_stopped_status.json.return_value = {"status": {"state": TogetherEndpointState.STOPPED}}
 
             # Status after PATCH shows STARTED
             mock_started_status = MagicMock()
-            mock_started_status.json.return_value = {"state": "STARTED"}
+            mock_started_status.json.return_value = {"status": {"state": TogetherEndpointState.STARTED}}
 
-            def side_effect(url, headers, json_payload, method):
+            def side_effect(url, headers, json_payload, method, params=None):
                 if url.endswith("/endpoints"):
                     return mock_endpoints_response
-                elif url.endswith("/test-endpoint-id"):
+                elif url.endswith("/test-deployment-id"):
                     if method == "GET":
                         # First status check returns STOPPED, subsequent ones return STARTED
                         if not hasattr(side_effect, "status_checked"):
@@ -471,7 +481,7 @@ class TestTogetherDedicatedChatSUT:
         with patch("modelgauge.suts.together_client._retrying_request") as mock_request:
             # Initial status shows STARTED
             mock_status = MagicMock()
-            mock_status.json.return_value = {"state": "STARTED"}
+            mock_status.json.return_value = {"status": {"state": TogetherEndpointState.STARTED}}
 
             # First chat attempt fails with 400
             mock_400_response = MagicMock()
@@ -489,7 +499,7 @@ class TestTogetherDedicatedChatSUT:
                 nonlocal call_count
                 if url.endswith("/endpoints"):
                     return mock_endpoints_response
-                elif url.endswith("/test-endpoint-id"):
+                elif url.endswith("/test-deployment-id"):
                     return mock_status
                 elif url == TogetherChatSUT._CHAT_COMPLETIONS_URL:
                     call_count += 1
@@ -518,7 +528,7 @@ class TestTogetherDedicatedChatSUT:
         with patch("modelgauge.suts.together_client._retrying_request") as mock_request:
             # Status shows STARTED
             mock_status = MagicMock()
-            mock_status.json.return_value = {"state": "STARTED"}
+            mock_status.json.return_value = {"status": {"state": TogetherEndpointState.STARTED}}
 
             # Chat attempt fails with 500
             mock_500_response = MagicMock()
@@ -528,7 +538,7 @@ class TestTogetherDedicatedChatSUT:
             def side_effect(url, headers, json_payload, method):
                 if url.endswith("/endpoints"):
                     return mock_endpoints_response
-                elif url.endswith("/test-endpoint-id"):
+                elif url.endswith("/test-deployment-id"):
                     return mock_status
                 elif url == TogetherChatSUT._CHAT_COMPLETIONS_URL:
                     raise APIException("Internal Server Error (500)")

--- a/tests/modelgauge_tests/sut_tests/test_together_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_client.py
@@ -342,12 +342,15 @@ def test_together_chat_translate_response_logprobs():
 class TestTogetherDedicatedChatSUT:
     @pytest.fixture
     def sut(self):
-        sut = TogetherDedicatedChatSUT(
-            uid="test-model",
-            model="some-model",
-            api_key=TogetherApiKey("some-value"),
-            project_id=TogetherProjectId("some-value"),
-        )
+        # Patch _set_endpoint_info so __init__ doesn't make a real API call;
+        # we set the endpoint fields manually below.
+        with patch("modelgauge.suts.together_client.TogetherDedicatedChatSUT._set_endpoint_info"):
+            sut = TogetherDedicatedChatSUT(
+                uid="test-model",
+                model="some-model",
+                api_key=TogetherApiKey("some-value"),
+                project_id=TogetherProjectId("some-value"),
+            )
         sut.endpoint_id = "test-endpoint-id"
         sut.endpoint_status = TogetherEndpointState.STARTED
         sut.deployment_id = "test-deployment-id"
@@ -361,7 +364,8 @@ class TestTogetherDedicatedChatSUT:
             "data": [
                 {
                     "id": "test-endpoint-id",
-                    "deployments": [{"name": "some-model", "id": "test-deployment-id"}],
+                    "name": "model-name",
+                    "deployments": [{"name": "my_proj/some-model", "id": "test-deployment-id"}],
                 }
             ]
         }
@@ -398,8 +402,9 @@ class TestTogetherDedicatedChatSUT:
                 api_key=TogetherApiKey("some-value"),
                 project_id=TogetherProjectId("some-value"),
             )
-            assert sut.endpoint_id is None
-            assert sut.deployment_id is None
+            assert sut.endpoint_id == "test-endpoint-id"
+            assert sut.deployment_id == "test-deployment-id"
+            assert sut.model == "model-name"
             assert sut.endpoint_status is None
 
             request = TogetherChatRequest(model="some-model", messages=[])
@@ -413,15 +418,13 @@ class TestTogetherDedicatedChatSUT:
         with patch("modelgauge.suts.together_client._retrying_request") as mock_request:
             # Mock the endpoints list response with no matching endpoint
             mock_request.return_value = mock_endpoints_response
-            sut = TogetherDedicatedChatSUT(
-                uid="test-model",
-                model="non-existent-model",
-                api_key=TogetherApiKey("some-value"),
-                project_id=TogetherProjectId("some-value"),
-            )
-            request = TogetherChatRequest(model="non-existent-model", messages=[])
             with pytest.raises(APIException, match="No endpoint found for model non-existent-model"):
-                sut.evaluate(request)
+                TogetherDedicatedChatSUT(
+                    uid="test-model",
+                    model="non-existent-model",
+                    api_key=TogetherApiKey("some-value"),
+                    project_id=TogetherProjectId("some-value"),
+                )
 
     def test_evaluate_endpoint_already_started(self, sut, mock_chat_response):
         with patch("modelgauge.suts.together_client._retrying_request") as mock_request:

--- a/tests/modelgauge_tests/sut_tests/test_together_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_client.py
@@ -18,6 +18,7 @@ from modelgauge.suts.together_client import (
     TogetherCompletionsRequest,
     TogetherCompletionsSUT,
     TogetherDedicatedChatSUT,
+    TogetherProjectId,
 )
 
 
@@ -345,6 +346,7 @@ class TestTogetherDedicatedChatSUT:
             uid="test-model",
             model="some-model",
             api_key=TogetherApiKey("some-value"),
+            project_id=TogetherProjectId("some-value"),
         )
         sut.endpoint_id = "test-endpoint-id"
         sut.endpoint_status = "STARTED"
@@ -386,6 +388,7 @@ class TestTogetherDedicatedChatSUT:
                 uid="test-model",
                 model="some-model",
                 api_key=TogetherApiKey("some-value"),
+                project_id=TogetherProjectId("some-value"),
             )
             assert sut.endpoint_id is None
             assert sut.endpoint_status is None
@@ -404,6 +407,7 @@ class TestTogetherDedicatedChatSUT:
                 uid="test-model",
                 model="non-existent-model",
                 api_key=TogetherApiKey("some-value"),
+                project_id=TogetherProjectId("some-value"),
             )
             request = TogetherChatRequest(model="non-existent-model", messages=[])
             with pytest.raises(APIException, match="No endpoint found for model non-existent-model"):
@@ -455,6 +459,7 @@ class TestTogetherDedicatedChatSUT:
                 uid="test-model",
                 model="some-model",
                 api_key=TogetherApiKey("some-value"),
+                project_id=TogetherProjectId("some-value"),
             )
             request = TogetherChatRequest(model="some-model", messages=[])
             response = sut.evaluate(request)
@@ -500,6 +505,7 @@ class TestTogetherDedicatedChatSUT:
                 uid="test-model",
                 model="some-model",
                 api_key=TogetherApiKey("some-value"),
+                project_id=TogetherProjectId("some-value"),
             )
             request = TogetherChatRequest(model="some-model", messages=[])
             response = sut.evaluate(request)
@@ -535,6 +541,7 @@ class TestTogetherDedicatedChatSUT:
                 uid="test-model",
                 model="some-model",
                 api_key=TogetherApiKey("some-value"),
+                project_id=TogetherProjectId("some-value"),
             )
             request = TogetherChatRequest(model="some-model", messages=[])
 

--- a/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
@@ -12,7 +12,7 @@ from modelgauge_tests.utilities import expensive_tests
 
 @pytest.fixture
 def together_factory():
-    factory = TogetherSUTFactory({"together": {"api_key": "value"}})
+    factory = TogetherSUTFactory({"together": {"api_key": "value", "project_id": "value"}})
     factory.client = MagicMock()
     return factory
 

--- a/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
@@ -4,6 +4,7 @@ import pytest
 
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
+from modelgauge.general import APIException
 from modelgauge.sut_definition import SUTDefinition
 from modelgauge.suts.together_client import TogetherChatSUT, TogetherDedicatedChatSUT
 from modelgauge.suts.together_sut_factory import TogetherSUTFactory
@@ -33,29 +34,6 @@ def test_find_serverless_bad_model(together_factory):
     assert result is None
 
 
-def test_find_dedicated(together_factory):
-    mock_endpoint = MagicMock()
-    mock_endpoint.model = "google/gemma"
-    mock_endpoint.name = "my-dedicated-endpoint"
-    together_factory.client.endpoints.list.return_value.data = [mock_endpoint]
-
-    result = together_factory._find_dedicated("google/gemma")
-    assert result == "my-dedicated-endpoint"
-    together_factory.client.endpoints.list.assert_called_once_with(type="dedicated", mine=True)
-
-
-def test_find_dedicated_not_found(together_factory):
-    together_factory.client.endpoints.list.return_value.data = []
-    result = together_factory._find_dedicated("google/gemma")
-    assert result is None
-
-
-def test_find_dedicated_error(together_factory):
-    together_factory.client.endpoints.list.side_effect = Exception("API error")
-    result = together_factory._find_dedicated("google/gemma")
-    assert result is None
-
-
 def test_make_sut_serverless(together_factory):
     together_factory.client.chat.completions.create.return_value = {}
     sut_definition = SUTDefinition(model="gemma", maker="google", driver="together")
@@ -66,24 +44,25 @@ def test_make_sut_serverless(together_factory):
     assert sut.api_key == "value"
 
 
-def test_make_sut_falls_back_to_dedicated(together_factory):
+def test_make_sut_falls_back_to_dedicated(together_factory, mocker):
+    mocker.patch.object(TogetherDedicatedChatSUT, "_set_endpoint_info")
     together_factory.client.chat.completions.create.side_effect = Exception("not serverless")
-    mock_endpoint = MagicMock()
-    mock_endpoint.model = "google/gemma"
-    mock_endpoint.name = "my-dedicated-endpoint"
-    together_factory.client.endpoints.list.return_value.data = [mock_endpoint]
 
     sut_definition = SUTDefinition(model="gemma", maker="google", driver="together")
     sut = together_factory.make_sut(sut_definition)
     assert isinstance(sut, TogetherDedicatedChatSUT)
     assert sut.uid == "google/gemma:together"
-    assert sut.model == "my-dedicated-endpoint"
+    assert sut.model == "google/gemma"
     assert sut.api_key == "value"
 
 
-def test_make_sut_not_found(together_factory):
+def test_make_sut_not_found(together_factory, mocker):
+    mocker.patch.object(
+        TogetherDedicatedChatSUT,
+        "_set_endpoint_info",
+        side_effect=APIException("No endpoint found for model fake/bogus"),
+    )
     together_factory.client.chat.completions.create.side_effect = Exception("not serverless")
-    together_factory.client.endpoints.list.return_value.data = []
 
     sut_definition = SUTDefinition(model="bogus", maker="fake", driver="together")
     with pytest.raises(ModelNotSupportedError):

--- a/tests/modelgauge_tests/test_safe.py
+++ b/tests/modelgauge_tests/test_safe.py
@@ -1,7 +1,7 @@
 import pytest
 
 from modelgauge.annotation import MissingAnnotationError, SafetyAnnotation
-from modelgauge.auth.together_key import TogetherApiKey
+from modelgauge.auth.together_secrets import TogetherApiKey
 from modelgauge.locales import EN_US, FR_FR, LOCALES
 from modelgauge.prompt import TextPrompt
 from modelgauge.prompt_sets import GENERAL_PROMPT_SETS, prompt_set_to_filename  # usort: skip


### PR DESCRIPTION
This fixes the broken together dedicated endpoint SUTs by upgrading to the new together API version.

If you want to use together dedicated endpoints, you now must add the project ID to your secrets.toml file under "project_id" in the `[together]` scope. You can find this key in 1Password.