### PR TITLE
Get parent output in context

### DIFF
--- a/src/modelgauge/annotators/composer/context.py
+++ b/src/modelgauge/annotators/composer/context.py
@@ -77,6 +77,9 @@ class EvalContext:
         """Return the NodeOutput for a specific node, or None if it was skipped."""
         return list(self._parent_outputs.values())
 
+    def parent_output(self, node_name: str) -> NodeOutput | None:
+        return self._parent_outputs.get(node_name)
+
     def to_dict(self) -> dict:
         return {
             "prompt": self.prompt,

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_context.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_context.py
@@ -108,6 +108,13 @@ def test_with_incompatible_parent_metadata(sample_ctx):
         sample_ctx.with_parent_outputs(parent_outputs)
 
 
+def test_parent_output(sample_ctx):
+    node_output = NodeOutput(value="result", original_ctx=sample_ctx)
+    ctx = sample_ctx.with_parent_outputs({"node_a": node_output})
+    assert ctx.parent_output("node_a") is node_output
+    assert ctx.parent_output("missing_node") is None
+
+
 def test_eq_with_non_eval_context(sample_ctx):
     assert sample_ctx != "not an EvalContext"
 


### PR DESCRIPTION
Helper method to easily access parent output for a particular node.