### PR TITLE
OpenAI Responses SUT

### DIFF
--- a/src/modelgauge/suts/modelship_sut.py
+++ b/src/modelgauge/suts/modelship_sut.py
@@ -4,7 +4,7 @@ from modelgauge.auth.openai_compatible_secrets import OpenAICompatibleApiKey
 from modelgauge.dynamic_sut_factory import DynamicDriverSUTFactory
 from modelgauge.secret_values import InjectSecret, RequiredSecret, SecretDescription
 from modelgauge.sut_definition import SUTDefinition
-from modelgauge.suts.openai_client import OpenAIChat, OpenAIChatRequest
+from modelgauge.suts.openai_client import OpenAIChatSUT, OpenAIChatRequest
 
 
 class ModelShipSecret(RequiredSecret):
@@ -15,7 +15,7 @@ class ModelShipSecret(RequiredSecret):
         return SecretDescription(scope=cls.provider, key="api_key", instructions="Ask around")
 
 
-class ModelShipSUT(OpenAIChat):
+class ModelShipSUT(OpenAIChatSUT):
 
     def __init__(
         self,

--- a/src/modelgauge/suts/nvidia_nim_api_client.py
+++ b/src/modelgauge/suts/nvidia_nim_api_client.py
@@ -5,7 +5,7 @@ from modelgauge.secret_values import (
     RequiredSecret,
     SecretDescription,
 )
-from modelgauge.suts.openai_client import OpenAIChat, OpenAIChatRequest
+from modelgauge.suts.openai_client import OpenAIChatSUT, OpenAIChatRequest
 from modelgauge.model_options import ModelOptions
 from modelgauge.sut_capabilities import (
     AcceptsChatPrompt,
@@ -39,7 +39,7 @@ class NIMOpenAIChatRequest(OpenAIChatRequest):
         AcceptsChatPrompt,
     ]
 )
-class NvidiaNIMApiClient(OpenAIChat):
+class NvidiaNIMApiClient(OpenAIChatSUT):
     """
     Documented at https://https://docs.api.nvidia.com/
     """

--- a/src/modelgauge/suts/nvidia_nim_api_client.py
+++ b/src/modelgauge/suts/nvidia_nim_api_client.py
@@ -47,8 +47,10 @@ class NvidiaNIMApiClient(OpenAIChat):
     def __init__(self, uid: str, model: str, api_key: NvidiaNIMApiKey):
         super().__init__(uid, model, api_key=api_key, base_url=BASE_URL)
 
-    def _translate_request(self, messages, options: ModelOptions, temp: float | None) -> NIMOpenAIChatRequest:
-        request = super()._translate_request(messages, options, temp)
+    def _translate_request_with_temperature(
+        self, messages, options: ModelOptions, temperature: float | None
+    ) -> NIMOpenAIChatRequest:
+        request = super()._translate_request_with_temperature(messages, options, temperature)
         request_json = request.model_dump(exclude_none=True)
         del request_json["max_completion_tokens"]  # NIM API doesn't allow extra inputs
         return NIMOpenAIChatRequest(

--- a/src/modelgauge/suts/nvidia_nim_api_client.py
+++ b/src/modelgauge/suts/nvidia_nim_api_client.py
@@ -47,8 +47,8 @@ class NvidiaNIMApiClient(OpenAIChat):
     def __init__(self, uid: str, model: str, api_key: NvidiaNIMApiKey):
         super().__init__(uid, model, api_key=api_key, base_url=BASE_URL)
 
-    def _translate_request(self, messages, options: ModelOptions) -> NIMOpenAIChatRequest:
-        request = super()._translate_request(messages, options)
+    def _translate_request(self, messages, options: ModelOptions, temp: float | None) -> NIMOpenAIChatRequest:
+        request = super()._translate_request(messages, options, temp)
         request_json = request.model_dump(exclude_none=True)
         del request_json["max_completion_tokens"]  # NIM API doesn't allow extra inputs
         return NIMOpenAIChatRequest(

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -90,7 +90,7 @@ class OpenAIResponsesRequest(BaseModel):
     tool_choice: Optional[Union[str, Dict]] = None
 
 
-class BaseOpenAI(PromptResponseSUT, ABC):
+class BaseOpenAISUT(PromptResponseSUT, ABC):
     """Core OpenAI functionality shared across OpenAI APIs."""
 
     def __init__(
@@ -208,7 +208,7 @@ class BaseOpenAI(PromptResponseSUT, ABC):
         ProducesPerTokenLogProbabilities,
     ]
 )
-class OpenAIChat(BaseOpenAI):
+class OpenAIChatSUT(BaseOpenAISUT):
     """
     Documented at https://platform.openai.com/docs/api-reference/chat/create
     """
@@ -261,7 +261,7 @@ class OpenAIChat(BaseOpenAI):
         ProducesPerTokenLogProbabilities,
     ]
 )
-class OpenAIResponses(BaseOpenAI):
+class OpenAIResponsesSUT(BaseOpenAISUT):
     """
     Documented at https://platform.openai.com/docs/api-reference/responses
     """
