### PR TITLE
Add ability to list dynamic SUTs

### DIFF
--- a/src/modelbench/cli.py
+++ b/src/modelbench/cli.py
@@ -201,7 +201,6 @@ def dynamic(driver):
         print("\nTry modelbench list-suts dynamic <driver> for more detail.")
 
 
-
 @benchmark.command("general", help="run a general purpose AI chat benchmark")
 @click.option(
     "--version",

--- a/src/modelbench/cli.py
+++ b/src/modelbench/cli.py
@@ -4,6 +4,8 @@ import io
 import json
 import os
 
+from modelgauge.sut_factory import SUT_FACTORY
+
 # silence Together's upgrade message, as the new library is not out of beta
 os.environ["TOGETHER_NO_BANNER"] = "1"
 
@@ -166,10 +168,38 @@ def at_end(result, **kwargs):
     PROMETHEUS.push_metrics()
 
 
-@cli.command(help="List known suts")
-@local_plugin_dir_option
+@cli.group(help="List known suts")
 def list_suts():
+    pass
+
+
+@list_suts.command(help="List static suts")
+def static():
     print(SUTS.compact_uid_list())
+
+
+@list_suts.command(help="List dynamic suts")
+@click.argument("driver", required=False)
+def dynamic(driver):
+    if driver:
+        if driver not in SUT_FACTORY.dynamic_sut_factories:
+            print(f"Unknown driver: {driver}")
+            exit(1)
+        factory = SUT_FACTORY.dynamic_sut_factories[driver]
+        suts = factory.list_suts()
+        if suts:
+            print(f"Models currently available for driver {driver}:")
+            for s in sorted(suts):
+                print(f"  {s}")
+        else:
+            print(f"Model information unavailable for driver {driver}")
+    else:
+        print("Standard form for a dynamic SUT uid is maker/model:[provider:]driver[;option=value]")
+        print("\nKnown dynamic SUT drivers:")
+        for k in sorted(SUT_FACTORY.dynamic_sut_factories.keys()):
+            print(f"  {k}")
+        print("\nTry modelbench list-suts dynamic <driver> for more detail.")
+
 
 
 @benchmark.command("general", help="run a general purpose AI chat benchmark")

--- a/src/modelgauge/dynamic_sut_factory.py
+++ b/src/modelgauge/dynamic_sut_factory.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from modelgauge.dependency_injection import inject_dependencies
 from modelgauge.secret_values import InjectSecret, RawSecrets
@@ -43,6 +44,9 @@ class DynamicSUTFactory(ABC):
     def make_sut(self, sut_definition: SUTDefinition) -> SUT:
         """Factories that handle special SUT config parameters (e.g. moderated, reasoning) must accept them as kwargs."""
         pass
+
+    def list_suts(self) -> Optional[list[str]]:
+        return None
 
 
 class DynamicDriverSUTFactory(DynamicSUTFactory, ABC):

--- a/src/modelgauge/suts/anthropic_sut_factory.py
+++ b/src/modelgauge/suts/anthropic_sut_factory.py
@@ -1,6 +1,7 @@
 import difflib
 import re
 from collections import defaultdict
+from typing import Optional
 
 from anthropic import Anthropic
 
@@ -30,8 +31,11 @@ class AnthropicSUTFactory(DynamicDriverSUTFactory):
     def _secret(self) -> AnthropicApiKey:
         return self.injected_secrets()[0]
 
+    def list_suts(self) -> Optional[list[str]]:
+        return [m.id for m in self.client().models.list()]
+
     def make_sut(self, sut_definition: SUTDefinition) -> SUT:
-        model_names = [m.id for m in self.client().models.list()]
+        model_names = self.list_suts()
         uid = sut_definition.dynamic_uid
         requested_model = sut_definition.to_dynamic_sut_metadata().model
         if requested_model not in model_names:

--- a/src/modelgauge/suts/aws_bedrock_sut_factory.py
+++ b/src/modelgauge/suts/aws_bedrock_sut_factory.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 import boto3
 
@@ -27,13 +28,10 @@ class AWSBedrockSUTFactory(DynamicDriverSUTFactory):
             )
         return self._client
 
