### PR TITLE
Change the exit code for consistency check failures to 3

### DIFF
--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -636,4 +636,4 @@ def summarize_consistency_check_results(checkers: List[ConsistencyChecker]):
 
 
 class ConsistencyCheckError(Exception):
-    EXIT_CODE = 2
+    EXIT_CODE = 3


### PR DESCRIPTION
Because 2 is used to indicate syntax errors.