@@ -306,7 +306,7 @@ class OpenAIResponses(BaseOpenAI):
 
 
 SUTS.register(
-    OpenAIChat,
+    OpenAIChatSUT,
     "gpt-3.5-turbo",
     "gpt-3.5-turbo",
     InjectSecret(OpenAIApiKey),
@@ -314,7 +314,7 @@ SUTS.register(
 )
 
 SUTS.register(
-    OpenAIChat,
+    OpenAIChatSUT,
     "gpt-4o",
     "gpt-4o",
     InjectSecret(OpenAIApiKey),
@@ -322,7 +322,7 @@ SUTS.register(
 )
 
 SUTS.register(
-    OpenAIChat,
+    OpenAIChatSUT,
     "gpt-4o-20250508",
     "gpt-4o",
     InjectSecret(OpenAIApiKey),
@@ -330,7 +330,7 @@ SUTS.register(
 )
 
 SUTS.register(
-    OpenAIChat,
+    OpenAIChatSUT,
     "gpt-4o-mini",
     "gpt-4o-mini",
     InjectSecret(OpenAIApiKey),

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -144,7 +144,7 @@ class OpenAIChat(PromptResponseSUT):
             **optional_kwargs,
         )
 
-    @retry(transient_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
+    @retry(do_not_retry_exceptions=[openai.NotFoundError], transient_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
     def evaluate(self, request: OpenAIChatRequest) -> ChatCompletion:
         if self.client is None:
             # Handle lazy init.

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -1,9 +1,11 @@
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
 import openai
 from openai import APITimeoutError, ConflictError, InternalServerError, RateLimitError
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
+from openai.types.responses import Response
 from pydantic import BaseModel
 
 from modelgauge.auth.openai_compatible_secrets import (
@@ -66,20 +68,25 @@ class OpenAIChatRequest(BaseModel):
     top_p: Optional[float] = None
     tools: Optional[List] = None
     tool_choice: Optional[Union[str, Dict]] = None
-    user: Optional[str] = None
 
 
-@modelgauge_sut(
-    capabilities=[
-        AcceptsTextPrompt,
-        AcceptsChatPrompt,
-        ProducesPerTokenLogProbabilities,
-    ]
-)
-class OpenAIChat(PromptResponseSUT):
-    """
-    Documented at https://platform.openai.com/docs/api-reference/chat/create
-    """
+class OpenAIResponsesRequest(BaseModel):
+    # https://developers.openai.com/api/reference/resources/responses
+    input: List[OpenAIChatMessage]
+    model: str
+    store: bool = False
+    top_logprobs: Optional[int] = None
+    include: Optional[List[str]] = None
+    max_output_tokens: Optional[int] = None
+    stream: Optional[bool] = None
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    tools: Optional[List] = None
+    tool_choice: Optional[Union[str, Dict]] = None
+
+
+class BaseOpenAI(PromptResponseSUT, ABC):
+    """Core OpenAI functionality shared across OpenAI APIs."""
 
     def __init__(
         self,
@@ -117,17 +124,66 @@ class OpenAIChat(PromptResponseSUT):
         else:
             return OpenAI(api_key=self.api_key, max_retries=7)
 
-    def translate_text_prompt(self, prompt: TextPrompt, options: ModelOptions) -> OpenAIChatRequest:
+    def translate_text_prompt(self, prompt: TextPrompt, options: ModelOptions):
         messages = [OpenAIChatMessage(content=prompt.text, role=_USER_ROLE)]
         return self._translate_request(messages, options)
 
-    def translate_chat_prompt(self, prompt: ChatPrompt, options: ModelOptions) -> OpenAIChatRequest:
+    def translate_chat_prompt(self, prompt: ChatPrompt, options: ModelOptions):
         messages = []
         for message in prompt.messages:
             messages.append(OpenAIChatMessage(content=message.text, role=_ROLE_MAP[message.role]))
         return self._translate_request(messages, options)
 
+    @abstractmethod
     def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions):
+        pass
+
+    @retry(
+        do_not_retry_exceptions=[openai.NotFoundError],
+        transient_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError],
+    )
+    def evaluate(self, request):
+        if self.client is None:
+            # Handle lazy init.
+            self.client = self._load_client()
+        try:
+            return self._call_client(request)
+        except openai.NotFoundError as e:
+            if self.base_url:
+                raise ValueError(f"404 for base URL {self.base_url}") from e
+            else:
+                raise
+        except openai.APIConnectionError as e:
+            if self.base_url:
+                raise ValueError(f"Couldn't connect to base URL {self.base_url}") from e
+            else:
+                raise
+
+    @abstractmethod
+    def _call_client(self, request):
+        pass
+
+    def request_as_dict_for_client(self, request: OpenAIChatRequest) -> dict[str, Any]:
+        return request.model_dump(exclude_none=True)
+
+    @abstractmethod
+    def translate_response(self, request, response) -> SUTResponse:
+        pass
+
+
+@modelgauge_sut(
+    capabilities=[
+        AcceptsTextPrompt,
+        AcceptsChatPrompt,
+        ProducesPerTokenLogProbabilities,
+    ]
+)
+class OpenAIChat(BaseOpenAI):
+    """
+    Documented at https://platform.openai.com/docs/api-reference/chat/create
+    """
+
+    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions) -> OpenAIChatRequest:
         optional_kwargs: Dict[str, Any] = {}
         if options.top_logprobs is not None:
             optional_kwargs["logprobs"] = True
@@ -144,26 +200,8 @@ class OpenAIChat(PromptResponseSUT):
             **optional_kwargs,
         )
 
-    @retry(do_not_retry_exceptions=[openai.NotFoundError], transient_exceptions=[APITimeoutError, ConflictError, InternalServerError, RateLimitError])
-    def evaluate(self, request: OpenAIChatRequest) -> ChatCompletion:
-        if self.client is None:
-            # Handle lazy init.
-            self.client = self._load_client()
-        try:
-            return self.client.chat.completions.create(**self.request_as_dict_for_client(request))
-        except openai.NotFoundError as e:
-            if self.base_url:
-                raise ValueError(f"404 for base URL {self.base_url}") from e
-            else:
-                raise
-        except openai.APIConnectionError as e:
-            if self.base_url:
-                raise ValueError(f"Couldn't connect to base URL {self.base_url}") from e
-            else:
-                raise
-
-    def request_as_dict_for_client(self, request: OpenAIChatRequest) -> dict[str, Any]:
-        return request.model_dump(exclude_none=True)
+    def _call_client(self, request):
+        return self.client.chat.completions.create(**self.request_as_dict_for_client(request))
 
     def translate_response(self, request: OpenAIChatRequest, response: ChatCompletion) -> SUTResponse:
         assert len(response.choices) == 1, f"Expected a single response message, got {len(response.choices)}."
@@ -182,6 +220,55 @@ class OpenAIChat(PromptResponseSUT):
                 logprobs.append(TopTokens(top_tokens=top_tokens))
         assert text is not None
         return SUTResponse(text=text, top_logprobs=logprobs)
+
+
+@modelgauge_sut(
+    capabilities=[
+        AcceptsTextPrompt,
+        AcceptsChatPrompt,
+        ProducesPerTokenLogProbabilities,
+    ]
+)
+class OpenAIResponses(BaseOpenAI):
+    """
+    Documented at https://platform.openai.com/docs/api-reference/responses
+    """
+
+    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions) -> OpenAIResponsesRequest:
+        optional_kwargs: Dict[str, Any] = {}
+        if options.top_logprobs is not None:
+            optional_kwargs["top_logprobs"] = min(options.top_logprobs, 20)
+            optional_kwargs["include"] = ["message.output_text.logprobs"]
+        return OpenAIResponsesRequest(
+            input=messages,
+            model=self.model,
+            max_output_tokens=options.max_tokens,
+            temperature=options.temperature,
+            top_p=options.top_p,
+            **optional_kwargs,
+        )
+
+    def _call_client(self, request) -> Response:
+        return self.client.responses.create(**self.request_as_dict_for_client(request))
+
+    def translate_response(self, request: OpenAIResponsesRequest, response: Response) -> SUTResponse:
+        top_logprobs: Optional[List[TopTokens]] = None
+        if request.top_logprobs:
+            top_logprobs = []
+            messages = []
+            for output in response.output:
+                if output.type == "message":
+                    messages.append(output)
+            assert len(messages) == 1, f"Expected a single message, got {len(messages)}."
+            assert len(messages[0].content) == 1, f"Expected a single content, got {len(messages[0] .content)}."
+            logprobs = messages[0].content[0].logprobs
+            assert logprobs is not None, "Expected logprobs, but not returned."
+            for logprob in logprobs:
+                top_tokens: List[TokenProbability] = []
+                for top in logprob.top_logprobs:
+                    top_tokens.append(TokenProbability(token=top.token, logprob=top.logprob))
+                top_logprobs.append(TopTokens(top_tokens=top_tokens))
+        return SUTResponse(text=response.output_text, top_logprobs=top_logprobs)
 
 
 SUTS.register(

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -132,15 +132,16 @@ class BaseOpenAI(PromptResponseSUT, ABC):
 
     @staticmethod
     def _check_accepts_temperature(model: str) -> bool:
-        if "gpt" in model:
-            if "pro" in model:
-                return False
-            try:
-                version = float(model.split("-")[1])
-            except ValueError:
-                return True
-            if version >= 5.5:
-                return False
+        if "gpt" not in model:
+            return True
+        if "pro" in model:
+            return False
+        try:
+            version = float(model.split("-")[1])
+        except ValueError:
+            return True
+        if version >= 5.5:
+            return False
         return True
 
     def translate_text_prompt(self, prompt: TextPrompt, options: ModelOptions):

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -8,6 +8,8 @@ from openai.types.chat import ChatCompletion
 from openai.types.responses import Response
 from pydantic import BaseModel
 
+from airrlogger.log_config import get_logger
+
 from modelgauge.auth.openai_compatible_secrets import (
     OpenAIApiKey,
     OpenAICompatibleApiKey,
@@ -29,6 +31,9 @@ from modelgauge.sut_capabilities import (
 )
 from modelgauge.sut_decorator import modelgauge_sut
 from modelgauge.sut_registry import SUTS
+
+logger = get_logger(__name__)
+
 
 _SYSTEM_ROLE = "system"
 _USER_ROLE = "user"
@@ -103,6 +108,7 @@ class BaseOpenAI(PromptResponseSUT, ABC):
         self.organization = organization.value if organization else None
         self.base_url = base_url if isinstance(base_url, str) else base_url.value if base_url else None
         self.client = client
+        self._accepts_temp = self._check_accepts_temp(model)
 
         # key and optional org id if you're talking to openAI
         # key and base_url if you're using this client to interact with e.g. gemini on google's hardware
@@ -124,18 +130,38 @@ class BaseOpenAI(PromptResponseSUT, ABC):
         else:
             return OpenAI(api_key=self.api_key, max_retries=7)
 
+    @staticmethod
+    def _check_accepts_temp(model: str) -> bool:
+        if "gpt" in model:
+            if "pro" in model:
+                return False
+            try:
+                version = float(model.split("-")[1])
+            except ValueError:
+                return True
+            if version >= 5.5:
+                return False
+        return True
+
     def translate_text_prompt(self, prompt: TextPrompt, options: ModelOptions):
         messages = [OpenAIChatMessage(content=prompt.text, role=_USER_ROLE)]
-        return self._translate_request(messages, options)
+        return self._translate_request_temp(messages, options)
 
     def translate_chat_prompt(self, prompt: ChatPrompt, options: ModelOptions):
         messages = []
         for message in prompt.messages:
             messages.append(OpenAIChatMessage(content=message.text, role=_ROLE_MAP[message.role]))
-        return self._translate_request(messages, options)
+        return self._translate_request_temp(messages, options)
+
+    def _translate_request_temp(self, messages: List[OpenAIChatMessage], options: ModelOptions):
+        if not self._accepts_temp:
+            if options.temperature is not None:
+                logger.warning(f"Temperature is not supported for model {self.model}, ignoring temperature.")
+            return self._translate_request(messages, options, None)
+        return self._translate_request(messages, options, options.temperature)
 
     @abstractmethod
-    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions):
+    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions, temp: float | None):
         pass
 
     @retry(
@@ -183,7 +209,9 @@ class OpenAIChat(BaseOpenAI):
     Documented at https://platform.openai.com/docs/api-reference/chat/create
     """
 
-    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions) -> OpenAIChatRequest:
+    def _translate_request(
+        self, messages: List[OpenAIChatMessage], options: ModelOptions, temp: float | None
+    ) -> OpenAIChatRequest:
         optional_kwargs: Dict[str, Any] = {}
         if options.top_logprobs is not None:
             optional_kwargs["logprobs"] = True
@@ -195,7 +223,7 @@ class OpenAIChat(BaseOpenAI):
             max_completion_tokens=options.max_tokens,
             presence_penalty=options.presence_penalty,
             stop=options.stop_sequences,
-            temperature=options.temperature,
+            temperature=temp,
             top_p=options.top_p,
             **optional_kwargs,
         )
@@ -234,7 +262,9 @@ class OpenAIResponses(BaseOpenAI):
     Documented at https://platform.openai.com/docs/api-reference/responses
     """
 
-    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions) -> OpenAIResponsesRequest:
+    def _translate_request(
+        self, messages: List[OpenAIChatMessage], options: ModelOptions, temp: float | None
+    ) -> OpenAIResponsesRequest:
         optional_kwargs: Dict[str, Any] = {}
         if options.top_logprobs is not None:
             optional_kwargs["top_logprobs"] = min(options.top_logprobs, 20)
@@ -243,7 +273,7 @@ class OpenAIResponses(BaseOpenAI):
             input=messages,
             model=self.model,
             max_output_tokens=options.max_tokens,
-            temperature=options.temperature,
+            temperature=temp,
             top_p=options.top_p,
             **optional_kwargs,
         )

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -145,23 +145,25 @@ class BaseOpenAI(PromptResponseSUT, ABC):
 
     def translate_text_prompt(self, prompt: TextPrompt, options: ModelOptions):
         messages = [OpenAIChatMessage(content=prompt.text, role=_USER_ROLE)]
-        return self._translate_request_temp(messages, options)
+        return self._translate_request(messages, options)
 
     def translate_chat_prompt(self, prompt: ChatPrompt, options: ModelOptions):
         messages = []
         for message in prompt.messages:
             messages.append(OpenAIChatMessage(content=message.text, role=_ROLE_MAP[message.role]))
-        return self._translate_request_temp(messages, options)
+        return self._translate_request(messages, options)
 
-    def _translate_request_temp(self, messages: List[OpenAIChatMessage], options: ModelOptions):
+    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions):
         if not self._accepts_temp:
             if options.temperature is not None:
                 logger.warning(f"Temperature is not supported for model {self.model}, ignoring temperature.")
