### PR TITLE
Dag handles n-ary routing

### DIFF
--- a/src/modelgauge/annotators/composer/dag.py
+++ b/src/modelgauge/annotators/composer/dag.py
@@ -23,7 +23,6 @@ from modelgauge.annotators.composer.nodes import (
     CacheableNodeMixin,
     ComposerNode,
     Enricher,
-    Gate,
     Router,
 )
 from modelgauge.annotators.composer.verdict import Verdict
@@ -409,11 +408,13 @@ class Composer:
     @requires_validate_and_build
     def potential_costs(self) -> dict[str, CostInfo]:
         """Run the DAG on all terminal paths and report total costs per path."""
-        gates = [name for name, node in self._nodes.items() if isinstance(node, Gate)]
+        routers = [(name, node) for name, node in self._nodes.items() if isinstance(node, Router)]
+        router_names = [name for name, _ in routers]
+        router_key_sets = [list(node.route_map.keys()) for _, node in routers]
         path_costs: dict[str, CostInfo] = {}
 
-        for combo in product([True, False], repeat=len(gates)):
-            gate_outcomes = dict(zip(gates, combo))
+        for combo in product(*router_key_sets):
+            router_outcomes = dict(zip(router_names, combo))
             reachable: set[str] = set(self._root_nodes)
             path: list[str] = []
             total = CostInfo()
@@ -424,7 +425,7 @@ class Composer:
                 node = self._nodes[node_name]
                 total += node.cost
                 path.append(node_name)
-                targets = node.next_nodes(gate_outcomes.get(node_name))
+                targets = node.next_nodes(router_outcomes.get(node_name))
                 for target in targets:
                     if not isinstance(target, Verdict):
                         reachable.add(target if isinstance(target, str) else target.name)
