### PR TITLE
Remove gate

### DIFF
--- a/src/modelgauge/annotators/composer/dag.py
+++ b/src/modelgauge/annotators/composer/dag.py
@@ -112,13 +112,13 @@ class Composer:
 
     Usage:
 
-        refusal_gate     = MyRefusalGate("RefusalGate", routes_true=[Score(value=1)], routes_false=["NonRefusal"])
+        refusal_router   = MyRefusalRouter("RefusalRouter", route_map={True: [Score(value=1)], False: ["NonRefusal"]})
         eval_non_refusal = MyNonRefusalEvaluator("NonRefusal", routes=["Arbiter"])
         arbiter          = MyArbiter("Arbiter")
 
         dag = (
             Composer("refusal_gated_safety_evaluator", verdict_type=Safety)
-            .add_node(refusal_gate)
+            .add_node(refusal_router)
             .add_node(eval_non_refusal)
             .add_node(arbiter)
         )
@@ -665,7 +665,7 @@ class Composer:
 
         The graph flows left to right. Node shapes and colors:
           - Input          — teal parallelogram (implicit; represents the prompt/response pair)
-          - Gate           — amber diamond; edges labelled "True" (green) / "False" (red)
+          - Router           — amber diamond; edges labelled "True" (green) / "False" (red)
           - Enricher       — light grey rectangle; edges are unlabelled
           - Arbiter        — light purple hexagon; edge labelled with the output type name
           - Output (direct instance)   — soft green rounded rectangle, solid border;

--- a/src/modelgauge/annotators/composer/nodes.py
+++ b/src/modelgauge/annotators/composer/nodes.py
@@ -120,9 +120,29 @@ class LLMCostMixin(ComposerNode):
         )
 
 
+class NoRouteError(Exception):
+    """Error raised when no route is found for a given output value."""
+
+    def __init__(self, node_name: str, output_value: Any) -> None:
+        super().__init__(f"Node {node_name} could not find a route for output value {output_value} in its route map.")
+
+
 class Router(ComposerNode):