-            return self._translate_request(messages, options, None)
-        return self._translate_request(messages, options, options.temperature)
+            return self._translate_request_with_temperature(messages, options, None)
+        return self._translate_request_with_temperature(messages, options, options.temperature)
 
     @abstractmethod
-    def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions, temp: float | None):
+    def _translate_request_with_temperature(
+        self, messages: List[OpenAIChatMessage], options: ModelOptions, temperature: float | None
+    ):
         pass
 
     @retry(
@@ -209,8 +211,8 @@ class OpenAIChat(BaseOpenAI):
     Documented at https://platform.openai.com/docs/api-reference/chat/create
     """
 
-    def _translate_request(
-        self, messages: List[OpenAIChatMessage], options: ModelOptions, temp: float | None
+    def _translate_request_with_temperature(
+        self, messages: List[OpenAIChatMessage], options: ModelOptions, temperature: float | None
     ) -> OpenAIChatRequest:
         optional_kwargs: Dict[str, Any] = {}
         if options.top_logprobs is not None:
@@ -223,7 +225,7 @@ class OpenAIChat(BaseOpenAI):
             max_completion_tokens=options.max_tokens,
             presence_penalty=options.presence_penalty,
             stop=options.stop_sequences,
-            temperature=temp,
+            temperature=temperature,
             top_p=options.top_p,
             **optional_kwargs,
         )
@@ -262,8 +264,8 @@ class OpenAIResponses(BaseOpenAI):
     Documented at https://platform.openai.com/docs/api-reference/responses
     """
 
-    def _translate_request(
-        self, messages: List[OpenAIChatMessage], options: ModelOptions, temp: float | None
+    def _translate_request_with_temperature(
+        self, messages: List[OpenAIChatMessage], options: ModelOptions, temperature: float | None
     ) -> OpenAIResponsesRequest:
         optional_kwargs: Dict[str, Any] = {}
         if options.top_logprobs is not None:
@@ -273,7 +275,7 @@ class OpenAIResponses(BaseOpenAI):
             input=messages,
             model=self.model,
             max_output_tokens=options.max_tokens,
-            temperature=temp,
+            temperature=temperature,
             top_p=options.top_p,
             **optional_kwargs,
         )

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -137,10 +137,11 @@ class BaseOpenAI(PromptResponseSUT, ABC):
         if "pro" in model:
             return False
         try:
-            version = float(model.split("-")[1])
+            parts = model.split("-")[1].split(".")
+            version = tuple(int(p) for p in parts)
         except ValueError:
             return True
-        if version >= 5.5:
+        if version >= (5, 5):
             return False
         return True
 

--- a/src/modelgauge/suts/openai_client.py
+++ b/src/modelgauge/suts/openai_client.py
@@ -108,7 +108,7 @@ class BaseOpenAI(PromptResponseSUT, ABC):
         self.organization = organization.value if organization else None
         self.base_url = base_url if isinstance(base_url, str) else base_url.value if base_url else None
         self.client = client
-        self._accepts_temp = self._check_accepts_temp(model)
+        self._accepts_temperature = self._check_accepts_temperature(model)
 
         # key and optional org id if you're talking to openAI
         # key and base_url if you're using this client to interact with e.g. gemini on google's hardware
@@ -131,7 +131,7 @@ class BaseOpenAI(PromptResponseSUT, ABC):
             return OpenAI(api_key=self.api_key, max_retries=7)
 
     @staticmethod
-    def _check_accepts_temp(model: str) -> bool:
+    def _check_accepts_temperature(model: str) -> bool:
         if "gpt" in model:
             if "pro" in model:
                 return False
@@ -154,7 +154,7 @@ class BaseOpenAI(PromptResponseSUT, ABC):
         return self._translate_request(messages, options)
 
     def _translate_request(self, messages: List[OpenAIChatMessage], options: ModelOptions):
-        if not self._accepts_temp:
+        if not self._accepts_temperature:
             if options.temperature is not None:
                 logger.warning(f"Temperature is not supported for model {self.model}, ignoring temperature.")
             return self._translate_request_with_temperature(messages, options, None)

--- a/src/modelgauge/suts/openai_sut_factory.py
+++ b/src/modelgauge/suts/openai_sut_factory.py
@@ -9,7 +9,7 @@ from modelgauge.dynamic_sut_factory import (
 )
 from modelgauge.secret_values import InjectSecret, RawSecrets
 from modelgauge.sut_definition import SUTDefinition
-from modelgauge.suts.openai_client import OpenAIChat
+from modelgauge.suts.openai_client import OpenAIResponses
 
 NUM_RETRIES = 7
 
@@ -39,7 +39,7 @@ class BaseOpenAISUTFactory(DynamicSUTFactory):
 class OpenAICompatibleSUTFactory(BaseOpenAISUTFactory, DynamicDriverSUTFactory):
     DRIVER_NAME = "openai"
 
-    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIChat:
+    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIResponses:
         factory = factory_class = None
         self.provider = sut_definition.get("provider")  # type: ignore
 
@@ -75,12 +75,12 @@ class OpenAISUTFactory(BaseOpenAISUTFactory):
             return False
         return True
 
-    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIChat:
+    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIResponses:
         if not self._model_exists(sut_definition):
             raise ModelNotSupportedError(
                 f"Model {sut_definition.external_model_name()} not found or not available on openai."
             )
-        return OpenAIChat(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
+        return OpenAIResponses(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
 
 
 class OpenAIGenericSUTFactory(BaseOpenAISUTFactory):
@@ -96,14 +96,14 @@ class OpenAIGenericSUTFactory(BaseOpenAISUTFactory):
         _client = OpenAI(api_key=api_key.value, base_url=self.base_url, max_retries=NUM_RETRIES)
         return _client
 
-    def make_sut(self, sut_definition: SUTDefinition, base_url: str | None = None) -> OpenAIChat:
+    def make_sut(self, sut_definition: SUTDefinition, base_url: str | None = None) -> OpenAIResponses:
         the_base_url = sut_definition.get("base_url", None)
         if base_url:
             the_base_url = base_url
         self.provider = sut_definition.get("provider")  # type: ignore
         if the_base_url:
             self.base_url = the_base_url
-        return OpenAIChat(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
+        return OpenAIResponses(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
 
 
 # this is how you add a new OpenAI-compatible SUT

--- a/src/modelgauge/suts/openai_sut_factory.py
+++ b/src/modelgauge/suts/openai_sut_factory.py
@@ -9,7 +9,7 @@ from modelgauge.dynamic_sut_factory import (
 )
 from modelgauge.secret_values import InjectSecret, RawSecrets
 from modelgauge.sut_definition import SUTDefinition
-from modelgauge.suts.openai_client import OpenAIResponses
+from modelgauge.suts.openai_client import OpenAIResponsesSUT
 
 NUM_RETRIES = 7
 
@@ -39,7 +39,7 @@ class BaseOpenAISUTFactory(DynamicSUTFactory):
 class OpenAICompatibleSUTFactory(BaseOpenAISUTFactory, DynamicDriverSUTFactory):
     DRIVER_NAME = "openai"
 
-    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIResponses:
+    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIResponsesSUT:
         factory = factory_class = None
         self.provider = sut_definition.get("provider")  # type: ignore
 
@@ -75,12 +75,12 @@ class OpenAISUTFactory(BaseOpenAISUTFactory):
             return False
         return True
 
-    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIResponses:
+    def make_sut(self, sut_definition: SUTDefinition) -> OpenAIResponsesSUT:
         if not self._model_exists(sut_definition):
             raise ModelNotSupportedError(
                 f"Model {sut_definition.external_model_name()} not found or not available on openai."
             )
-        return OpenAIResponses(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
+        return OpenAIResponsesSUT(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
 
 
 class OpenAIGenericSUTFactory(BaseOpenAISUTFactory):
@@ -96,14 +96,14 @@ class OpenAIGenericSUTFactory(BaseOpenAISUTFactory):
         _client = OpenAI(api_key=api_key.value, base_url=self.base_url, max_retries=NUM_RETRIES)
         return _client
 
-    def make_sut(self, sut_definition: SUTDefinition, base_url: str | None = None) -> OpenAIResponses:
+    def make_sut(self, sut_definition: SUTDefinition, base_url: str | None = None) -> OpenAIResponsesSUT:
         the_base_url = sut_definition.get("base_url", None)
         if base_url:
             the_base_url = base_url
         self.provider = sut_definition.get("provider")  # type: ignore
         if the_base_url:
             self.base_url = the_base_url
-        return OpenAIResponses(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
+        return OpenAIResponsesSUT(sut_definition.uid, sut_definition.get("model"), client=self.client)  # type: ignore
 
 
 # this is how you add a new OpenAI-compatible SUT

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -27,17 +27,17 @@ def openai_client():
 class TestBaseOpenAIEvaluate:
 
     def test_check_accepts_temp(self):
-        assert BaseOpenAI._check_accepts_temp("some-model") is True
-        assert BaseOpenAI._check_accepts_temp("gpt-4o") is True
-        assert BaseOpenAI._check_accepts_temp("gpt-5.4") is True
-        assert BaseOpenAI._check_accepts_temp("gpt-5.4-nano") is True
-        assert BaseOpenAI._check_accepts_temp("gpt-5.4-mini") is True
+        assert BaseOpenAI._check_accepts_temperature("some-model") is True
+        assert BaseOpenAI._check_accepts_temperature("gpt-4o") is True
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.4") is True
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.4-nano") is True
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.4-mini") is True
 
-        assert BaseOpenAI._check_accepts_temp("gpt-5.6") is False
-        assert BaseOpenAI._check_accepts_temp("gpt-5.6-sol") is False
-        assert BaseOpenAI._check_accepts_temp("gpt-5.5") is False
-        assert BaseOpenAI._check_accepts_temp("gpt-5.5-pro") is False
-        assert BaseOpenAI._check_accepts_temp("gpt-5.4-pro") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.6") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.6-sol") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.5") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.5-pro") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.4-pro") is False
 
 
 class TestOpenAIChat:
@@ -266,15 +266,15 @@ class TestOpenAIChat:
         )
 
     def test_translate_request_includes_temperature_when_accepted(self, client):
-        """When _accepts_temp is True, temperature from options is included in the request."""
-        assert client._accepts_temp is True
+        """When _accepts_temperature is True, temperature from options is included in the request."""
+        assert client._accepts_temperature is True
         prompt = TextPrompt(text="some-text")
         request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
         assert request.temperature == 0.7
 
     def test_translate_request_omits_temperature_when_not_accepted(self, client):
-        """When _accepts_temp is False, temperature is excluded from the request even if provided."""
-        client._accepts_temp = False
+        """When _accepts_temperature is False, temperature is excluded from the request even if provided."""
+        client._accepts_temperature = False
         prompt = TextPrompt(text="some-text")
         request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
         assert request.temperature is None
@@ -449,15 +449,15 @@ class TestOpenAIResponses:
         )
 
     def test_translate_request_includes_temperature_when_accepted(self, client):
-        """When _accepts_temp is True, temperature from options is included in the request."""
-        assert client._accepts_temp is True
+        """When _accepts_temperature is True, temperature from options is included in the request."""
+        assert client._accepts_temperature is True
         prompt = TextPrompt(text="some-text")
         request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
         assert request.temperature == 0.7
 
     def test_translate_request_omits_temperature_when_not_accepted(self, client):
-        """When _accepts_temp is False, temperature is excluded from the request even if provided."""
-        client._accepts_temp = False
+        """When _accepts_temperature is False, temperature is excluded from the request even if provided."""
+        client._accepts_temperature = False
         prompt = TextPrompt(text="some-text")
         request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
         assert request.temperature is None

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -29,6 +29,7 @@ class TestBaseOpenAIEvaluate:
     def test_check_accepts_temp(self):
         assert BaseOpenAI._check_accepts_temperature("some-model") is True
         assert BaseOpenAI._check_accepts_temperature("gpt-4o") is True
+        assert BaseOpenAI._check_accepts_temperature("gpt-4.6") is True
         assert BaseOpenAI._check_accepts_temperature("gpt-5.4") is True
         assert BaseOpenAI._check_accepts_temperature("gpt-5.4-nano") is True
         assert BaseOpenAI._check_accepts_temperature("gpt-5.4-mini") is True
@@ -38,6 +39,9 @@ class TestBaseOpenAIEvaluate:
         assert BaseOpenAI._check_accepts_temperature("gpt-5.5") is False
         assert BaseOpenAI._check_accepts_temperature("gpt-5.5-pro") is False
         assert BaseOpenAI._check_accepts_temperature("gpt-5.4-pro") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.7") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.10") is False
+        assert BaseOpenAI._check_accepts_temperature("gpt-5.10.0") is False
 
 
 class TestOpenAIChat:

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -1,7 +1,9 @@
+import pytest
 from pytest import raises
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
+from openai.types.responses import Response
 
 from modelgauge.prompt import TextPrompt
 from modelgauge.sut import SUTResponse
@@ -12,241 +14,406 @@ from modelgauge.suts.openai_client import (
     OpenAIChatMessage,
     OpenAIChatRequest,
     OpenAIOrganization,
+    OpenAIResponses,
+    OpenAIResponsesRequest,
 )
 
 
-def _make_client():
-    return OpenAIChat(
-        uid="test-model",
-        model="some-model",
-        api_key=OpenAIApiKey("some-value"),
-        organization=OpenAIOrganization(None),
-    )
-
-
-def _make_openai_client():
+@pytest.fixture
+def openai_client():
     return OpenAI(api_key="some-value", organization="some-org", max_retries=1)
 
 
-def test_openai_constructor():
-    # these should all work
-    key_only = OpenAIChat(
-        uid="test-model", model="some-model", api_key=OpenAIApiKey("some-value"), organization=OpenAIOrganization(None)
-    )
-    key_and_org = OpenAIChat(
-        uid="test-model",
-        model="some-model",
-        api_key=OpenAIApiKey("some-value"),
-        organization=OpenAIOrganization("some-org"),
-    )
-    key_and_base_url = OpenAIChat(
-        uid="test-model",
-        model="some-model",
-        api_key=OpenAIApiKey("some-value"),
-        base_url="some-url",
-    )
-
-    client = _make_openai_client()
-    with_client = OpenAIChat(
-        uid="test-model",
-        model="some-model",
-        client=client,  # type: ignore
-    )
-
-    # these should all fail
-
-    # no key and no client
-    with raises(AssertionError):
-        _ = OpenAIChat(uid="test-model", model="some-model")
-
-    # base_url and organization
-    with raises(AssertionError):
-        _ = OpenAIChat(
+class TestOpenAIChat:
+    @pytest.fixture
+    def client(self):
+        return OpenAIChat(
             uid="test-model",
             model="some-model",
+            api_key=OpenAIApiKey("some-value"),
+            organization=OpenAIOrganization(None),
+        )
+
+    def test_openai_constructor(self, openai_client):
+        # these should all work
+        key_only = OpenAIChat(
+            uid="test-model",
+            model="some-model",
+            api_key=OpenAIApiKey("some-value"),
+            organization=OpenAIOrganization(None),
+        )
+        key_and_org = OpenAIChat(
+            uid="test-model",
+            model="some-model",
+            api_key=OpenAIApiKey("some-value"),
             organization=OpenAIOrganization("some-org"),
+        )
+        key_and_base_url = OpenAIChat(
+            uid="test-model",
+            model="some-model",
+            api_key=OpenAIApiKey("some-value"),
             base_url="some-url",
         )
 
+        with_client = OpenAIChat(
+            uid="test-model",
+            model="some-model",
+            client=openai_client,  # type: ignore
+        )
 
-def test_openai_chat_translate_request():
-    client = _make_client()
-    prompt = TextPrompt(text="some-text")
-    request = client.translate_text_prompt(prompt, ModelOptions(max_tokens=100))
-    assert request == OpenAIChatRequest(
-        model="some-model",
-        messages=[OpenAIChatMessage(content="some-text", role="user")],
-        max_completion_tokens=100,
-    )
+        # these should all fail
 
+        # no key and no client
+        with raises(AssertionError):
+            _ = OpenAIChat(uid="test-model", model="some-model")
 
-def test_openai_chat_translate_request_logprobs():
-    client = _make_client()
-    prompt = TextPrompt(text="some-text")
-    request = client.translate_text_prompt(prompt, ModelOptions(top_logprobs=2))
-    assert request == OpenAIChatRequest(
-        model="some-model",
-        messages=[OpenAIChatMessage(content="some-text", role="user")],
-        max_completion_tokens=None,
-        logprobs=True,
-        top_logprobs=2,
-    )
+        # base_url and organization
+        with raises(AssertionError):
+            _ = OpenAIChat(
+                uid="test-model",
+                model="some-model",
+                organization=OpenAIOrganization("some-org"),
+                base_url="some-url",
+            )
 
+    def test_openai_chat_translate_request(self, client):
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(max_tokens=100))
+        assert request == OpenAIChatRequest(
+            model="some-model",
+            messages=[OpenAIChatMessage(content="some-text", role="user")],
+            max_completion_tokens=100,
+        )
 
-def test_openai_chat_translate_request_excessive_logprobs():
-    client = _make_client()
-    # Set value above limit of 20
-    prompt = TextPrompt(text="some-text")
-    request = client.translate_text_prompt(prompt, ModelOptions(top_logprobs=21))
-    assert request == OpenAIChatRequest(
-        model="some-model",
-        messages=[OpenAIChatMessage(content="some-text", role="user")],
-        max_completion_tokens=None,
-        logprobs=True,
-        top_logprobs=20,
-    )
+    def test_openai_chat_translate_request_logprobs(self, client):
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(top_logprobs=2))
+        assert request == OpenAIChatRequest(
+            model="some-model",
+            messages=[OpenAIChatMessage(content="some-text", role="user")],
+            max_completion_tokens=None,
+            logprobs=True,
+            top_logprobs=2,
+        )
 
+    def test_openai_chat_translate_request_excessive_logprobs(self, client):
+        # Set value above limit of 20
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(top_logprobs=21))
+        assert request == OpenAIChatRequest(
+            model="some-model",
+            messages=[OpenAIChatMessage(content="some-text", role="user")],
+            max_completion_tokens=None,
+            logprobs=True,
+            top_logprobs=20,
+        )
 
-def test_openai_chat_translate_response():
-    client = _make_client()
-    request = OpenAIChatRequest(
-        model="some-model",
-        messages=[],
-    )
-    # Pulled from https://platform.openai.com/docs/api-reference/chat/create
-    response = ChatCompletion.model_validate_json("""\
-{
-  "id": "chatcmpl-123",
-  "object": "chat.completion",
-  "created": 1677652288,
-  "model": "gpt-3.5-turbo-0125",
-  "system_fingerprint": "fp_44709d6fcb",
-  "choices": [{
-    "index": 0,
-    "message": {
-      "role": "assistant",
-      "content": "Hello there, how may I assist you today?"
-    },
-    "logprobs": null,
-    "finish_reason": "stop"
-  }],
-  "usage": {
-    "prompt_tokens": 9,
-    "completion_tokens": 12,
-    "total_tokens": 21
-  }
-}
-""")
-    result = client.translate_response(request, response)
-    assert result == SUTResponse(text="Hello there, how may I assist you today?", top_logprobs=None)
-
-
-def test_openai_chat_translate_response_logprobs():
-    client = _make_client()
-    request = OpenAIChatRequest(
-        model="some-model",
-        messages=[],
-        logprobs=True,
-    )
-    # Copied from a real response.
-    response = ChatCompletion.model_validate_json("""\
-{
-  "id": "made-this-fake",
-  "choices": [
-    {
-      "finish_reason": "length",
-      "index": 0,
-      "logprobs": {
-        "content": [
+    def test_openai_chat_translate_response(self, client):
+        request = OpenAIChatRequest(
+            model="some-model",
+            messages=[],
+        )
+        # Pulled from https://platform.openai.com/docs/api-reference/chat/create
+        response = ChatCompletion.model_validate_json("""\
           {
-            "token": "Hello",
-            "logprob": -0.10257129,
-            "top_logprobs": [
-              {
-                "token": "Hello",
-                "bytes": [
-                  72,
-                  101,
-                  108,
-                  108,
-                  111
-                ],
-                "logprob": -0.10257129
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "model": "gpt-3.5-turbo-0125",
+            "system_fingerprint": "fp_44709d6fcb",
+            "choices": [{
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hello there, how may I assist you today?"
               },
-              {
-                "token": "Hi",
-                "bytes": [
-                  72,
-                  105
-                ],
-                "logprob": -2.349693
-              }
-            ]
-          },
-          {
-            "token": "!",
-            "bytes": [
-              33
-            ],
-            "logprob": -0.009831643,
-            "top_logprobs": [
-              {
-                "token": "!",
-                "bytes": [
-                  33
-                ],
-                "logprob": -0.009831643
-              },
-              {
-                "token": " there",
-                "bytes": [
-                  32,
-                  116,
-                  104,
-                  101,
-                  114,
-                  101
-                ],
-                "logprob": -4.699771
-              }
-            ]
+              "logprobs": null,
+              "finish_reason": "stop"
+            }],
+            "usage": {
+              "prompt_tokens": 9,
+              "completion_tokens": 12,
+              "total_tokens": 21
+            }
           }
-        ]
-      },
-      "message": {
-        "content": "Hello!",
-        "role": "assistant",
-        "function_call": null,
-        "tool_calls": null
-      }
-    }
-  ],
-  "created": 1711044293,
-  "model": "gpt-3.5-turbo-0125",
-  "object": "chat.completion",
-  "system_fingerprint": "fp_fa89f7a861",
-  "usage": {
-    "completion_tokens": 2,
-    "prompt_tokens": 9,
-    "total_tokens": 11
-  }
-}
-""")
-    result = client.translate_response(request, response)
-    assert result == SUTResponse(
-        text="Hello!",
-        top_logprobs=[
-            TopTokens(
-                top_tokens=[
-                    TokenProbability(token="Hello", logprob=-0.10257129),
-                    TokenProbability(token="Hi", logprob=-2.349693),
+          """)
+        result = client.translate_response(request, response)
+        assert result == SUTResponse(text="Hello there, how may I assist you today?", top_logprobs=None)
+
+    def test_openai_chat_translate_response_logprobs(self, client):
+        request = OpenAIChatRequest(
+            model="some-model",
+            messages=[],
+            logprobs=True,
+        )
+        # Copied from a real response.
+        response = ChatCompletion.model_validate_json("""\
+        {
+          "id": "made-this-fake",
+          "choices": [
+            {
+              "finish_reason": "length",
+              "index": 0,
+              "logprobs": {
+                "content": [
+                  {
+                    "token": "Hello",
+                    "logprob": -0.10257129,
+                    "top_logprobs": [
+                      {
+                        "token": "Hello",
+                        "bytes": [
+                          72,
+                          101,
+                          108,
+                          108,
+                          111
+                        ],
+                        "logprob": -0.10257129
+                      },
+                      {
+                        "token": "Hi",
+                        "bytes": [
+                          72,
+                          105
+                        ],
+                        "logprob": -2.349693
+                      }
+                    ]
+                  },
+                  {
+                    "token": "!",
+                    "bytes": [
+                      33
+                    ],
+                    "logprob": -0.009831643,
+                    "top_logprobs": [
+                      {
+                        "token": "!",
+                        "bytes": [
+                          33
+                        ],
+                        "logprob": -0.009831643
+                      },
+                      {
+                        "token": " there",
+                        "bytes": [
+                          32,
+                          116,
+                          104,
+                          101,
+                          114,
+                          101
+                        ],
+                        "logprob": -4.699771
+                      }
+                    ]
+                  }
                 ]
-            ),
-            TopTokens(
-                top_tokens=[
-                    TokenProbability(token="!", logprob=-0.009831643),
-                    TokenProbability(token=" there", logprob=-4.699771),
-                ]
-            ),
-        ],
+              },
+              "message": {
+                "content": "Hello!",
+                "role": "assistant",
+                "function_call": null,
+                "tool_calls": null
+              }
+            }
+          ],
+          "created": 1711044293,
+          "model": "gpt-3.5-turbo-0125",
+          "object": "chat.completion",
+          "system_fingerprint": "fp_fa89f7a861",
+          "usage": {
+            "completion_tokens": 2,
+            "prompt_tokens": 9,
+            "total_tokens": 11
+          }
+        }
+        """)
+        result = client.translate_response(request, response)
+        assert result == SUTResponse(
+            text="Hello!",
+            top_logprobs=[
+                TopTokens(
+                    top_tokens=[
+                        TokenProbability(token="Hello", logprob=-0.10257129),
+                        TokenProbability(token="Hi", logprob=-2.349693),
+                    ]
+                ),
+                TopTokens(
+                    top_tokens=[
+                        TokenProbability(token="!", logprob=-0.009831643),
+                        TokenProbability(token=" there", logprob=-4.699771),
+                    ]
+                ),
+            ],
+        )
+
+
+def _make_response(text: str, logprobs=None) -> Response:
+    content = {"type": "output_text", "text": text, "annotations": []}
+    if logprobs is not None:
+        content["logprobs"] = logprobs
+    return Response.model_validate(
+        {
+            "id": "resp-fake",
+            "object": "response",
+            "created_at": 1677652288,
+            "model": "gpt-4o",
+            "status": "completed",
+            "parallel_tool_calls": False,
+            "tool_choice": "auto",
+            "tools": [],
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg-fake",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [content],
+                }
+            ],
+            "usage": {
+                "input_tokens": 9,
+                "output_tokens": 12,
+                "total_tokens": 21,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+        }
     )