@@ -454,7 +455,7 @@ class Composer:
         traced = node_outputs is not None
 
         _NODE_STYLES: dict[type, dict] = {
-            Gate: {"shape": "diamond", "style": "filled", "fillcolor": "#ffe082"},
+            Router: {"shape": "diamond", "style": "filled", "fillcolor": "#ffe082"},
             Arbiter: {"shape": "hexagon", "style": "filled", "fillcolor": "#e1bee7"},
             Verdict: {
                 "shape": "rectangle",
@@ -597,7 +598,7 @@ class Composer:
                     attrs["penwidth"] = "2.5"
                 else:
                     label = node_name
-            _fill = 0.45 if isinstance(node, Gate) else 0.65 if isinstance(node, Arbiter) else 0.8
+            _fill = 0.45 if isinstance(node, Router) else 0.65 if isinstance(node, Arbiter) else 0.8
             dot.node(node_name, label, fontsize=_fontsize(label, fill=_fill), **attrs)
 
         # edges from implicit input to root nodes
@@ -606,29 +607,21 @@ class Composer:
 
         # edges between processing nodes
         for node_name, node in self._nodes.items():
-            if isinstance(node, Gate):
-                for target in node.routes_true:
-                    t = target if isinstance(target, str) else target.name
-                    hot = not traced or (node_name, t) in traversed_edges  # type: ignore[operator]
-                    dot.edge(
-                        node_name,
-                        t,
-                        label=" True",
-                        color="#2e7d32" if hot else "#cccccc",
-                        fontcolor="#2e7d32" if hot else "#cccccc",
-                        penwidth="2" if hot and traced else "1",
-                    )
-                for target in node.routes_false:
-                    t = target if isinstance(target, str) else target.name
-                    hot = not traced or (node_name, t) in traversed_edges  # type: ignore[operator]
-                    dot.edge(
-                        node_name,
-                        t,
-                        label=" False",
-                        color="#c62828" if hot else "#cccccc",
-                        fontcolor="#c62828" if hot else "#cccccc",
-                        penwidth="2" if hot and traced else "1",
-                    )
+            if isinstance(node, Router):
+                _ROUTER_KEY_COLORS = {True: "#2e7d32", False: "#c62828"}
+                for key, targets in node.route_map.items():
+                    active_color = _ROUTER_KEY_COLORS.get(key, "#555555")  # type: ignore
+                    for target in targets:
+                        t = target if isinstance(target, str) else target.name
+                        hot = not traced or (node_name, t) in traversed_edges  # type: ignore[operator]
+                        dot.edge(
+                            node_name,
+                            t,
+                            label=f" {key}",
+                            color=active_color if hot else "#cccccc",
+                            fontcolor=active_color if hot else "#cccccc",
+                            penwidth="2" if hot and traced else "1",
+                        )
             elif isinstance(node, Arbiter):
                 output_node_id = f"__output_{self.verdict_type.__name__}__"
                 hot = not traced or node_name in (node_outputs or {})

--- a/src/modelgauge/annotators/composer/dag.py
+++ b/src/modelgauge/annotators/composer/dag.py
@@ -24,6 +24,7 @@ from modelgauge.annotators.composer.nodes import (
     ComposerNode,
     Enricher,
     Gate,
+    Router,
 )
 from modelgauge.annotators.composer.verdict import Verdict
 

--- a/src/modelgauge/annotators/composer/dag.py
+++ b/src/modelgauge/annotators/composer/dag.py
@@ -22,6 +22,7 @@ from modelgauge.annotators.composer.nodes import (
     Arbiter,
     CacheableNodeMixin,
     ComposerNode,
+    Enricher,
     Gate,
 )
 from modelgauge.annotators.composer.verdict import Verdict
@@ -422,12 +423,7 @@ class Composer:
                 node = self._nodes[node_name]
                 total += node.cost
                 path.append(node_name)
-                if isinstance(node, Gate):
-                    targets = node.routes_true if gate_outcomes[node_name] else node.routes_false
-                elif isinstance(node, Arbiter):
-                    targets = []  # type: ignore
-                else:
-                    targets = node.routes
+                targets = node.next_nodes(gate_outcomes.get(node_name))
                 for target in targets:
                     if not isinstance(target, Verdict):
                         reachable.add(target if isinstance(target, str) else target.name)
@@ -641,7 +637,7 @@ class Composer:
                     color="#555555" if hot else "#cccccc",
                     penwidth="2" if hot and traced else "1",
                 )
-            else:
+            elif isinstance(node, Enricher):
                 for target in node.routes:
                     t = target if isinstance(target, str) else target.name
                     hot = not traced or (node_name, t) in traversed_edges  # type: ignore[operator]
@@ -656,6 +652,8 @@ class Composer:
                         fontcolor="#555555" if hot else "#cccccc",
                         penwidth="2" if hot and traced else "1",
                     )
+            else:
+                raise ValueError(f"Unknown node type: {node!r}")
 
         try:
             return Image(dot.pipe(format="png"))

--- a/src/modelgauge/annotators/composer/nodes.py
+++ b/src/modelgauge/annotators/composer/nodes.py
@@ -19,34 +19,18 @@ from modelgauge.annotators.composer.verdict import Verdict
 
 
 class ComposerNode(ABC):
-    def __init__(
-        self,
-        name: str,
-        routes_true: Optional[Sequence[str | Verdict]] = None,
-        routes_false: Optional[Sequence[str | Verdict]] = None,
-        routes: Optional[Sequence[str | Verdict]] = None,
-    ) -> None:
+    def __init__(self, name: str) -> None:
         self.name = name
-        self._routes_true: tuple[str | Verdict, ...] = tuple(routes_true or [])
-        self._routes_false: tuple[str | Verdict, ...] = tuple(routes_false or [])
-        self._routes: tuple[str | Verdict, ...] = tuple(routes or [])
         self.validate()
-
-    @property
-    def routes_true(self) -> tuple[str | Verdict, ...]:
-        return self._routes_true
-
-    @property
-    def routes_false(self) -> tuple[str | Verdict, ...]:
-        return self._routes_false
-
-    @property
-    def routes(self) -> tuple[str | Verdict, ...]:
-        return self._routes
 
     @abstractmethod
     def all_routes(self) -> list[str | Verdict]:
