### PR TITLE
Consistency checker handles safety 1.2

### DIFF
--- a/src/modelbench/consistency_checker.py
+++ b/src/modelbench/consistency_checker.py
@@ -269,7 +269,9 @@ class AnnotationsMergedCorrectly(JournalCheck):
             starting_run_entry = search_engine.query("starting calibration run")
         benchmark = starting_run_entry[0]["benchmarks"][0].lower()
         # "private" refers to evaluator
-        self.allow_singleton_annotator = "security" in benchmark or not benchmark.endswith("private")
+        self.allow_singleton_annotator = (
+            "security" in benchmark or not benchmark.endswith("private") or "1.2" in benchmark
+        )
 
         translated_responses = search_engine.query("translated sut response", sut=sut, test=test)
         self.response_by_id = {i["prompt_id"]: i["response_text"] for i in translated_responses}

--- a/tests/modelbench_tests/test_consistency_checker.py
+++ b/tests/modelbench_tests/test_consistency_checker.py
@@ -466,6 +466,23 @@ def test_ensemble_members_counted_for_both_annotator_shapes(tmp_path, make_annot
     assert subchecker.results[row][subchecker._col_name(AnnotationsMergedCorrectly)] is True
 
 
+def test_general_1_2_benchmark_annotations_merged_correctly_passes_with_singleton_ensemble(tmp_path):
+    run = make_basic_run(
+        suts=["sut1"],
+        test_prompts={"test1": ["prompt1"]},
+        annotators=["annotator1"],
+        hazard_tests={"hazard1": ["test1"]},
+        benchmark="general_purpose_ai_chat_benchmark-1.2-en_us-official-private",
+    )
+    checker = init_checker_for_journal(tmp_path, run)
+    checker.run()
+
+    subchecker = checker.test_sut_level_checker
+    failed_row = subchecker._row_key(sut="sut1", test="test1")
+    assert subchecker.check_is_complete()
+    assert subchecker.results[failed_row][subchecker._col_name(AnnotationsMergedCorrectly)] is True
+
+
 @pytest.mark.parametrize("annotator_type", (["default"], ["private"]))
 def test_security_benchmark_annotations_merged_correctly_passes_with_singleton_ensemble(tmp_path, annotator_type):
     # Simulate run with only 1 annotator.


### PR DESCRIPTION
I wasn't able to test that this works with an actual benchmark run since cheval is broken. But it passes the unit test!