-    def _convert_model_id(self, model_id: str) -> SUTDefinition:
-        """Convert AWS model IDs (maker.model[:version?]) to our standard format."""
-        maker, model_name = model_id.split(".", maxsplit=1)
-        model_name = model_name.replace(":", ".")
-        return SUTDefinition({"maker": maker, "model": model_name, "driver": self.DRIVER_NAME})
+    def list_suts(self) -> Optional[list[str]]:
+        return [f"{m.get('maker')}/{m.get('model')}" for m in self._get_available_models().values()]
 
-    def _get_available_models(self, maker: str):
+    def _get_available_models(self) -> dict[str, SUTDefinition]:
         response = self.client.list_foundation_models()
         models = {}
         for m in response["modelSummaries"]:
@@ -42,8 +40,14 @@ class AWSBedrockSUTFactory(DynamicDriverSUTFactory):
             models[m["modelId"]] = self._convert_model_id(m["modelId"])
         return models
 
+    def _convert_model_id(self, model_id: str) -> SUTDefinition:
+        """Convert AWS model IDs (maker.model[:version?]) to our standard format."""
+        maker, model_name = model_id.split(".", maxsplit=1)
+        model_name = model_name.replace(":", ".")
+        return SUTDefinition({"maker": maker, "model": model_name, "driver": self.DRIVER_NAME})
+
     def _get_model_id(self, sut_definition: SUTDefinition):
-        models = self._get_available_models(sut_definition.to_dynamic_sut_metadata().maker)
+        models = self._get_available_models()
         for model_id, model_definition in models.items():
             if str(model_definition.to_dynamic_sut_metadata()) == str(sut_definition.to_dynamic_sut_metadata()):
                 return model_id

--- a/src/modelgauge/suts/google_sut_factory.py
+++ b/src/modelgauge/suts/google_sut_factory.py
@@ -39,3 +39,6 @@ class GoogleSUTFactory(DynamicDriverSUTFactory):
         return GoogleGenAiSUT(
             sut_definition.dynamic_uid, requested_model, sut_definition.get("reasoning", False), self._gemini_secret()
         )
+
+    def list_suts(self) -> list[str]:
+        return [m.name.replace("models/", "google/") for m in self.gemini_client().models.list()]

--- a/src/modelgauge/suts/huggingface_sut_factory.py
+++ b/src/modelgauge/suts/huggingface_sut_factory.py
@@ -1,7 +1,9 @@
 import logging
+from typing import Optional
 
 import huggingface_hub as hfh
 from airrlogger.log_config import get_logger