-        """Return a list of all route targets from this node."""
+        """Return a list of all possible route targets from this node."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def all_route_paths(self) -> list[list[str | Verdict]]:
+        """Return a list of possible route paths, separated by branches."""
         raise NotImplementedError
 
     @abstractmethod
@@ -103,7 +87,7 @@ class ComposerNode(ABC):
     def validate(self) -> None:
         """Validate that the node's routing configuration is consistent with its type."""
         # validate that routes with Verdicts only have one Verdict
-        for route_list in [self.routes_true, self.routes_false, self.routes]:
+        for route_list in self.all_route_paths():
             output_routes = [r for r in route_list if isinstance(r, Verdict)]
             if len(output_routes) > 1:
                 raise ValueError(f"{self!r} has multiple Verdict routes {output_routes}, which is not allowed.")
@@ -136,51 +120,48 @@ class LLMCostMixin(ComposerNode):
         )
 
 
-def _validate_binary_routes(node: ComposerNode) -> None:
-    if not node.routes_true or not node.routes_false:
-        raise ValueError(f"{node!r} requires both routes_true and routes_false")
-    if node.routes:
-        raise ValueError(f"{node!r} should not have routes= (use routes_true= / routes_false=)")
-
-
-def _validate_unary_routes(node: ComposerNode) -> None:
-    if not node.routes:
-        raise ValueError(f"{node!r} requires routes=")
-    if node.routes_true or node.routes_false:
-        raise ValueError(f"{node!r} should not have routes_true= / routes_false= (use routes=)")
-
-
-def _validate_terminal(node: ComposerNode) -> None:
-    if node.routes_true or node.routes_false or node.routes:
-        raise ValueError(f"{node!r} is terminal and cannot have routing kwargs")
-
-
 class Gate(ComposerNode):
     """Binary test node."""
+
+    def __init__(
+        self,
+        name: str,
+        routes_true: Sequence[str | Verdict],
+        routes_false: Sequence[str | Verdict],
+    ) -> None:
+        self.routes_true: tuple[str | Verdict, ...] = tuple(routes_true)
+        self.routes_false: tuple[str | Verdict, ...] = tuple(routes_false)
+        super().__init__(name)
 
     def all_routes(self) -> list[str | Verdict]:
         return [*self.routes_true, *self.routes_false]
 
+    def all_route_paths(self) -> list[list[str | Verdict]]:
+        return [list(self.routes_true), list(self.routes_false)]
+
     def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
         return self.routes_true if output_value else self.routes_false
-
-    def validate(self) -> None:
-        super().validate()
-        _validate_binary_routes(self)
 
 
 class Enricher(ComposerNode):
     """Context transformation node."""
 
+    def __init__(
+        self,
+        name: str,
+        routes: Sequence[str | Verdict],
+    ) -> None:
+        self.routes: tuple[str | Verdict, ...] = tuple(routes)
+        super().__init__(name)
+
     def all_routes(self) -> list[str | Verdict]:
         return list(self.routes)
 
+    def all_route_paths(self) -> list[list[str | Verdict]]:
+        return [self.all_routes()]
+
     def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
         return self.routes
-
-    def validate(self) -> None:
-        super().validate()
-        _validate_unary_routes(self)
 
 
 class Arbiter(ComposerNode):
@@ -189,12 +170,11 @@ class Arbiter(ComposerNode):
     def all_routes(self) -> list[str | Verdict]:
         return []
 
+    def all_route_paths(self) -> list[list[str | Verdict]]:
+        return []
+
     def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
         return ()
-
-    def validate(self) -> None:
-        super().validate()
-        _validate_terminal(self)
 
     @property
     @abstractmethod

--- a/src/modelgauge/annotators/composer/nodes.py
+++ b/src/modelgauge/annotators/composer/nodes.py
@@ -4,7 +4,8 @@ Node types for the Composer pipeline.
 Class hierarchy:
 
     ComposerNode (ABC)
-    ├── Gate       (binary test; routes on True/False)
+    ├── Router     (routes to other nodes based on run output)
+        ├── Gate       (binary test; routes on True/False)
     ├── Enricher   (produces arbitary output; routes forward unconditionally)
     └── Arbiter    (produces Output)
     Output         (terminal; carries a verdict value)
