### PR TITLE
Node ancestor outputs

### DIFF
--- a/src/modelgauge/annotators/composer/context.py
+++ b/src/modelgauge/annotators/composer/context.py
@@ -38,6 +38,7 @@ class EvalContext:
         self.response = response
         self.metadata = metadata or {}
         self._parent_outputs: dict[str, NodeOutput] = {}
+        self._ancestor_outputs: dict[str, NodeOutput] = {}
 
     def with_parent_outputs(self, outputs: dict[str, NodeOutput]) -> EvalContext:
         updated_ctx = None
@@ -71,6 +72,7 @@ class EvalContext:
                 metadata=self.metadata,
             )
         ctx._parent_outputs = outputs
+        ctx._ancestor_outputs = self._ancestor_outputs | outputs
         return ctx
 
     def parent_outputs(self) -> list[NodeOutput]:
@@ -79,6 +81,12 @@ class EvalContext:
 
     def parent_output(self, node_name: str) -> NodeOutput | None:
         return self._parent_outputs.get(node_name)
+
+    def ancestor_outputs(self) -> list[NodeOutput]:
+        return list(self._ancestor_outputs.values())
+
+    def ancestor_output(self, node_name: str) -> NodeOutput | None:
+        return self._ancestor_outputs.get(node_name)
 
     def to_dict(self) -> dict:
         return {

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
@@ -497,3 +497,84 @@ def test_dag_with_router_skips_other_branch(router_dag, sample_ctx):
     assert "router" in output.node_outputs
     assert "always_safe" in output.node_outputs
     assert "always_unsafe" not in output.node_outputs
+
+
+def test_ancestor_output_excludes_skipped_branch(sample_ctx):
+    """Nodes on the unexecuted branch must not appear in a downstream ancestor_outputs."""
+    captured_ctx: dict[str, EvalContext] = {}
+
+    class CapturingArbiter(AlwaysSafe):
+        def run(self, ctx: EvalContext):
+            captured_ctx["arbiter"] = ctx
+            return super().run(ctx)
+
+    dag = (
+        Composer("branch_test", verdict_type=Safety)
+        .add_node(AlwaysTrue(name="router", route_map={True: ["taken"], False: ["skipped"]}))
+        .add_node(NoOpEnricher(name="taken", routes=["arbiter"]))
+        .add_node(NoOpEnricher(name="skipped", routes=["arbiter"]))
+        .add_node(CapturingArbiter(name="arbiter"))
+    )
+    dag.run(sample_ctx)
+
+    arbiter_ctx = captured_ctx["arbiter"]
+    assert arbiter_ctx.ancestor_output("taken") is not None
+    assert arbiter_ctx.ancestor_output("skipped") is None
+
+
+def test_ancestor_outputs_diamond_structure(sample_ctx):
+    """A→[B,C], B→C: C has A and B as direct parents; A is also an ancestor via B.
+    ancestor_outputs should contain A and B exactly once each."""
+    captured_ctx: dict[str, EvalContext] = {}
+
+    class CapturingArbiter(AlwaysSafe):
+        def run(self, ctx: EvalContext):
+            captured_ctx["C"] = ctx
+            return super().run(ctx)
+
+    dag = (
+        Composer("diamond_test", verdict_type=Safety)
+        .add_node(AlwaysTrue(name="A", route_map={True: ["B", "C"], False: ["C"]}))
+        .add_node(NoOpEnricher(name="B", routes=["C"]))
+        .add_node(CapturingArbiter(name="C"))
+    )
+    dag.run(sample_ctx)
+
+    c_ctx = captured_ctx["C"]
+    assert c_ctx.ancestor_output("A") is not None
+    assert c_ctx.ancestor_output("B") is not None
+    # A is only counted once even though it reaches C via two paths (A→C and A→B→C).
+    assert len(c_ctx.ancestor_outputs()) == 2
+
+
+def test_ancestor_output_outputs_passed_along_to_grandchild():
+    """In a linear chain grandparent→parent→grandchild, the grandchild can access the
+    grandparent's output directly via parent_output(), not just through the parent's
+    original_ctx chain."""
+    captured_ctx: dict[str, EvalContext] = {}
+
+    class CapturingArbiter(AlwaysSafe):
+        def run(self, ctx: EvalContext):
+            captured_ctx["grandchild"] = ctx
+            return super().run(ctx)
+
+    ctx = EvalContext(prompt="p", response="r")
+    dag = (
+        Composer("grandparent_test", verdict_type=Safety)
+        .add_node(NoOpEnricher(name="grandparent", routes=["parent"]))
+        .add_node(NoOpEnricher(name="parent", routes=["grandchild"]))
+        .add_node(CapturingArbiter(name="grandchild"))
+    )
+    dag.run(ctx)
+
+    grandchild_ctx = captured_ctx["grandchild"]
+
+    # Direct parent output is accessible.
+    assert grandchild_ctx.ancestor_output("parent") is not None
+
+    # Grandparent output is also directly accessible even though it is not an immediate
+    # predecessor — all previously executed node outputs are passed along.
+    assert grandchild_ctx.ancestor_output("grandparent") is not None
+
+    # parent_outputs() still returns only immediate predecessors (direct parents).
+    assert len(grandchild_ctx.ancestor_outputs()) == 2

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_composer.py
@@ -549,7 +549,7 @@ def test_ancestor_outputs_diamond_structure(sample_ctx):
 
 def test_ancestor_output_outputs_passed_along_to_grandchild():
     """In a linear chain grandparent→parent→grandchild, the grandchild can access the
-    grandparent's output directly via parent_output(), not just through the parent's
+    grandparent's output directly via ancestor_output(), not just through the parent's
     original_ctx chain."""
     captured_ctx: dict[str, EvalContext] = {}
 
@@ -576,5 +576,5 @@ def test_ancestor_output_outputs_passed_along_to_grandchild():
     # predecessor — all previously executed node outputs are passed along.
     assert grandchild_ctx.ancestor_output("grandparent") is not None
 
-    # parent_outputs() still returns only immediate predecessors (direct parents).
+    # abcestor_outputs() still returns only immediate predecessors (direct parents).
     assert len(grandchild_ctx.ancestor_outputs()) == 2

--- a/tests/modelgauge_tests/annotator_tests/composer_tests/test_context.py
+++ b/tests/modelgauge_tests/annotator_tests/composer_tests/test_context.py
@@ -115,6 +115,33 @@ def test_parent_output(sample_ctx):
     assert ctx.parent_output("missing_node") is None
 
 
+def test_ancestor_output_returns_none_for_unknown_node(sample_ctx):
+    parent_out = NodeOutput(value="x", original_ctx=sample_ctx)
+    ctx = sample_ctx.with_parent_outputs({"parent": parent_out})
+    assert ctx.ancestor_output("nonexistent") is None
+
+
+def test_ancestor_output_empty_at_root(sample_ctx):
+    ctx = sample_ctx.with_parent_outputs({})
+    assert ctx.ancestor_outputs() == []
+
+
+def test_ancestor_output_deep_chain(sample_ctx):
+    """great_grandparent → grandparent → parent → child: all three ancestors visible."""
+    ggp_out = NodeOutput(value="ggp", original_ctx=sample_ctx)
+    ggp_ctx = sample_ctx.with_parent_outputs({"great_grandparent": ggp_out})
+
+    gp_out = NodeOutput(value="gp", original_ctx=ggp_ctx)
+    gp_ctx = ggp_ctx.with_parent_outputs({"grandparent": gp_out})
+
+    p_out = NodeOutput(value="p", original_ctx=gp_ctx)
+    child_ctx = gp_ctx.with_parent_outputs({"parent": p_out})
+
+    assert child_ctx.ancestor_output("parent") is not None
+    assert child_ctx.ancestor_output("grandparent") is not None
+    assert child_ctx.ancestor_output("great_grandparent") is not None
+
+
 def test_eq_with_non_eval_context(sample_ctx):
     assert sample_ctx != "not an EvalContext"
 


### PR DESCRIPTION
Nodes can now access outputs from ancestors beyond just their parents. 