+
+
+class TestOpenAIResponses:
+    @pytest.fixture
+    def client(self):
+        return OpenAIResponses(
+            uid="test-model",
+            model="some-model",
+            api_key=OpenAIApiKey("some-value"),
+            organization=OpenAIOrganization(None),
+        )
+
+    def test_openai_constructor(self, openai_client):
+        # these should all work
+        key_only = OpenAIResponses(
+            uid="test-model",
+            model="some-model",
+            api_key=OpenAIApiKey("some-value"),
+            organization=OpenAIOrganization(None),
+        )
+        key_and_org = OpenAIResponses(
+            uid="test-model",
+            model="some-model",
+            api_key=OpenAIApiKey("some-value"),
+            organization=OpenAIOrganization("some-org"),
+        )
+        key_and_base_url = OpenAIResponses(
+            uid="test-model",
+            model="some-model",
+            api_key=OpenAIApiKey("some-value"),
+            base_url="some-url",
+        )
+
+        with_client = OpenAIResponses(
+            uid="test-model",
+            model="some-model",
+            client=openai_client,  # type: ignore
+        )
+
+        # these should all fail
+
+        # no key and no client
+        with raises(AssertionError):
+            _ = OpenAIResponses(uid="test-model", model="some-model")
+
+        # base_url and organization
+        with raises(AssertionError):
+            _ = OpenAIResponses(
+                uid="test-model",
+                model="some-model",
+                organization=OpenAIOrganization("some-org"),
+                base_url="some-url",
+            )
+
+    def test_translate_request(self, client):
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(max_tokens=100))
+        assert request == OpenAIResponsesRequest(
+            model="some-model",
+            input=[OpenAIChatMessage(content="some-text", role="user")],
+            max_output_tokens=100,
+        )
+
+    def test_translate_request_logprobs(self, client):
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(top_logprobs=2))
+        assert request == OpenAIResponsesRequest(
+            model="some-model",
+            input=[OpenAIChatMessage(content="some-text", role="user")],
+            max_output_tokens=None,
+            top_logprobs=2,
+            include=["message.output_text.logprobs"],
+        )
+
+    def test_translate_request_excessive_logprobs(self, client):
+        # Set value above limit of 20
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(top_logprobs=21))
+        assert request == OpenAIResponsesRequest(
+            model="some-model",
+            input=[OpenAIChatMessage(content="some-text", role="user")],
+            max_output_tokens=None,
+            top_logprobs=20,
+            include=["message.output_text.logprobs"],
+        )
+
+    def test_translate_response(self, client):
+        request = OpenAIResponsesRequest(model="some-model", input=[])
+        response = _make_response("Hello there, how may I assist you today?")
+        result = client.translate_response(request, response)
+        assert result == SUTResponse(text="Hello there, how may I assist you today?", top_logprobs=None)
+
+    def test_translate_response_logprobs(self, client):
+        request = OpenAIResponsesRequest(model="some-model", input=[], top_logprobs=2)
+        response = _make_response(
+            "Hello!",
+            logprobs=[
+                {
+                    "token": "Hello",
+                    "logprob": -0.10257129,
+                    "bytes": [72, 101, 108, 108, 111],
+                    "top_logprobs": [
+                        {"token": "Hello", "logprob": -0.10257129, "bytes": [72, 101, 108, 108, 111]},
+                        {"token": "Hi", "logprob": -2.349693, "bytes": [72, 105]},
+                    ],
+                },
+                {
+                    "token": "!",
+                    "logprob": -0.009831643,
+                    "bytes": [33],
+                    "top_logprobs": [
+                        {"token": "!", "logprob": -0.009831643, "bytes": [33]},
+                        {"token": " there", "logprob": -4.699771, "bytes": [32, 116, 104, 101, 114, 101]},
+                    ],
+                },
+            ],
+        )
+        result = client.translate_response(request, response)
+        assert result == SUTResponse(
+            text="Hello!",
+            top_logprobs=[
+                TopTokens(
+                    top_tokens=[
+                        TokenProbability(token="Hello", logprob=-0.10257129),
+                        TokenProbability(token="Hi", logprob=-2.349693),
+                    ]
+                ),
+                TopTokens(
+                    top_tokens=[
+                        TokenProbability(token="!", logprob=-0.009831643),
+                        TokenProbability(token=" there", logprob=-4.699771),
+                    ]
+                ),
+            ],
+        )

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -1,5 +1,4 @@
 import pytest