@@ -121,8 +122,8 @@ class LLMCostMixin(ComposerNode):
 
 
 class Router(ComposerNode):
-    def __init__(self, name: str, route_map: Dict[str, Sequence[str | Verdict]]) -> None:
-        self.route_map: Dict[str, tuple[str | Verdict, ...]] = {k: tuple(v) for k, v in route_map.items()}
+    def __init__(self, name: str, route_map: Dict[bool | str, Sequence[str | Verdict]]) -> None:
+        self.route_map: Dict[bool | str, tuple[str | Verdict, ...]] = {k: tuple(v) for k, v in route_map.items()}
         super().__init__(name)
 
     def all_routes(self) -> list[str | Verdict]:
@@ -138,7 +139,7 @@ class Router(ComposerNode):
         return self.route_map[output_value]
 
 
-class Gate(ComposerNode):
+class Gate(Router):
     """Binary test node."""
 
     def __init__(
@@ -147,18 +148,8 @@ class Gate(ComposerNode):
         routes_true: Sequence[str | Verdict],
         routes_false: Sequence[str | Verdict],
     ) -> None:
-        self.routes_true: tuple[str | Verdict, ...] = tuple(routes_true)
-        self.routes_false: tuple[str | Verdict, ...] = tuple(routes_false)
-        super().__init__(name)
-
-    def all_routes(self) -> list[str | Verdict]:
-        return [*self.routes_true, *self.routes_false]
-
-    def all_route_paths(self) -> list[list[str | Verdict]]:
-        return [list(self.routes_true), list(self.routes_false)]
-
-    def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
-        return self.routes_true if output_value else self.routes_false
+        route_map: Dict[bool | str, Sequence[str | Verdict]] = {True: routes_true, False: routes_false}
+        super().__init__(name, route_map)
 
 
 class Enricher(ComposerNode):

--- a/src/modelgauge/annotators/composer/nodes.py
+++ b/src/modelgauge/annotators/composer/nodes.py
@@ -11,7 +11,7 @@ Class hierarchy:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence
 
 from modelgauge.annotators.composer.context import EvalContext, NodeOutput
 from modelgauge.annotators.composer.cost import CostInfo, RealizedCost
@@ -118,6 +118,24 @@ class LLMCostMixin(ComposerNode):
             fixed_cost=self.cost.fixed_cost,
             latency_seconds=self.cost.latency_seconds,
         )
+
+
+class Router(ComposerNode):
+    def __init__(self, name: str, route_map: Dict[str, Sequence[str | Verdict]]) -> None:
+        self.route_map: Dict[str, tuple[str | Verdict, ...]] = {k: tuple(v) for k, v in route_map.items()}
+        super().__init__(name)
+
+    def all_routes(self) -> list[str | Verdict]:
+        result: list[str | Verdict] = []
+        for route_targets in self.route_map.values():
+            result.extend(route_targets)
+        return result
+
+    def all_route_paths(self) -> list[list[str | Verdict]]:
+        return [list(routes) for routes in self.route_map.values()]
+
+    def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
+        return self.route_map[output_value]
 
 
 class Gate(ComposerNode):

--- a/src/modelgauge/annotators/composer/nodes.py
+++ b/src/modelgauge/annotators/composer/nodes.py
@@ -45,6 +45,16 @@ class ComposerNode(ABC):
         return self._routes
 
     @abstractmethod
+    def all_routes(self) -> list[str | Verdict]:
+        """Return a list of all route targets from this node."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
+        """Given the node's output value, return the tuple of next node names to activate."""
+        raise NotImplementedError
+
+    @abstractmethod
     def run(self, ctx: EvalContext) -> NodeOutput:
         """Execute the node and return its output and realized cost."""
         raise NotImplementedError  # pragma: no cover
@@ -89,17 +99,6 @@ class ComposerNode(ABC):
             return f"{output:.3g}"
         s = str(output)
         return s if len(s) <= 30 else s[:27] + "..."
