### PR TITLE
fix(consistency-checker): guard empty denominators

### DIFF
--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -247,10 +247,17 @@ class MinValidAnnotatorItems(JournalCheck):
         self.num_invalid_annotations = len(invalid_annotations)
 
     def check(self) -> bool:
+        if self.num_translated_annotations == 0:
+            # No translated annotations means nothing was successfully annotated
+            # for this annotator (e.g. it errored on every item). That is itself a
+            # failed run the checker should flag, not divide by zero.
+            return False
         return float(self.num_invalid_annotations) / self.num_translated_annotations < self.INVALID_THRESHOLD
 
     def failure_message(self) -> str:
         assert not self.check()
+        if self.num_translated_annotations == 0:
+            return f"Expected translated annotations for annotator {self.annotator} in SUT {self.sut} for test {self.test}, but found none."
         return f"Expected less than {self.INVALID_THRESHOLD * 100}% invalid annotations for annotator {self.annotator} in SUT {self.sut} for test {self.test}. Found {self.num_invalid_annotations} invalid annotations out of {self.num_translated_annotations} total."
 
 
@@ -373,6 +380,11 @@ class HazardScoreIsFracSafe(JournalCheck):
                     num_safe += 1
                 elif entry["measurements"]["is_safe"] != UNSAFE_SCORE:
                     raise ValueError(f"Invalid is_safe value: {entry['measurements']['is_safe']}")
+        if num_scored == 0:
+            # No items were measured for this hazard, so there is no fraction to
+            # report. Return nan so the equality check fails and the run is flagged
+            # rather than crashing on the division.
+            return float("nan")
         return float(num_safe) / num_scored
 
     def check(self) -> bool:

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -1,4 +1,5 @@
 import json
+import math
 import re
 from typing import Dict, List
 
@@ -690,3 +691,42 @@ def test_run_consistency_check_returns_false_for_directory_with_failing_journal(
     result = run_consistency_check(journal_dir, verbose=False)
 
     assert result is False
+
+
+def test_min_valid_annotator_items_flags_annotator_with_no_translations(tmp_path):
+    """An annotator that produced zero translated annotations is flagged, not a crash.
+
+    Regression for the ZeroDivisionError when num_translated_annotations == 0.
+    """
+    journal = FakeJournal([make_sut_entry("translated annotation", annotator="present_annotator")])
+    journal_path = tmp_path / "journal.jsonl"
+    write_journal_to_file(journal, journal_path)
+    search = JournalSearch(journal_path)
+
+    check = MinValidAnnotatorItems(search, sut=DEFAULT_SUT, test=DEFAULT_TEST, annotator="missing_annotator")
+
+    assert check.num_translated_annotations == 0
+    assert check.check() is False
+    assert "found none" in check.failure_message()
+
+
+def test_hazard_score_is_frac_safe_handles_no_measured_items(tmp_path):
+    """A hazard with no measured items reports NaN and fails, rather than crashing.
+
+    Regression for the ZeroDivisionError when num_scored == 0 in _get_frac_safe.
+    """
+    journal = FakeJournal(
+        [
+            {"message": "hazard info", "hazard": DEFAULT_HAZARD, "tests": [DEFAULT_TEST]},
+            {"message": "hazard scored", "sut": DEFAULT_SUT, "hazard": DEFAULT_HAZARD, "score": 0.5},
+            # No "measured item quality" entries, so num_scored == 0.
+        ]
+    )
+    journal_path = tmp_path / "journal.jsonl"
+    write_journal_to_file(journal, journal_path)
+    search = JournalSearch(journal_path)
+
+    check = HazardScoreIsFracSafe(search, sut=DEFAULT_SUT, hazard=DEFAULT_HAZARD)
+
+    assert math.isnan(check.total_frac_safe)
+    assert check.check() is False


### PR DESCRIPTION
## What

Guard two empty-denominator divisions in the consistency checker that raise a `ZeroDivisionError` on a failed run. The exception propagates out of `ConsistencyChecker.run()`, and the CLI catches it per journal, so the tool does not crash, but that journal's entire consistency check is abandoned and reported as an opaque `Error running consistency check float division by zero` instead of the actual findings.

## Why

The consistency checker exists to flag broken runs, but two checks crash on exactly those runs:

- `MinValidAnnotatorItems.check` divides by `num_translated_annotations`, which is 0 when an annotator produced no translated annotations (for example, its API was down for the whole run). `run_checks_for_row` calls `check.check()` with no guard, and the runner iterates every annotator the test declares, so the exception propagates out of `ConsistencyChecker.run()`; the CLI's `run_consistency_check` catches it per journal, abandoning that journal's whole check and reporting a generic error instead of the specific finding.
- `HazardScoreIsFracSafe._get_frac_safe` divides by `num_scored`, which is 0 when no items were measured for a hazard; this runs in `__init__`, so constructing the check crashes.

Details and a standalone repro are in #1629.

## Change

- `MinValidAnnotatorItems.check` returns `False` (with a clear failure message) when there are no translated annotations, flagging the annotator instead of crashing.
- `HazardScoreIsFracSafe._get_frac_safe` returns `nan` when nothing was measured, so the equality check fails rather than crashing.
- Regression tests for both.

This mirrors the empty-denominator guard already in flight in #1608.

Fixes #1629