-from pytest import raises
 
 from openai import OpenAI
 from openai.types.chat import ChatCompletion
@@ -9,6 +8,7 @@ from modelgauge.prompt import TextPrompt
 from modelgauge.sut import SUTResponse
 from modelgauge.model_options import ModelOptions, TokenProbability, TopTokens
 from modelgauge.suts.openai_client import (
+    BaseOpenAI,
     OpenAIApiKey,
     OpenAIChat,
     OpenAIChatMessage,
@@ -22,6 +22,22 @@ from modelgauge.suts.openai_client import (
 @pytest.fixture
 def openai_client():
     return OpenAI(api_key="some-value", organization="some-org", max_retries=1)
+
+
+class TestBaseOpenAIEvaluate:
+
+    def test_check_accepts_temp(self):
+        assert BaseOpenAI._check_accepts_temp("some-model") is True
+        assert BaseOpenAI._check_accepts_temp("gpt-4o") is True
+        assert BaseOpenAI._check_accepts_temp("gpt-5.4") is True
+        assert BaseOpenAI._check_accepts_temp("gpt-5.4-nano") is True
+        assert BaseOpenAI._check_accepts_temp("gpt-5.4-mini") is True
+
+        assert BaseOpenAI._check_accepts_temp("gpt-5.6") is False
+        assert BaseOpenAI._check_accepts_temp("gpt-5.6-sol") is False
+        assert BaseOpenAI._check_accepts_temp("gpt-5.5") is False
+        assert BaseOpenAI._check_accepts_temp("gpt-5.5-pro") is False
+        assert BaseOpenAI._check_accepts_temp("gpt-5.4-pro") is False
 
 
 class TestOpenAIChat:
@@ -64,11 +80,11 @@ class TestOpenAIChat:
         # these should all fail
 
         # no key and no client
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             _ = OpenAIChat(uid="test-model", model="some-model")
 
         # base_url and organization
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             _ = OpenAIChat(
                 uid="test-model",
                 model="some-model",
@@ -249,6 +265,20 @@ class TestOpenAIChat:
             ],
         )
 
+    def test_translate_request_includes_temperature_when_accepted(self, client):
+        """When _accepts_temp is True, temperature from options is included in the request."""
+        assert client._accepts_temp is True
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
+        assert request.temperature == 0.7
+
+    def test_translate_request_omits_temperature_when_not_accepted(self, client):
+        """When _accepts_temp is False, temperature is excluded from the request even if provided."""
+        client._accepts_temp = False
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
+        assert request.temperature is None
+
 
 def _make_response(text: str, logprobs=None) -> Response:
     content = {"type": "output_text", "text": text, "annotations": []}
@@ -324,11 +354,11 @@ class TestOpenAIResponses:
         # these should all fail
 
         # no key and no client
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             _ = OpenAIResponses(uid="test-model", model="some-model")
 
         # base_url and organization
-        with raises(AssertionError):
+        with pytest.raises(AssertionError):
             _ = OpenAIResponses(
                 uid="test-model",
                 model="some-model",
@@ -417,3 +447,17 @@ class TestOpenAIResponses:
                 ),
             ],
         )