-
-    def all_routes(self) -> list[str | Verdict]:
-        """Return a list of all route targets from this node."""
-        return [*self.routes_true, *self.routes_false, *self.routes]
-
-    def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
-        """Given the node's output value, return the tuple of next node names to activate."""
-        if isinstance(self, Gate):
-            return self.routes_true if output_value else self.routes_false
-        else:
-            return self.routes
 
     def validate(self) -> None:
         """Validate that the node's routing configuration is consistent with its type."""
@@ -159,6 +158,12 @@ def _validate_terminal(node: ComposerNode) -> None:
 class Gate(ComposerNode):
     """Binary test node."""
 
+    def all_routes(self) -> list[str | Verdict]:
+        return [*self.routes_true, *self.routes_false]
+
+    def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
+        return self.routes_true if output_value else self.routes_false
+
     def validate(self) -> None:
         super().validate()
         _validate_binary_routes(self)
@@ -167,13 +172,25 @@ class Gate(ComposerNode):
 class Enricher(ComposerNode):
     """Context transformation node."""
 
+    def all_routes(self) -> list[str | Verdict]:
+        return list(self.routes)
+
+    def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
+        return self.routes
+
     def validate(self) -> None:
         super().validate()
         _validate_unary_routes(self)
 
 
 class Arbiter(ComposerNode):
-    """Takes context and returns a Verdict indicating the final verdict (based on routes)."""
+    """Terminal node. Takes context and returns a Verdict indicating the final verdict (based on routes)."""
+
+    def all_routes(self) -> list[str | Verdict]:
+        return []
+
+    def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
+        return ()
 
     def validate(self) -> None:
         super().validate()

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/conftest.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/conftest.py
@@ -16,6 +16,9 @@ from modelgauge_tests.annotator_tests.composer_tests.mocks import (
     LowerCaser,
     LowerCaseScorer,
     PromptLengthGate,
+    PromptLengthRouter,
+    RouterA,
+    RouterB,
     ThresholdArbiter,
     UnexpectedArbiter,
     UnexpectedOutput,
@@ -32,8 +35,11 @@ TRUE_BRANCH: tuple[str | Verdict] = ("true_branch",)
 FALSE_BRANCH: tuple[str | Verdict] = ("false_branch",)
 DEFAULT_BRANCH: tuple[str | Verdict] = ("next_node",)
 BAD_BRANCH: tuple[str | Verdict] = ("undefined_node",)
+VERDICT_BRANCH: tuple[str | Verdict] = (Safety(is_safe=True),)
 SCORE1 = 1.0
 SCORE2 = 2.0
+ROUTER_KEY_A = "key_a"
+ROUTER_KEY_B = "key_b"
 
 skip_in_ci = pytest.mark.skipif(os.getenv("CI") == "true", reason="skipped in CI")
 
@@ -51,6 +57,29 @@ def bad_gate() -> AlwaysTrue:
 @pytest.fixture
 def always_false_gate() -> AlwaysFalse:
     return AlwaysFalse(name="always_false", routes_true=TRUE_BRANCH, routes_false=FALSE_BRANCH)
+
+
+@pytest.fixture
+def router_a() -> RouterA:
+    return RouterA(name="router_a", route_map={ROUTER_KEY_A: TRUE_BRANCH, ROUTER_KEY_B: FALSE_BRANCH})
+
+
+@pytest.fixture
+def router_b() -> RouterB:
+    return RouterB(name="router_b", route_map={ROUTER_KEY_A: TRUE_BRANCH, ROUTER_KEY_B: FALSE_BRANCH})
+
+
+@pytest.fixture
+def router_to_verdict() -> RouterA:
+    return RouterA(name="router_to_verdict", route_map={ROUTER_KEY_A: VERDICT_BRANCH, ROUTER_KEY_B: FALSE_BRANCH})
+
+
+@pytest.fixture
+def prompt_length_router() -> PromptLengthRouter:
+    return PromptLengthRouter(
+        name="prompt_length_router",
+        route_map={PromptLengthRouter.SHORT_KEY: TRUE_BRANCH, PromptLengthRouter.LONG_KEY: FALSE_BRANCH},
+    )
 
 
 @pytest.fixture
@@ -91,6 +120,22 @@ def always_safe() -> AlwaysSafe:
 @pytest.fixture
 def threshold_arbiter() -> ThresholdArbiter:
     return ThresholdArbiter(name="threshold_arbiter", threshold=1.5)
+
+
+@pytest.fixture
+def router_dag() -> Composer:
+    """Two-branch DAG: RouterA always picks key_a → AlwaysSafe; key_b → AlwaysUnsafe."""
+    return (
+        Composer("router_dag", verdict_type=Safety)
+        .add_node(
+            RouterA(
+                name="router",
+                route_map={"key_a": ["always_safe"], "key_b": ["always_unsafe"]},
+            )
+        )
+        .add_node(AlwaysSafe(name="always_safe"))
+        .add_node(AlwaysUnsafe(name="always_unsafe"))
+    )
 
 
 @pytest.fixture

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/mocks.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/mocks.py
@@ -7,6 +7,7 @@ from modelgauge.annotators.composer.nodes import (
     Enricher,
     Gate,
     LLMCostMixin,
+    Router,
 )
 from modelgauge.annotators.composer.verdict import Verdict
 
@@ -71,6 +72,32 @@ class PromptLengthGate(Gate):
             fixed_cost=0.2,
             latency_seconds=0.2,
         )
