### PR TITLE
Security practice prompt set

### DIFF
--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -45,7 +45,8 @@ SECURITY_JAILBREAK_PROMPT_SETS = {
 SECURITY_NAIVE_PROMPT_SETS = {
     "official": {
         "en_us": "airr_official_security_naive_1.0.1_heldback_en_us_prompt_set_release",
-    }
+    },
+    "practice": {"en_us": "airr_official_security_naive_1.0.1_heldback_en_us_prompt_set_release_one_per_hazard"},
 }
 PROMPT_SET_DOWNLOAD_URL = "https://ailuminate.mlcommons.org/files/download"
 

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -39,14 +39,14 @@ SECURITY_JAILBREAK_PROMPT_SETS = {
         "en_us": "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release",
     },
     "practice": {
-        "en_us": "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release_one_per_hazard",
+        "en_us": "airr_official_security_attack_1.0.1_practice_en_us_prompt_set_release_one_per_hazard",
     },
 }
 SECURITY_NAIVE_PROMPT_SETS = {
     "official": {
         "en_us": "airr_official_security_naive_1.0.1_heldback_en_us_prompt_set_release",
     },
-    "practice": {"en_us": "airr_official_security_naive_1.0.1_heldback_en_us_prompt_set_release_one_per_hazard"},
+    "practice": {"en_us": "airr_official_security_naive_1.0.1_practice_en_us_prompt_set_release_one_per_hazard"},
 }
 PROMPT_SET_DOWNLOAD_URL = "https://ailuminate.mlcommons.org/files/download"
 

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -39,7 +39,7 @@ SECURITY_JAILBREAK_PROMPT_SETS = {
         "en_us": "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release",
     },
     "practice": {
-        "en_us": "airr_official_security_attack_1.0.1_practice_en_us_prompt_set_release",
+        "en_us": "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release_one_per_hazard",
     },
 }
 SECURITY_NAIVE_PROMPT_SETS = {

--- a/src/modelgauge/prompt_sets.py
+++ b/src/modelgauge/prompt_sets.py
@@ -37,7 +37,10 @@ GENERAL_PROMPT_SETS = {
 SECURITY_JAILBREAK_PROMPT_SETS = {
     "official": {
         "en_us": "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release",
-    }
+    },
+    "practice": {
+        "en_us": "airr_official_security_attack_1.0.1_practice_en_us_prompt_set_release",
+    },
 }
 SECURITY_NAIVE_PROMPT_SETS = {
     "official": {

--- a/tests/modelbench_tests/test_benchmark.py
+++ b/tests/modelbench_tests/test_benchmark.py
@@ -169,7 +169,7 @@ def test_security_benchmark_definition_basics(prompt_set, fake_secrets):
 
     assert isinstance(h[1], SecurityNaiveHazardV1_0_2)
     assert h[1].locale == EN_US
-    assert h[1].prompt_set == "official"
+    assert h[1].prompt_set == prompt_set
 
 
 @pytest.mark.parametrize("prompt_set", SECURITY_JAILBREAK_PROMPT_SETS.keys())

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -46,7 +46,7 @@ def test_file_base_name():
         prompt_set_file_base_name(SECURITY_JAILBREAK_PROMPT_SETS, "practice", "fr_fr")
 
     with pytest.raises(ValueError):
-        prompt_set_file_base_name(SECURITY_NAIVE_PROMPT_SETS, "practice")
+        prompt_set_file_base_name(SECURITY_NAIVE_PROMPT_SETS, "practice", "fr_fr")
 
     with pytest.raises(ValueError):
         prompt_set_file_base_name({"fake": "thing"}, "practice", "en_us")

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -28,6 +28,10 @@ def test_file_base_name():
         == "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release"
     )
     assert (
+        prompt_set_file_base_name(SECURITY_JAILBREAK_PROMPT_SETS, "practice")
+        == "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release_one_per_hazard"
+    )
+    assert (
         prompt_set_file_base_name(SECURITY_NAIVE_PROMPT_SETS, "official")
         == "airr_official_security_naive_1.0.1_heldback_en_us_prompt_set_release"
     )
@@ -39,7 +43,7 @@ def test_file_base_name():
         prompt_set_file_base_name(GENERAL_PROMPT_SETS, "practice", "bogus")
 
     with pytest.raises(ValueError):
-        prompt_set_file_base_name(SECURITY_JAILBREAK_PROMPT_SETS, "practice")
+        prompt_set_file_base_name(SECURITY_JAILBREAK_PROMPT_SETS, "practice", "fr_fr")
 
     with pytest.raises(ValueError):
         prompt_set_file_base_name(SECURITY_NAIVE_PROMPT_SETS, "practice")

--- a/tests/modelgauge_tests/test_prompt_sets.py
+++ b/tests/modelgauge_tests/test_prompt_sets.py
@@ -29,11 +29,15 @@ def test_file_base_name():
     )
     assert (
         prompt_set_file_base_name(SECURITY_JAILBREAK_PROMPT_SETS, "practice")
-        == "airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release_one_per_hazard"
+        == "airr_official_security_attack_1.0.1_practice_en_us_prompt_set_release_one_per_hazard"
     )
     assert (
         prompt_set_file_base_name(SECURITY_NAIVE_PROMPT_SETS, "official")
         == "airr_official_security_naive_1.0.1_heldback_en_us_prompt_set_release"
+    )
+    assert (
+        prompt_set_file_base_name(SECURITY_NAIVE_PROMPT_SETS, "practice")
+        == "airr_official_security_naive_1.0.1_practice_en_us_prompt_set_release_one_per_hazard"
     )
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
I created the airr_official_security_attack_1.0.1_heldback_en_us_prompt_set_release_one_per_hazard file in

https://ailuminate.mlcommons.org/files/

using 1 sample per hazard from the original prompt set.

https://github.com/mlcommons/sugar/issues/635