+
+    def test_translate_request_includes_temperature_when_accepted(self, client):
+        """When _accepts_temp is True, temperature from options is included in the request."""
+        assert client._accepts_temp is True
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
+        assert request.temperature == 0.7
+
+    def test_translate_request_omits_temperature_when_not_accepted(self, client):
+        """When _accepts_temp is False, temperature is excluded from the request even if provided."""
+        client._accepts_temp = False
+        prompt = TextPrompt(text="some-text")
+        request = client.translate_text_prompt(prompt, ModelOptions(temperature=0.7))
+        assert request.temperature is None

--- a/tests/modelgauge_tests/sut_tests/test_openai_client.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_client.py
@@ -8,13 +8,13 @@ from modelgauge.prompt import TextPrompt
 from modelgauge.sut import SUTResponse
 from modelgauge.model_options import ModelOptions, TokenProbability, TopTokens
 from modelgauge.suts.openai_client import (
-    BaseOpenAI,
+    BaseOpenAISUT,
     OpenAIApiKey,
-    OpenAIChat,
+    OpenAIChatSUT,
     OpenAIChatMessage,
     OpenAIChatRequest,
     OpenAIOrganization,
-    OpenAIResponses,
+    OpenAIResponsesSUT,
     OpenAIResponsesRequest,
 )
 