+
+
+class PassthroughRouter(Router):
+    ROUTE_KEY: str
+
+    def run(self, ctx: EvalContext) -> NodeOutput:
+        return self.build_output(self.ROUTE_KEY, ctx)
+
+
+class RouterA(PassthroughRouter):
+    ROUTE_KEY = "key_a"
+
+
+class RouterB(PassthroughRouter):
+    ROUTE_KEY = "key_b"
+
+
+class PromptLengthRouter(Router):
+    """Routes to 'short' or 'long' based on whether the prompt is under 20 characters."""
+
+    SHORT_KEY = "short"
+    LONG_KEY = "long"
+
+    def run(self, ctx: EvalContext) -> NodeOutput:
+        key = self.SHORT_KEY if len(ctx.prompt) < 20 else self.LONG_KEY
+        return self.build_output(key, ctx)
 
 
 class Caser(Enricher, LLMCostMixin):

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
@@ -10,9 +10,12 @@ from modelgauge_tests.annotator_tests.composer_tests.mocks import (
     AlwaysSafe,
     AlwaysTrue,
     AlwaysTrueCacheable,
+    AlwaysUnsafe,
     LowerCaser,
     LowerCaseScorer,
     NoOpEnricher,
+    PromptLengthRouter,
+    RouterA,
     ThresholdArbiter,
     UpperCaser,
 )
@@ -489,3 +492,100 @@ def test_composer_names_override():
 def test_composer_names_partial_override_no_name_raises():
     with pytest.raises(ValueError, match="composer_name must be provided"):
         ComposerColumnNames(output_col_name="my_output")
