### PR TITLE
Include run_id in benchmark record and annotation file names

### DIFF
--- a/src/modelbench/cli.py
+++ b/src/modelbench/cli.py
@@ -243,14 +243,14 @@ def run_and_report_benchmark(benchmark, sut, max_instances, debug, json_logs, ru
     output_path = run_path / outputdir
     output_path.mkdir(exist_ok=True, parents=True)
     print_summary(benchmark, benchmark_scores)
-    json_path = output_path / f"benchmark_record-{benchmark.uid}.json"
+    json_path = output_path / f"benchmark_record-{benchmark.uid}-{run.run_id}.json"
     scores = [score for score in benchmark_scores if score.benchmark_definition == benchmark]
     dump_json(json_path, start_time, benchmark, scores, run_uid, user)
     print(f"Wrote record for {benchmark.uid} to {json_path}.")
 
     # export the annotations separately
     annotations = {"job_id": run.run_id, "annotations": run.compile_annotations()}
-    annotation_path = output_path / f"annotations-{benchmark.uid}.json"
+    annotation_path = output_path / f"annotations-{benchmark.uid}-{run.run_id}.json"
     with open(annotation_path, "w") as annotation_records:
         annotation_records.write(json.dumps(annotations))
     print(f"Wrote annotations for {benchmark.uid} to {annotation_path}.")

--- a/tests/modelbench_tests/test_run.py
+++ b/tests/modelbench_tests/test_run.py
@@ -360,9 +360,10 @@ class TestCli:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert (run_dir / "records" / f"benchmark_record-{benchmark.uid}.json").exists()
+        run_id = mock_run_benchmarks.return_value.run_id
+        assert (run_dir / "records" / f"benchmark_record-{benchmark.uid}-{run_id}.json").exists()
 
-        annotation_file_path = run_dir / "records" / f"annotations-{benchmark.uid}.json"
+        annotation_file_path = run_dir / "records" / f"annotations-{benchmark.uid}-{run_id}.json"
         assert annotation_file_path.exists()
         # TODO find a better spot for this test. It's handy here because all the objects are available.
         assert annotations_are_correct(annotation_file_path, prompt_set)
@@ -436,7 +437,8 @@ class TestCli:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        assert (run_dir / "records" / f"benchmark_record-{benchmark.uid}.json").exists
+        run_id = mock_run_benchmarks.return_value.run_id
+        assert (run_dir / "records" / f"benchmark_record-{benchmark.uid}-{run_id}.json").exists
 
     @pytest.mark.parametrize("benchmark_type", ["general", "security"])
     def test_general_benchmark_exits_when_consistency_fails(self, runner, benchmark_type, sut, monkeypatch):


### PR DESCRIPTION
Previously these files were named only after the benchmark UID, so each new run silently overwrote the previous run's output. Reusing the existing per-run run_id (already used for the journal file name) makes each run's files unique without introducing a new identifier.

Fixes #1415