@@ -27,27 +27,27 @@ def openai_client():
 class TestBaseOpenAIEvaluate:
 
     def test_check_accepts_temp(self):
-        assert BaseOpenAI._check_accepts_temperature("some-model") is True
-        assert BaseOpenAI._check_accepts_temperature("gpt-4o") is True
-        assert BaseOpenAI._check_accepts_temperature("gpt-4.6") is True
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.4") is True
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.4-nano") is True
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.4-mini") is True
+        assert BaseOpenAISUT._check_accepts_temperature("some-model") is True
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-4o") is True
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-4.6") is True
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.4") is True
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.4-nano") is True
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.4-mini") is True
 
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.6") is False
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.6-sol") is False
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.5") is False
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.5-pro") is False
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.4-pro") is False
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.7") is False
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.10") is False
-        assert BaseOpenAI._check_accepts_temperature("gpt-5.10.0") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.6") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.6-sol") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.5") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.5-pro") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.4-pro") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.7") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.10") is False
+        assert BaseOpenAISUT._check_accepts_temperature("gpt-5.10.0") is False
 
 
 class TestOpenAIChat:
     @pytest.fixture
     def client(self):
-        return OpenAIChat(
+        return OpenAIChatSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
@@ -56,26 +56,26 @@ class TestOpenAIChat:
 
     def test_openai_constructor(self, openai_client):
         # these should all work
-        key_only = OpenAIChat(
+        key_only = OpenAIChatSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
             organization=OpenAIOrganization(None),
         )
-        key_and_org = OpenAIChat(
+        key_and_org = OpenAIChatSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
             organization=OpenAIOrganization("some-org"),
         )
-        key_and_base_url = OpenAIChat(
+        key_and_base_url = OpenAIChatSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
             base_url="some-url",
         )
 
-        with_client = OpenAIChat(
+        with_client = OpenAIChatSUT(
             uid="test-model",
             model="some-model",
             client=openai_client,  # type: ignore
@@ -85,11 +85,11 @@ class TestOpenAIChat:
 
         # no key and no client
         with pytest.raises(AssertionError):
-            _ = OpenAIChat(uid="test-model", model="some-model")
+            _ = OpenAIChatSUT(uid="test-model", model="some-model")
 
         # base_url and organization
         with pytest.raises(AssertionError):
-            _ = OpenAIChat(
+            _ = OpenAIChatSUT(
                 uid="test-model",
                 model="some-model",
                 organization=OpenAIOrganization("some-org"),
@@ -321,7 +321,7 @@ def _make_response(text: str, logprobs=None) -> Response:
 class TestOpenAIResponses:
     @pytest.fixture
     def client(self):
-        return OpenAIResponses(
+        return OpenAIResponsesSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
@@ -330,26 +330,26 @@ class TestOpenAIResponses:
 
     def test_openai_constructor(self, openai_client):
         # these should all work
-        key_only = OpenAIResponses(
+        key_only = OpenAIResponsesSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
             organization=OpenAIOrganization(None),
         )
-        key_and_org = OpenAIResponses(
+        key_and_org = OpenAIResponsesSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
             organization=OpenAIOrganization("some-org"),
         )
-        key_and_base_url = OpenAIResponses(
+        key_and_base_url = OpenAIResponsesSUT(
             uid="test-model",
             model="some-model",
             api_key=OpenAIApiKey("some-value"),
             base_url="some-url",
         )
 
-        with_client = OpenAIResponses(
+        with_client = OpenAIResponsesSUT(
             uid="test-model",
             model="some-model",
             client=openai_client,  # type: ignore
@@ -359,11 +359,11 @@ class TestOpenAIResponses:
 
         # no key and no client
         with pytest.raises(AssertionError):
-            _ = OpenAIResponses(uid="test-model", model="some-model")
+            _ = OpenAIResponsesSUT(uid="test-model", model="some-model")
 
         # base_url and organization
         with pytest.raises(AssertionError):
-            _ = OpenAIResponses(
+            _ = OpenAIResponsesSUT(
                 uid="test-model",
                 model="some-model",
                 organization=OpenAIOrganization("some-org"),

--- a/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError, ProviderNotFoundError
 from modelgauge.sut_definition import SUTDefinition
-from modelgauge.suts.openai_client import OpenAIChat
+from modelgauge.suts.openai_client import OpenAIResponses
 from modelgauge.suts.openai_sut_factory import OpenAICompatibleSUTFactory, OpenAIGenericSUTFactory, OpenAISUTFactory
 from modelgauge_tests.utilities import expensive_tests
 
@@ -44,7 +44,7 @@ def test_make_sut(openai_factory):
     ):
         sut_definition = SUTDefinition(model="gpt-4o", maker="openai", driver="openai")
         sut = openai_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIChat)
+    assert isinstance(sut, OpenAIResponses)
     assert sut.uid == "openai/gpt-4o:openai"
     assert sut.model == "gpt-4o"
     assert isinstance(sut.client, OpenAI)
@@ -57,7 +57,7 @@ def test_make_sut_with_no_maker(openai_factory):
     ):
         sut_definition = SUTDefinition(model="gpt-4o", driver="openai")
         sut = openai_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIChat)
+    assert isinstance(sut, OpenAIResponses)
     assert sut.uid == "gpt-4o:openai"
     assert sut.model == "gpt-4o"
 
@@ -76,7 +76,7 @@ def test_make_unknown_sut_raises_error(openai_factory):
 def test_make_generic_sut(openai_generic_factory, sut_definition):
     openai_generic_factory.base_url = "https://example.com"
     sut = openai_generic_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIChat)
+    assert isinstance(sut, OpenAIResponses)
     assert sut.uid == "some_maker/some_model:demo:openai"
     assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
@@ -85,7 +85,7 @@ def test_make_generic_sut(openai_generic_factory, sut_definition):
 ### SUTs using the OpenAI client running anywhere
 def test_make_generic_sut_with_late_base_url(openai_generic_factory, sut_definition):
     sut = openai_generic_factory.make_sut(sut_definition, base_url="https://example.com")
-    assert isinstance(sut, OpenAIChat)
+    assert isinstance(sut, OpenAIResponses)
     assert sut.uid == "some_maker/some_model:demo:openai"
     assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
@@ -97,7 +97,7 @@ def test_factory_makes_the_right_generic_sut(factory):
         model="some_model", maker="some_maker", driver="openai", provider="demo", base_url="https://example.org"
     )
     sut = factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIChat)
+    assert isinstance(sut, OpenAIResponses)
     assert sut.uid == "some_maker/some_model:demo:openai;url=https://example.org"
     assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
@@ -115,7 +115,7 @@ def test_factory_tries_to_make_a_generic_sut(factory, sut_definition):
     # there is a secret for the "unknown" provider, so we try to make a SUT
     new_factory = OpenAICompatibleSUTFactory(raw_secrets={"unknown": {"api_key": "some_key"}})
     sut = new_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIChat)
+    assert isinstance(sut, OpenAIResponses)
     assert isinstance(sut.client, OpenAI)
 
 

--- a/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_openai_sut_factory.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError, ProviderNotFoundError
 from modelgauge.sut_definition import SUTDefinition
-from modelgauge.suts.openai_client import OpenAIResponses
+from modelgauge.suts.openai_client import OpenAIResponsesSUT
 from modelgauge.suts.openai_sut_factory import OpenAICompatibleSUTFactory, OpenAIGenericSUTFactory, OpenAISUTFactory
 from modelgauge_tests.utilities import expensive_tests
 
@@ -44,7 +44,7 @@ def test_make_sut(openai_factory):
     ):
         sut_definition = SUTDefinition(model="gpt-4o", maker="openai", driver="openai")
         sut = openai_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIResponses)
+    assert isinstance(sut, OpenAIResponsesSUT)
     assert sut.uid == "openai/gpt-4o:openai"
     assert sut.model == "gpt-4o"
     assert isinstance(sut.client, OpenAI)
@@ -57,7 +57,7 @@ def test_make_sut_with_no_maker(openai_factory):
     ):
         sut_definition = SUTDefinition(model="gpt-4o", driver="openai")
         sut = openai_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIResponses)