+
+
+# ---------------------------------------------------------------------------
+# Router-based DAG tests
+# ---------------------------------------------------------------------------
+
+
+def test_dag_with_router_takes_correct_branch(router_dag, sample_ctx):
+    """RouterA always emits key_a, so the DAG should resolve to SAFE."""
+    output = router_dag.run(sample_ctx)
+    assert output.verdict.name == "SAFE"
+
+
+def test_dag_with_router_skips_other_branch(router_dag, sample_ctx):
+    """Nodes on the unselected branch should not appear in node_outputs."""
+    output = router_dag.run(sample_ctx)
+    assert "router" in output.node_outputs
+    assert "always_safe" in output.node_outputs
+    assert "always_unsafe" not in output.node_outputs
+
+
+def test_dag_with_router_routes_to_verdict_directly(sample_ctx):
+    """A router can point to a Verdict directly instead of to a downstream node."""
+    dag = Composer("router_to_verdict", verdict_type=Safety).add_node(
+        RouterA(
+            name="router",
+            route_map={"key_a": [Safety(is_safe=True)], "key_b": [Safety(is_safe=False)]},
+        )
+    )
+    output = dag.run(sample_ctx)
+    assert output.verdict.name == "SAFE"
+
+
+def test_dag_with_router_routes_to_verdict_false_branch():
+    """If the router emits the key mapping to is_safe=False, verdict should be UNSAFE."""
+    from modelgauge_tests.annotator_tests.composer_tests.mocks import RouterB
+
+    dag = Composer("router_to_verdict_b", verdict_type=Safety).add_node(
+        RouterB(
+            name="router",
+            route_map={"key_a": [Safety(is_safe=True)], "key_b": [Safety(is_safe=False)]},
+        )
+    )
+    ctx = EvalContext(prompt="hello", response="world")
+    output = dag.run(ctx)
+    assert output.verdict.name == "UNSAFE"
+
+
+def test_dag_with_prompt_length_router_short_prompt():
+    """PromptLengthRouter routes a short prompt (<20 chars) to 'short' → AlwaysSafe."""
+    dag = (
+        Composer("plr_dag", verdict_type=Safety)
+        .add_node(
+            PromptLengthRouter(
+                name="length_router",
+                route_map={
+                    PromptLengthRouter.SHORT_KEY: ["always_safe"],
+                    PromptLengthRouter.LONG_KEY: ["always_unsafe"],
+                },
+            )
+        )
+        .add_node(AlwaysSafe(name="always_safe"))
+        .add_node(AlwaysUnsafe(name="always_unsafe"))
+    )
+    ctx = EvalContext(prompt="Hi", response="Response.")
+    output = dag.run(ctx)
+    assert output.verdict.name == "SAFE"
+
+
+def test_dag_with_prompt_length_router_long_prompt():
+    """PromptLengthRouter routes a long prompt (≥20 chars) to 'long' → AlwaysUnsafe."""
+    dag = (
+        Composer("plr_dag_long", verdict_type=Safety)
+        .add_node(
+            PromptLengthRouter(
+                name="length_router",
+                route_map={
+                    PromptLengthRouter.SHORT_KEY: ["always_safe"],
+                    PromptLengthRouter.LONG_KEY: ["always_unsafe"],
+                },
+            )
+        )
+        .add_node(AlwaysSafe(name="always_safe"))
+        .add_node(AlwaysUnsafe(name="always_unsafe"))
+    )
+    ctx = EvalContext(prompt="This is a much longer prompt string", response="Response.")
+    output = dag.run(ctx)
+    assert output.verdict.name == "UNSAFE"
+
+
+def test_dag_cost_all_paths_with_router(router_dag):
+    """potential_costs should enumerate one path per router key."""
+    costs = router_dag.potential_costs()
+    assert costs.keys() == {
+        "router -> always_safe -> Out (Safety)",
+        "router -> always_unsafe -> Out (Safety)",
+    }

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
@@ -86,48 +86,6 @@ def test_gate_with_two_outputs():
         )
 
 
-def test_gate_with_no_true_route():
-    with pytest.raises(ValueError, match="requires both routes_true and routes_false"):
-        AlwaysTrue(
-            name="bad_gate",
-            routes_false=FALSE_BRANCH,
-        )
-
-
-def test_gate_with_routes():
-    with pytest.raises(ValueError, match="should not have routes"):
-        AlwaysTrue(
-            name="bad_gate",
-            routes_true=TRUE_BRANCH,
-            routes_false=FALSE_BRANCH,
-            routes=DEFAULT_BRANCH,
-        )
-
-
-def test_enricher_with_binary_routes():
-    with pytest.raises(ValueError, match="should not have routes_true= / routes_false="):
-        LowerCaser(
-            name="bad_enricher",
-            routes_true=TRUE_BRANCH,
-            routes=DEFAULT_BRANCH,
-        )
-
-
-def test_enricher_with_no_routes():
-    with pytest.raises(ValueError, match="requires routes="):
-        LowerCaser(
-            name="bad_enricher",
-        )
-
-
-def test_arbiter_with_routes():
-    with pytest.raises(ValueError, match="is terminal and cannot have routing kwargs"):
-        AlwaysUnsafe(
-            name="bad_arbiter",
-            routes=DEFAULT_BRANCH,
-        )
-
-
 def test_note_format_output():
     assert ComposerNode.format_output(3.1415926535) == "3.14"
     assert ComposerNode.format_output("short string") == "short string"

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
@@ -4,18 +4,24 @@ import pytest
 from modelgauge_tests.annotator_tests.composer_tests.conftest import (
     DEFAULT_BRANCH,
     FALSE_BRANCH,
+    ROUTER_KEY_A,
+    ROUTER_KEY_B,
     SCORE1,
     SCORE2,
     TRUE_BRANCH,
+    VERDICT_BRANCH,
 )
 from modelgauge_tests.annotator_tests.composer_tests.mocks import (
     AlwaysTrue,
     AlwaysUnsafe,
     LowerCaser,
+    PromptLengthRouter,
+    RouterA,
+    RouterB,
 )
 
 from modelgauge.annotators.composed_annotator import Safety