+from huggingface_hub import InferenceEndpoint
 
 from modelgauge.auth.huggingface_inference_token import HuggingFaceInferenceToken
 from modelgauge.dynamic_sut_factory import (
@@ -74,13 +76,15 @@ class HuggingFaceChatCompletionDedicatedSUTFactory(DynamicDriverSUTFactory):
         hf_token = InjectSecret(HuggingFaceInferenceToken)
         return [hf_token]
 
+    def list_suts(self) -> Optional[list[str]]:
+        ep = self.get_endpoints()
+        return [e.repository.lower() for e in ep]
+
     def _find(self, sut_definition: SUTDefinition) -> tuple[str | None, str | None]:
         """Find endpoint, if it exists."""
         model_name = sut_definition.external_model_name()
         try:
-            token = self.injected_secrets()[0]
-            hfh.login(token.value)
-            endpoints = hfh.list_inference_endpoints()
+            endpoints = self.get_endpoints()
             for e in endpoints:
                 if e.repository.lower() == model_name.lower():
                     if e.status != "running":
@@ -94,6 +98,12 @@ class HuggingFaceChatCompletionDedicatedSUTFactory(DynamicDriverSUTFactory):
         except Exception as oe:
             logger.error(f"Error looking up dedicated endpoints for {model_name}: {oe}")
         return None, None
+
+    def get_endpoints(self) -> list[InferenceEndpoint]:
+        token = self.injected_secrets()[0]
+        hfh.login(token.value)
+        endpoints = hfh.list_inference_endpoints()
+        return endpoints
 
     def make_sut(self, sut_definition: SUTDefinition) -> HuggingFaceChatCompletionDedicatedSUT:
         endpoint_name, model_name = self._find(sut_definition)

--- a/src/modelgauge/suts/meta_llama_factory.py
+++ b/src/modelgauge/suts/meta_llama_factory.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from llama_api_client import LlamaAPIClient
 
 from modelgauge.dynamic_sut_factory import DynamicDriverSUTFactory, ModelNotSupportedError
@@ -24,6 +26,9 @@ class LlamaSUTFactory(DynamicDriverSUTFactory):
     def get_secrets(self) -> list[InjectSecret]:
         api_key = InjectSecret(MetaLlamaApiKey)
         return [api_key]
+
+    def list_suts(self) -> Optional[list[str]]:
+        return [m.id.lower() for m in self.client.models.list()]
 
     def _get_model_name(self, model) -> str | None:
         """Llama API model names are case sensitive."""

--- a/src/modelgauge/suts/mistral_sut_factory.py
+++ b/src/modelgauge/suts/mistral_sut_factory.py
@@ -32,7 +32,6 @@ class MistralSUTFactory(DynamicDriverSUTFactory):
         model_list: ModelList = self.client.client.models.list()
         return [f"{self.DRIVER_NAME}/{m.id}" for m in model_list.data]
 
-
     def make_sut(self, sut_definition: SUTDefinition) -> SUT:
         model_name = sut_definition.to_dynamic_sut_metadata().external_model_name()
 

--- a/src/modelgauge/suts/mistral_sut_factory.py
+++ b/src/modelgauge/suts/mistral_sut_factory.py
@@ -1,3 +1,7 @@
+from typing import Optional
+
+from mistralai.client.models import ModelList
+
 from modelgauge.dynamic_sut_factory import DynamicDriverSUTFactory, ModelNotSupportedError
 from modelgauge.secret_values import InjectSecret, RawSecrets
 from modelgauge.sut import SUT
@@ -23,6 +27,11 @@ class MistralSUTFactory(DynamicDriverSUTFactory):
     def get_secrets(self) -> list[InjectSecret]:
         api_key = InjectSecret(MistralAIAPIKey)
         return [api_key]
+
+    def list_suts(self) -> Optional[list[str]]:
+        model_list: ModelList = self.client.client.models.list()
+        return [f"{self.DRIVER_NAME}/{m.id}" for m in model_list.data]
+
 
     def make_sut(self, sut_definition: SUTDefinition) -> SUT:
         model_name = sut_definition.to_dynamic_sut_metadata().external_model_name()

--- a/src/modelgauge/suts/nvidia_nim_sut_factory.py
+++ b/src/modelgauge/suts/nvidia_nim_sut_factory.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from openai import OpenAI
 
 from modelgauge.dynamic_sut_factory import DynamicDriverSUTFactory, ModelNotSupportedError
@@ -18,6 +20,10 @@ class NvidiaNIMSUTFactory(DynamicDriverSUTFactory):
         if self._client is None:
             self._client = OpenAI(api_key=self.injected_secrets()[0].value, base_url=BASE_URL)
         return self._client
+
+    def list_suts(self) -> Optional[list[str]]:
+        model_list = self.client.models.list().data
+        return [m.id for m in model_list]
 
     def get_secrets(self) -> list[InjectSecret]:
         return [InjectSecret(NvidiaNIMApiKey)]

--- a/src/modelgauge/suts/together_sut_factory.py
+++ b/src/modelgauge/suts/together_sut_factory.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from airrlogger.log_config import get_logger
 from together import Together  # type: ignore
@@ -34,6 +35,10 @@ class TogetherServerlessSUTFactory(DynamicDriverSUTFactory):
     @client.setter
     def client(self, value: Together) -> None:
         self._client = value
+
+    def list_suts(self) -> Optional[list[str]]:
+        model_list = self.client.models.list()
+        return [m.id for m in model_list]
 
     def _find(self, model: str) -> str | None:
         try:

--- a/tests/modelgauge_tests/sut_tests/test_anthropic_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_anthropic_sut_factory.py
@@ -70,6 +70,10 @@ def test_autocorrect_is_limited(factory):
     assert "claude-sonnet-4-5-20250929" in str(e.value)
 
 
+def test_list_suts(factory):
+    suts = factory.list_suts()
+    assert "claude-sonnet-4-5-20250929" in suts
+
 @expensive_tests
 def test_connection():
     factory = AnthropicSUTFactory(load_secrets_from_config(path="."))

--- a/tests/modelgauge_tests/sut_tests/test_anthropic_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_anthropic_sut_factory.py
@@ -74,6 +74,7 @@ def test_list_suts(factory):
     suts = factory.list_suts()
     assert "claude-sonnet-4-5-20250929" in suts
 
+
 @expensive_tests
 def test_connection():
     factory = AnthropicSUTFactory(load_secrets_from_config(path="."))

--- a/tests/modelgauge_tests/sut_tests/test_aws_bedrock_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_aws_bedrock_sut_factory.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
 from modelgauge.sut_definition import SUTDefinition
@@ -66,3 +67,8 @@ def test_make_sut_legacy_model(factory, mock_list_foundation_models):
     sut_definition = SUTDefinition(model="old_model", maker="amazon", driver="aws")
     with pytest.raises(ModelNotSupportedError):
         factory.make_sut(sut_definition)
+
+
+def test_list_suts(factory, mock_list_foundation_models):
+    suts = factory.list_suts()
+    assert "amazon/nova-1.0-micro-v1.0" in suts

--- a/tests/modelgauge_tests/sut_tests/test_google_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_google_sut_factory.py
@@ -54,6 +54,10 @@ def test_make_sut_bad_model(factory):
     assert "gemini-2.5-flash" in str(e.value)
 
 
+def test_list_suts(factory):
+    suts = factory.list_suts()
+    assert "google/gemini-2.5-flash" in suts
+
 @expensive_tests
 def test_connection():
     factory = GoogleSUTFactory(load_secrets_from_config(path="."))

--- a/tests/modelgauge_tests/sut_tests/test_google_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_google_sut_factory.py
@@ -58,6 +58,7 @@ def test_list_suts(factory):
     suts = factory.list_suts()
     assert "google/gemini-2.5-flash" in suts
 
+
 @expensive_tests
 def test_connection():
     factory = GoogleSUTFactory(load_secrets_from_config(path="."))

--- a/tests/modelgauge_tests/sut_tests/test_meta_llama_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_meta_llama_factory.py
@@ -1,5 +1,7 @@
+from collections import namedtuple
+from unittest.mock import patch, MagicMock
+
 import pytest
-from unittest.mock import patch
 
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
 from modelgauge.sut_definition import SUTDefinition
@@ -34,3 +36,10 @@ def test_make_sut_bad_model(factory):
     with patch("modelgauge.suts.meta_llama_factory.LlamaSUTFactory._get_model_name", return_value=None):
         with pytest.raises(ModelNotSupportedError):
             factory.make_sut(sut_definition)
+
+
+def test_list_suts(factory):
+    factory._client = MagicMock()
+    m = namedtuple("FakeModel", ["id"])("some/model-1.0")
+    factory._client.models.list = MagicMock(return_value=[m])
+    assert factory.list_suts() == [m.id]

--- a/tests/modelgauge_tests/sut_tests/test_mistral_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_mistral_sut_factory.py
@@ -34,7 +34,7 @@ def test_make_sut_bad_model(factory):
 
 def test_list_suts(factory):
     model_list = MagicMock()
-    model_list.data = [(namedtuple("FakeModel", ["id"])("thingy-1.0"))]
+    model_list.data = [namedtuple("FakeModel", ["id"])("thingy-1.0")]
     factory._client = MagicMock()
     factory._client.client.models.list.return_value = model_list
     assert "mistral/thingy-1.0" in factory.list_suts()

--- a/tests/modelgauge_tests/sut_tests/test_mistral_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_mistral_sut_factory.py
@@ -1,5 +1,7 @@
+from collections import namedtuple
+from unittest.mock import patch, MagicMock
+
 import pytest
-from unittest.mock import patch
 
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
 from modelgauge.sut_definition import SUTDefinition
@@ -28,3 +30,11 @@ def test_make_sut_bad_model(factory):
     with patch("modelgauge.suts.mistral_client.MistralAIClient.model_info", side_effect=Exception()):
         with pytest.raises(ModelNotSupportedError):
             factory.make_sut(sut_definition)
+
+
+def test_list_suts(factory):
+    model_list = MagicMock()
+    model_list.data = [(namedtuple("FakeModel", ["id"])("thingy-1.0"))]
+    factory._client = MagicMock()
+    factory._client.client.models.list.return_value = model_list
+    assert "mistral/thingy-1.0" in factory.list_suts()

--- a/tests/modelgauge_tests/sut_tests/test_nvidia_nim_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_nvidia_nim_sut_factory.py
@@ -1,5 +1,7 @@
-import pytest
+from collections import namedtuple
 from unittest.mock import MagicMock
+
+import pytest
 
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
 from modelgauge.sut_definition import SUTDefinition
@@ -30,3 +32,13 @@ def test_make_sut_bad_model(factory):
     factory._client.models.retrieve.side_effect = Exception()
     with pytest.raises(ModelNotSupportedError):
         factory.make_sut(sut_definition)
+
+
+def test_list_suts(factory):
+    m = namedtuple("FakeModel", ["id"])("fnord/thingy-1.0")
+    model_list = MagicMock()
+    model_list.data = [m]
+    factory._client = MagicMock()
+    factory._client.models.list.return_value = model_list
+
+    assert factory.list_suts() == [m.id]

--- a/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
@@ -1,7 +1,7 @@
+from collections import namedtuple
 from unittest.mock import MagicMock
 
 import pytest
-from modelgauge_tests.utilities import expensive_tests
 
 from modelgauge.config import load_secrets_from_config
 from modelgauge.dynamic_sut_factory import ModelNotSupportedError
@@ -11,6 +11,7 @@ from modelgauge.suts.together_sut_factory import (
     TogetherDedicatedSUTFactory,
     TogetherServerlessSUTFactory,
 )
+from modelgauge_tests.utilities import expensive_tests
 
 
 @pytest.fixture
@@ -59,6 +60,13 @@ def test_serverless_make_sut_not_found(serverless_factory):
     with pytest.raises(ModelNotSupportedError):
         serverless_factory.make_sut(sut_definition)
 
+
+def test_list_suts(serverless_factory):
+    m = namedtuple("FakeModel", ["id"])("fnord/thingy-1.0")
+    serverless_factory._client = MagicMock()
+    serverless_factory._client.models.list.return_value = [m]
+
+    assert serverless_factory.list_suts() == [m.id]
 
 def test_dedicated_make_sut(dedicated_factory, mocker):
     mock_endpoint = MagicMock()

--- a/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
+++ b/tests/modelgauge_tests/sut_tests/test_together_sut_factory.py
@@ -68,6 +68,7 @@ def test_list_suts(serverless_factory):
 
     assert serverless_factory.list_suts() == [m.id]
 
+
 def test_dedicated_make_sut(dedicated_factory, mocker):
     mock_endpoint = MagicMock()
     mock_endpoint.model = "google/gemma"


### PR DESCRIPTION
The dynamic SUTs stuff was a bit opaque to me. I added the ability to list dynamic SUT drivers and, where convenient, the available models.

The previous behavior, which shows all the preconfigured SUTs,  is at `modelbench list-suts static`.

Doing `modelbench list-suts dynamic` will get a list of available drivers. Adding on a driver name will in many cases get a list of models available via that driver.

One possible direction for expansion is adding per-driver help text to document the expected SUT uid format.