-    def __init__(self, name: str, route_map: Dict[bool | str, Sequence[str | Verdict]]) -> None:
+    """
+    Node that routes to other nodes based on the output value.
+    If the output value is not in the route map, the default_route is used. If no default_route is provided, an error is raised.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        route_map: Dict[bool | str, Sequence[str | Verdict]],
+        default_route: Optional[Sequence[str | Verdict]] = None,
+    ) -> None:
         self.route_map: Dict[bool | str, tuple[str | Verdict, ...]] = {k: tuple(v) for k, v in route_map.items()}
+        self.default_route: Optional[tuple[str | Verdict, ...]] = (
+            tuple(default_route) if default_route is not None else None
+        )
         super().__init__(name)
 
     def all_routes(self) -> list[str | Verdict]:
@@ -135,6 +155,10 @@ class Router(ComposerNode):
         return [list(routes) for routes in self.route_map.values()]
 
     def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
+        if output_value not in self.route_map:
+            if self.default_route is None:
+                raise NoRouteError(self.name, output_value)
+            return self.default_route
         return self.route_map[output_value]
 
 

--- a/src/modelgauge/annotators/composer/nodes.py
+++ b/src/modelgauge/annotators/composer/nodes.py
@@ -5,7 +5,6 @@ Class hierarchy:
 
     ComposerNode (ABC)
     ├── Router     (routes to other nodes based on run output)
-        ├── Gate       (binary test; routes on True/False)
     ├── Enricher   (produces arbitary output; routes forward unconditionally)
     └── Arbiter    (produces Output)
     Output         (terminal; carries a verdict value)
@@ -137,19 +136,6 @@ class Router(ComposerNode):
 
     def next_nodes(self, output_value: Any) -> tuple[str | Verdict, ...]:
         return self.route_map[output_value]
-
-
-class Gate(Router):
-    """Binary test node."""
-
-    def __init__(
-        self,
-        name: str,
-        routes_true: Sequence[str | Verdict],
-        routes_false: Sequence[str | Verdict],
-    ) -> None:
-        route_map: Dict[bool | str, Sequence[str | Verdict]] = {True: routes_true, False: routes_false}
-        super().__init__(name, route_map)
 
 
 class Enricher(ComposerNode):

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/conftest.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/conftest.py
@@ -46,17 +46,17 @@ skip_in_ci = pytest.mark.skipif(os.getenv("CI") == "true", reason="skipped in CI
 
 @pytest.fixture
 def always_true_gate() -> AlwaysTrue:
-    return AlwaysTrue(name="always_true", routes_true=TRUE_BRANCH, routes_false=FALSE_BRANCH)
+    return AlwaysTrue(name="always_true", route_map={True: TRUE_BRANCH, False: FALSE_BRANCH})
 
 
 @pytest.fixture
 def bad_gate() -> AlwaysTrue:
-    return AlwaysTrue(name="bad_gate", routes_true=BAD_BRANCH, routes_false=FALSE_BRANCH)
+    return AlwaysTrue(name="bad_gate", route_map={True: BAD_BRANCH, False: FALSE_BRANCH})
 
 
 @pytest.fixture
 def always_false_gate() -> AlwaysFalse:
-    return AlwaysFalse(name="always_false", routes_true=TRUE_BRANCH, routes_false=FALSE_BRANCH)
+    return AlwaysFalse(name="always_false", route_map={True: TRUE_BRANCH, False: FALSE_BRANCH})
 
 
 @pytest.fixture
@@ -145,8 +145,7 @@ def one_step_dag():
         .add_node(
             AlwaysFalse(
                 name="gate",
-                routes_true=[Safety(is_safe=True)],
-                routes_false=["always_unsafe"],
+                route_map={True: [Safety(is_safe=True)], False: ["always_unsafe"]},
             )
         )
         .add_node(AlwaysUnsafe(name="always_unsafe"))
@@ -158,8 +157,7 @@ def cached_minimal_dag(tmp_path):
     return Composer("cached_minimal", verdict_type=Safety, cache_path=tmp_path).add_node(
         AlwaysTrueCacheable(
             name="always_true",
-            routes_true=[Safety(is_safe=True)],
-            routes_false=[Safety(is_safe=False)],
+            route_map={True: [Safety(is_safe=True)], False: [Safety(is_safe=False)]},
         )
     )
 
@@ -171,16 +169,14 @@ def cached_simple_dag(tmp_path):
         .add_node(
             AlwaysTrueCacheable(
                 name="always_true",
-                routes_true=["lower_caser", "prompt_parity"],
-                routes_false=["always_safe"],
+                route_map={True: ["lower_caser", "prompt_parity"], False: ["always_safe"]},
             )
         )
         .add_node(AlwaysSafe(name="always_safe"))
         .add_node(
             PromptLengthGate(
                 name="prompt_parity",
-                routes_true=[Safety(is_safe=False)],
-                routes_false=["upper_scorer"],
+                route_map={True: [Safety(is_safe=False)], False: ["upper_scorer"]},
             )
         )
         .add_node(LowerCaser(name="lower_caser", routes=["lower_scorer", "upper_scorer"]))
@@ -197,16 +193,14 @@ def simple_dag():
         .add_node(
             AlwaysTrue(
                 name="always_true",
-                routes_true=["lower_caser", "prompt_parity"],
-                routes_false=["always_safe"],
+                route_map={True: ["lower_caser", "prompt_parity"], False: ["always_safe"]},
             )
         )
         .add_node(AlwaysSafe(name="always_safe"))
         .add_node(
             PromptLengthGate(
                 name="prompt_parity",
-                routes_true=[Safety(is_safe=False)],
-                routes_false=["upper_scorer"],
+                route_map={True: [Safety(is_safe=False)], False: ["upper_scorer"]},
             )
         )
         .add_node(LowerCaser(name="lower_caser", routes=["lower_scorer", "upper_scorer"]))
@@ -223,22 +217,19 @@ def bad_dag_with_cycle():
         .add_node(
             AlwaysTrue(
                 name="node1",
-                routes_true=["node2"],
-                routes_false=["node3"],
+                route_map={True: ["node2"], False: ["node3"]},
             )
         )
         .add_node(
             AlwaysTrue(
                 name="node2",
-                routes_true=["node3"],
-                routes_false=["node1"],
+                route_map={True: ["node3"], False: ["node1"]},
             )
         )
         .add_node(
             AlwaysTrue(
                 name="node3",
-                routes_true=[Safety(is_safe=True)],
-                routes_false=[Safety(is_safe=False)],
+                route_map={True: [Safety(is_safe=True)], False: [Safety(is_safe=False)]},
             )
         )
     )
@@ -265,8 +256,7 @@ def bad_one_step_dag():
         .add_node(
             AlwaysFalse(
                 name="gate",
-                routes_true=[UnexpectedOutput()],
-                routes_false=["always_unsafe"],
+                route_map={True: [UnexpectedOutput()], False: ["always_unsafe"]},
             )
         )
         .add_node(AlwaysUnsafe(name="always_unsafe"))

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/conftest.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/conftest.py
@@ -16,9 +16,7 @@ from modelgauge_tests.annotator_tests.composer_tests.mocks import (
     LowerCaser,
     LowerCaseScorer,
     PromptLengthGate,
-    PromptLengthRouter,
     RouterA,
-    RouterB,
     ThresholdArbiter,
     UnexpectedArbiter,
     UnexpectedOutput,
@@ -65,21 +63,8 @@ def router_a() -> RouterA:
 
 
 @pytest.fixture
-def router_b() -> RouterB:
-    return RouterB(name="router_b", route_map={ROUTER_KEY_A: TRUE_BRANCH, ROUTER_KEY_B: FALSE_BRANCH})
-
-
-@pytest.fixture
 def router_to_verdict() -> RouterA:
     return RouterA(name="router_to_verdict", route_map={ROUTER_KEY_A: VERDICT_BRANCH, ROUTER_KEY_B: FALSE_BRANCH})
-
-
-@pytest.fixture
-def prompt_length_router() -> PromptLengthRouter:
-    return PromptLengthRouter(
-        name="prompt_length_router",
-        route_map={PromptLengthRouter.SHORT_KEY: TRUE_BRANCH, PromptLengthRouter.LONG_KEY: FALSE_BRANCH},
-    )
 
 
 @pytest.fixture

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/mocks.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/mocks.py
@@ -5,7 +5,6 @@ from modelgauge.annotators.composer.nodes import (
     Arbiter,
     CacheableNodeMixin,
     Enricher,
-    Gate,
     LLMCostMixin,
     Router,
 )
@@ -22,7 +21,7 @@ class FailingNode(Enricher):
         raise RuntimeError("I'm afraid I can't do that, Dave.")
 
 
-class PassthroughGate(Gate, LLMCostMixin):
+class PassthroughGate(Router, LLMCostMixin):
     ROUTE_TO_TAKE: bool
 
     def run(self, ctx: EvalContext) -> NodeOutput:
@@ -62,7 +61,7 @@ class AlwaysFalse(PassthroughGate):
         )
 
 
-class PromptLengthGate(Gate):
+class PromptLengthGate(Router):
     def run(self, ctx: EvalContext) -> NodeOutput:
         return self.build_output(len(ctx.prompt) % 2 == 0, ctx)
 

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
@@ -89,13 +89,11 @@ def test_dag_uses_per_node_disk_cache(tmp_path, sample_ctx):
     """Each cacheable node must use cache_path / node.name, not a shared store."""
     gate_a = AlwaysTrueCacheable(
         name="gate_a",
-        routes_true=["gate_b"],
-        routes_false=[Safety(is_safe=False)],
+        route_map={True: ["gate_b"], False: [Safety(is_safe=False)]},
     )
     gate_b = AlwaysTrueCacheable(
         name="gate_b",
-        routes_true=[Safety(is_safe=True)],
-        routes_false=[Safety(is_safe=False)],
+        route_map={True: [Safety(is_safe=True)], False: [Safety(is_safe=False)]},
     )
     dag = Composer("per_node_cache", verdict_type=Safety, cache_path=tmp_path).add_node(gate_a).add_node(gate_b)
 
@@ -130,8 +128,7 @@ def test_dag_cacheable_node_without_cache_path_runs_each_time(sample_ctx):
     dag = Composer("no_cache", verdict_type=Safety).add_node(
         AlwaysTrueCacheable(
             name="always_true",
-            routes_true=[Safety(is_safe=True)],
-            routes_false=[Safety(is_safe=False)],
+            route_map={True: [Safety(is_safe=True)], False: [Safety(is_safe=False)]},
         )
     )
     dag.run(sample_ctx)
@@ -185,8 +182,7 @@ def test_dag_passes_updated_context_to_downstream_nodes():
         .add_node(
             AlwaysTrue(
                 name="always_true",
-                routes_true=["lower_caser"],
-                routes_false=["always_safe"],
+                route_map={True: ["lower_caser"], False: ["always_safe"]},
             )
         )
         .add_node(AlwaysSafe(name="always_safe"))
@@ -210,8 +206,7 @@ def test_dag_updated_context_not_passed_to_parallel_nodes():
         .add_node(
             AlwaysTrue(
                 name="always_true",
-                routes_true=["lower_caser", "noop"],
-                routes_false=["always_safe"],
+                route_map={True: ["lower_caser", "noop"], False: ["always_safe"]},
             )
         )
         .add_node(AlwaysSafe(name="always_safe"))
@@ -267,8 +262,7 @@ def test_dag_parallel_nodes_different_updated_contexts_raises_error():
         .add_node(
             AlwaysTrue(
                 name="always_true",
-                routes_true=["lower_caser", "upper_caser"],
-                routes_false=["always_safe"],
+                route_map={True: ["lower_caser", "upper_caser"], False: ["always_safe"]},
             )
         )
         .add_node(AlwaysSafe(name="always_safe"))

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
@@ -14,8 +14,6 @@ from modelgauge_tests.annotator_tests.composer_tests.mocks import (
     LowerCaser,
     LowerCaseScorer,
     NoOpEnricher,
-    PromptLengthRouter,
-    RouterA,
     ThresholdArbiter,
     UpperCaser,
 )
@@ -493,93 +491,9 @@ def test_composer_names_partial_override_no_name_raises():
 # ---------------------------------------------------------------------------
 
 
-def test_dag_with_router_takes_correct_branch(router_dag, sample_ctx):
-    """RouterA always emits key_a, so the DAG should resolve to SAFE."""
-    output = router_dag.run(sample_ctx)
-    assert output.verdict.name == "SAFE"
-
-
 def test_dag_with_router_skips_other_branch(router_dag, sample_ctx):
     """Nodes on the unselected branch should not appear in node_outputs."""
     output = router_dag.run(sample_ctx)
     assert "router" in output.node_outputs
     assert "always_safe" in output.node_outputs
     assert "always_unsafe" not in output.node_outputs
-
-
-def test_dag_with_router_routes_to_verdict_directly(sample_ctx):
-    """A router can point to a Verdict directly instead of to a downstream node."""
-    dag = Composer("router_to_verdict", verdict_type=Safety).add_node(
-        RouterA(
-            name="router",
-            route_map={"key_a": [Safety(is_safe=True)], "key_b": [Safety(is_safe=False)]},
-        )
-    )
-    output = dag.run(sample_ctx)
-    assert output.verdict.name == "SAFE"
-
-
-def test_dag_with_router_routes_to_verdict_false_branch():
-    """If the router emits the key mapping to is_safe=False, verdict should be UNSAFE."""
-    from modelgauge_tests.annotator_tests.composer_tests.mocks import RouterB
-
-    dag = Composer("router_to_verdict_b", verdict_type=Safety).add_node(
-        RouterB(
-            name="router",
-            route_map={"key_a": [Safety(is_safe=True)], "key_b": [Safety(is_safe=False)]},
-        )
-    )
-    ctx = EvalContext(prompt="hello", response="world")
-    output = dag.run(ctx)
-    assert output.verdict.name == "UNSAFE"
-
-
-def test_dag_with_prompt_length_router_short_prompt():
-    """PromptLengthRouter routes a short prompt (<20 chars) to 'short' → AlwaysSafe."""
-    dag = (
-        Composer("plr_dag", verdict_type=Safety)
-        .add_node(
-            PromptLengthRouter(
-                name="length_router",
-                route_map={
-                    PromptLengthRouter.SHORT_KEY: ["always_safe"],
-                    PromptLengthRouter.LONG_KEY: ["always_unsafe"],
-                },
-            )
-        )
-        .add_node(AlwaysSafe(name="always_safe"))
-        .add_node(AlwaysUnsafe(name="always_unsafe"))
-    )
-    ctx = EvalContext(prompt="Hi", response="Response.")
-    output = dag.run(ctx)
-    assert output.verdict.name == "SAFE"
-
-
-def test_dag_with_prompt_length_router_long_prompt():
-    """PromptLengthRouter routes a long prompt (≥20 chars) to 'long' → AlwaysUnsafe."""
-    dag = (
-        Composer("plr_dag_long", verdict_type=Safety)
-        .add_node(
-            PromptLengthRouter(
-                name="length_router",
-                route_map={
-                    PromptLengthRouter.SHORT_KEY: ["always_safe"],
-                    PromptLengthRouter.LONG_KEY: ["always_unsafe"],
-                },
-            )
-        )
-        .add_node(AlwaysSafe(name="always_safe"))
-        .add_node(AlwaysUnsafe(name="always_unsafe"))
-    )
-    ctx = EvalContext(prompt="This is a much longer prompt string", response="Response.")
-    output = dag.run(ctx)
-    assert output.verdict.name == "UNSAFE"
-
-
-def test_dag_cost_all_paths_with_router(router_dag):
-    """potential_costs should enumerate one path per router key."""
-    costs = router_dag.potential_costs()
-    assert costs.keys() == {
-        "router -> always_safe -> Out (Safety)",
-        "router -> always_unsafe -> Out (Safety)",
-    }

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
@@ -10,11 +10,11 @@ from modelgauge_tests.annotator_tests.composer_tests.conftest import (
     TRUE_BRANCH,
     VERDICT_BRANCH,
 )
-from modelgauge_tests.annotator_tests.composer_tests.mocks import AlwaysTrue
+from modelgauge_tests.annotator_tests.composer_tests.mocks import AlwaysTrue, RouterA
 
 from modelgauge.annotators.composed_annotator import Safety
 from modelgauge.annotators.composer.context import NodeOutput
-from modelgauge.annotators.composer.nodes import ComposerNode
+from modelgauge.annotators.composer.nodes import ComposerNode, NoRouteError
 
 
 def test_true_routes_to_true_branch(sample_ctx, always_true_gate):
@@ -75,9 +75,18 @@ def test_threshold_arbiter_false(sample_ctx, threshold_arbiter):
     assert output.value.name == "SAFE"
 
 
-def test_router_unknown_key_raises(router_a):
-    with pytest.raises(KeyError):
+def test_router_no_default_route_raises_no_route_error(router_a):
+    with pytest.raises(NoRouteError):
         router_a.next_nodes("unknown_key")
+
+
+def test_router_default_route_used_for_unknown_key():
+    router = RouterA(
+        name="test_router",
+        route_map={ROUTER_KEY_A: TRUE_BRANCH},
+        default_route=FALSE_BRANCH,
+    )
+    assert router.next_nodes("unexpected_key") == FALSE_BRANCH
 
 
 def test_router_all_routes_contains_all_branches(router_a):

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
@@ -5,23 +5,15 @@ from modelgauge_tests.annotator_tests.composer_tests.conftest import (
     DEFAULT_BRANCH,
     FALSE_BRANCH,
     ROUTER_KEY_A,
-    ROUTER_KEY_B,
     SCORE1,
     SCORE2,
     TRUE_BRANCH,
     VERDICT_BRANCH,
 )
-from modelgauge_tests.annotator_tests.composer_tests.mocks import (
-    AlwaysTrue,
-    AlwaysUnsafe,
-    LowerCaser,
-    PromptLengthRouter,
-    RouterA,
-    RouterB,
-)
+from modelgauge_tests.annotator_tests.composer_tests.mocks import AlwaysTrue
 
 from modelgauge.annotators.composed_annotator import Safety
-from modelgauge.annotators.composer.context import EvalContext, NodeOutput
+from modelgauge.annotators.composer.context import NodeOutput
 from modelgauge.annotators.composer.nodes import ComposerNode
 
 
@@ -83,18 +75,6 @@ def test_threshold_arbiter_false(sample_ctx, threshold_arbiter):
     assert output.value.name == "SAFE"
 
 
-def test_router_routes_to_key_a(sample_ctx, router_a):
-    output = router_a.run(sample_ctx)
-    assert output.value == ROUTER_KEY_A
-    assert router_a.next_nodes(output.value) == TRUE_BRANCH
-
-
-def test_router_routes_to_key_b(sample_ctx, router_b):
-    output = router_b.run(sample_ctx)
-    assert output.value == ROUTER_KEY_B
-    assert router_b.next_nodes(output.value) == FALSE_BRANCH
-
-
 def test_router_unknown_key_raises(router_a):
     with pytest.raises(KeyError):
         router_a.next_nodes("unknown_key")
@@ -122,28 +102,6 @@ def test_router_routes_to_verdict(sample_ctx, router_to_verdict):
     assert len(next_nodes) == len(VERDICT_BRANCH)
     assert isinstance(next_nodes[0], Safety)
     assert next_nodes[0].is_safe is True
-
-
-def test_router_with_two_verdicts_in_path_raises():
-    with pytest.raises(ValueError, match="has multiple Verdict routes"):
-        RouterA(
-            name="bad_router",
-            route_map={ROUTER_KEY_A: [Safety(is_safe=True), Safety(is_safe=False)], ROUTER_KEY_B: FALSE_BRANCH},
-        )
-
-
-def test_prompt_length_router_short_prompt(sample_ctx, prompt_length_router):
-    # sample_ctx has prompt="Hello, world" (12 chars < 20)
-    output = prompt_length_router.run(sample_ctx)
-    assert output.value == PromptLengthRouter.SHORT_KEY
-    assert prompt_length_router.next_nodes(output.value) == TRUE_BRANCH
-
-
-def test_prompt_length_router_long_prompt(prompt_length_router):
-    ctx = EvalContext(prompt="This is a much longer prompt string", response="Response.")
-    output = prompt_length_router.run(ctx)
-    assert output.value == PromptLengthRouter.LONG_KEY
-    assert prompt_length_router.next_nodes(output.value) == FALSE_BRANCH
 
 
 def test_gate_with_two_outputs():

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_nodes.py
@@ -150,8 +150,7 @@ def test_gate_with_two_outputs():
     with pytest.raises(ValueError, match="has multiple Verdict routes"):
         AlwaysTrue(
             name="bad_gate",
-            routes_true=[Safety(is_safe=True), Safety(is_safe=False)],
-            routes_false=FALSE_BRANCH,
+            route_map={True: [Safety(is_safe=True), Safety(is_safe=False)], False: FALSE_BRANCH},
         )
 
 


### PR DESCRIPTION
Simplification because `Gate` doesn't provide any value over `Router`.
Also added functionality to the `Router` that allows a user to specify a `default_branch` to use in the case that the output doesn't match any `route_map` keys.