+    assert isinstance(sut, OpenAIResponsesSUT)
     assert sut.uid == "gpt-4o:openai"
     assert sut.model == "gpt-4o"
 
@@ -76,7 +76,7 @@ def test_make_unknown_sut_raises_error(openai_factory):
 def test_make_generic_sut(openai_generic_factory, sut_definition):
     openai_generic_factory.base_url = "https://example.com"
     sut = openai_generic_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIResponses)
+    assert isinstance(sut, OpenAIResponsesSUT)
     assert sut.uid == "some_maker/some_model:demo:openai"
     assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
@@ -85,7 +85,7 @@ def test_make_generic_sut(openai_generic_factory, sut_definition):
 ### SUTs using the OpenAI client running anywhere
 def test_make_generic_sut_with_late_base_url(openai_generic_factory, sut_definition):
     sut = openai_generic_factory.make_sut(sut_definition, base_url="https://example.com")
-    assert isinstance(sut, OpenAIResponses)
+    assert isinstance(sut, OpenAIResponsesSUT)
     assert sut.uid == "some_maker/some_model:demo:openai"
     assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
@@ -97,7 +97,7 @@ def test_factory_makes_the_right_generic_sut(factory):
         model="some_model", maker="some_maker", driver="openai", provider="demo", base_url="https://example.org"
     )
     sut = factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIResponses)
+    assert isinstance(sut, OpenAIResponsesSUT)
     assert sut.uid == "some_maker/some_model:demo:openai;url=https://example.org"
     assert sut.model == "some_model"
     assert isinstance(sut.client, OpenAI)
@@ -115,7 +115,7 @@ def test_factory_tries_to_make_a_generic_sut(factory, sut_definition):
     # there is a secret for the "unknown" provider, so we try to make a SUT
     new_factory = OpenAICompatibleSUTFactory(raw_secrets={"unknown": {"api_key": "some_key"}})
     sut = new_factory.make_sut(sut_definition)
-    assert isinstance(sut, OpenAIResponses)
+    assert isinstance(sut, OpenAIResponsesSUT)
     assert isinstance(sut.client, OpenAI)
 
 


### PR DESCRIPTION
This adds a new SUT based on OpenAI's new Responses API. This API is necessary to support some newer models (e.g. gpt-5.4-pro, gpt-5.5-pro). OpenAI also recommends Responses over Chat Completions for "new projects". 
I chose to keep the Chat Completions SUT because Nvidia NIM and ModelShip are dependent on this SUT. And Nvidia NIM is not compatible with the Responses API. But I did change the dynamic OpenAI SUT factory to create `Response` SUTs when `:openai` is in a uid. 

This PR also adds some handling for gpt models (`pro` models, anything >=`5.5`) that do not accept a `temperature` arg.  Before, these models would completely fail in benchmark runs because the benchmark passes a temperature value. I chose to hardcode a temp-acceptance-checker based on the model name. This is a little rudimentary, but I believe it is better than the other option: try to call the client, if it fails then replace the temp value in the request with `None` and retry. I don't like this option because requests should be immutable. It would be misleading if a run record says the request included `temp=0.01`, when in reality that value was actually replaced.

This PR should enable us to run all current text GPT models.