-from modelgauge.annotators.composer.context import NodeOutput
+from modelgauge.annotators.composer.context import EvalContext, NodeOutput
 from modelgauge.annotators.composer.nodes import ComposerNode
 
 
@@ -75,6 +81,69 @@ def test_threshold_arbiter_false(sample_ctx, threshold_arbiter):
     )
     output = threshold_arbiter.run(run_ctx)
     assert output.value.name == "SAFE"
+
+
+def test_router_routes_to_key_a(sample_ctx, router_a):
+    output = router_a.run(sample_ctx)
+    assert output.value == ROUTER_KEY_A
+    assert router_a.next_nodes(output.value) == TRUE_BRANCH
+
+
+def test_router_routes_to_key_b(sample_ctx, router_b):
+    output = router_b.run(sample_ctx)
+    assert output.value == ROUTER_KEY_B
+    assert router_b.next_nodes(output.value) == FALSE_BRANCH
+
+
+def test_router_unknown_key_raises(router_a):
+    with pytest.raises(KeyError):
+        router_a.next_nodes("unknown_key")
+
+
+def test_router_all_routes_contains_all_branches(router_a):
+    routes = router_a.all_routes()
+    for target in TRUE_BRANCH:
+        assert target in routes
+    for target in FALSE_BRANCH:
+        assert target in routes
+
+
+def test_router_all_route_paths_single_group(router_a):
+    route_paths = router_a.all_route_paths()
+    assert len(route_paths) == 2
+    assert list(TRUE_BRANCH) in route_paths
+    assert list(FALSE_BRANCH) in route_paths
+
+
+def test_router_routes_to_verdict(sample_ctx, router_to_verdict):
+    output = router_to_verdict.run(sample_ctx)
+    assert output.value == ROUTER_KEY_A
+    next_nodes = router_to_verdict.next_nodes(output.value)
+    assert len(next_nodes) == len(VERDICT_BRANCH)
+    assert isinstance(next_nodes[0], Safety)
+    assert next_nodes[0].is_safe is True
+
+
+def test_router_with_two_verdicts_in_path_raises():
+    with pytest.raises(ValueError, match="has multiple Verdict routes"):
+        RouterA(
+            name="bad_router",
+            route_map={ROUTER_KEY_A: [Safety(is_safe=True), Safety(is_safe=False)], ROUTER_KEY_B: FALSE_BRANCH},
+        )
+
+
+def test_prompt_length_router_short_prompt(sample_ctx, prompt_length_router):
+    # sample_ctx has prompt="Hello, world" (12 chars < 20)
+    output = prompt_length_router.run(sample_ctx)
+    assert output.value == PromptLengthRouter.SHORT_KEY
+    assert prompt_length_router.next_nodes(output.value) == TRUE_BRANCH
+
+
+def test_prompt_length_router_long_prompt(prompt_length_router):
+    ctx = EvalContext(prompt="This is a much longer prompt string", response="Response.")
+    output = prompt_length_router.run(ctx)
+    assert output.value == PromptLengthRouter.LONG_KEY
+    assert prompt_length_router.next_nodes(output.value) == FALSE_BRANCH
 
 
 def test_gate_with_two_outputs():


### PR DESCRIPTION
New node object called `Router` which can route to multiple node paths depending on a route_map.
The `Gate` node is still there and is now a subclass of `Router`.